### PR TITLE
make indentation configurable for codegen tools

### DIFF
--- a/pkg/analysis_server/tool/spec/codegen_tools.dart
+++ b/pkg/analysis_server/tool/spec/codegen_tools.dart
@@ -104,7 +104,10 @@ class CodeGenerator {
   /**
    * Execute [callback], indenting any code it outputs by two spaces.
    */
-  void indent(void callback()) => indentSpecial('  ', '  ', callback);
+  void indent(void callback()) {
+    indentSpecial(codeGeneratorSettings.indent, codeGeneratorSettings.indent,
+      callback);
+  }
 
   /**
    * Execute [callback], using [additionalIndent] to indent any code it outputs.
@@ -237,10 +240,15 @@ class CodeGeneratorSettings {
    */
   int commentLineLength;
 
+  /**
+   * String used for indenting code.
+   */
+  String indent;
+
   CodeGeneratorSettings({this.languageName: 'java',
       this.lineCommentLineLeader: '// ', this.docCommentStartMarker: '/**',
       this.docCommentLineLeader: ' * ', this.docCommentEndMarker: ' */',
-      this.commentLineLength: 99});
+      this.commentLineLength: 99, this.indent: '  '});
 }
 
 abstract class GeneratedContent {

--- a/pkg/analysis_server/tool/spec/codegen_tools.dart
+++ b/pkg/analysis_server/tool/spec/codegen_tools.dart
@@ -102,7 +102,7 @@ class CodeGenerator {
   }
 
   /**
-   * Execute [callback], indenting any code it outputs by two spaces.
+   * Execute [callback], indenting any code it outputs.
    */
   void indent(void callback()) {
     indentSpecial(codeGeneratorSettings.indent, codeGeneratorSettings.indent,


### PR DESCRIPTION
These changes should not affect the existing generators, but they may come in handy to generate API classes for Python and other languages if they prefer indentation sizes other than 2 spaces.
