### PR TITLE
Removing Polymer from core SDK API's homepage

### DIFF
--- a/sdk/api_readme.md
+++ b/sdk/api_readme.md
@@ -11,16 +11,13 @@ Some of the most fundamental Dart libraries include:
     I/O for command-line apps.
   
 Except for dart:core, you must import a library before you can use it.
-Here's an example of importing dart:html, dart:math, and a
-third popular library called [polymer.dart](https://www.dartlang.org/polymer-dart/):
+Here's an example of importing dart:html and dart:math:
   
     import 'dart:html';
     import 'dart:math';
-    import 'package:polymer/polymer.dart';
   
-Polymer.dart is an example of a library that isn't
-included in the Dart download,
-but is easy to get and update using the _pub package manager_.
+You can install more libraries
+using the _pub package manager_.
 For information on finding, using, and publishing libraries (and more)
 with pub, see [pub.dartlang.org](https://pub.dartlang.org).
   
@@ -35,8 +32,6 @@ Check out these pages:
   * [A Tour of the Dart Libraries](https://www.dartlang.org/docs/dart-up-and-running/contents/ch03.html)
   
 This API reference is automatically generated from the source code in the
-[Dart project](https://code.google.com/p/dart/).
+[Dart project](https://github.com/dart-lang/sdk).
 If you'd like to contribute to this documentation, see
-[Contributing](https://code.google.com/p/dart/wiki/Contributing)
-and
-[Writing API Documentation](https://code.google.com/p/dart/wiki/WritingApiDocumentation).
+[Contributing](https://github.com/dart-lang/sdk/wiki/Contributing).


### PR DESCRIPTION
Also, the "writing API documentation" page was never moved over from the codesite.
