### PR TITLE
fix links in the sdk readme doc

### DIFF
--- a/sdk/api_readme.md
+++ b/sdk/api_readme.md
@@ -1,38 +1,31 @@
-Welcome to the Dart API reference documentation,
-covering the official Dart API libraries.
-
-Some of the most fundamental Dart libraries include:
+Welcome to the Dart API reference documentation, covering the official Dart API
+libraries. Some of the most fundamental Dart libraries include:
    
-  * [dart:core](./dart_core/index.html):
-    Core functionality such as strings, numbers, collections, errors,
-    dates, and URIs.
-  * [dart:html](./dart_html/index.html):
-    DOM manipulation for web apps.
-  * [dart:io](./dart_io/index.html):
-    I/O for command-line apps.
+  * [dart:core](dart-core/index.html): Core functionality such as strings, numbers, collections, errors, dates, and URIs.
+  * [dart:html](dart-html/index.html): DOM manipulation for web apps.
+  * [dart:io](dart-io/index.html): I/O for command-line apps.
   
-Except for dart:core, you must import a library before you can use it.
-Here's an example of importing dart:html and dart:math:
-  
-    import 'dart:html';
-    import 'dart:math';
-  
-You can install more libraries
-using the _pub package manager_.
-For information on finding, using, and publishing libraries (and more)
-with pub, see [pub.dartlang.org](https://pub.dartlang.org).
+Except for `dart:core`, you must import a library before you can use it. Here's
+an example of importing `dart:html` and `dart:math`:
+
+```dart
+import 'dart:html';
+import 'dart:math';
+```
+
+You can install more libraries using the pub package manager. For information
+on finding, using, and publishing libraries with pub, see 
+[pub.dartlang.org](https://pub.dartlang.org).
   
 The main site for learning and using Dart is
-[www.dartlang.org](https://www.dartlang.org).
-Check out these pages:
+[www.dartlang.org](https://www.dartlang.org). Check out these additional pages:
   
-  * [Dart homepage](https://www.dartlang.org)
   * [Tutorials](https://www.dartlang.org/docs/tutorials/)
   * [Programmer's Guide](https://www.dartlang.org/docs/)
   * [Samples](https://www.dartlang.org/samples/)
   * [A Tour of the Dart Libraries](https://www.dartlang.org/docs/dart-up-and-running/contents/ch03.html)
   
 This API reference is automatically generated from the source code in the
-[Dart project](https://github.com/dart-lang/sdk).
-If you'd like to contribute to this documentation, see
+[Dart project](https://github.com/dart-lang/sdk). If you'd like to contribute to
+this documentation, see
 [Contributing](https://github.com/dart-lang/sdk/wiki/Contributing).


### PR DESCRIPTION
- fix the links for the `dart:core`, `dart:html`, and `dart:io` libraries
- various tweaks to the display of the sdk readme

@keertip @sethladd 
