### PR TITLE
add optional param to control whether to add newline

### DIFF
--- a/pkg/analysis_server/tool/spec/text_formatter.dart
+++ b/pkg/analysis_server/tool/spec/text_formatter.dart
@@ -19,12 +19,13 @@ final RegExp whitespace = new RegExp(r'\s');
  * If [javadocStyle] is true, then the output is compatable with Javadoc,
  * which understands certain HTML constructs.
  */
-String nodesToText(List<dom.Node> desc, int width, bool javadocStyle) {
+String nodesToText(List<dom.Node> desc, int width, bool javadocStyle, {
+    bool removeTrailingNewLine: false}) {
   _TextFormatter formatter = new _TextFormatter(width, javadocStyle);
   return formatter.collectCode(() {
     formatter.addAll(desc);
     formatter.lineBreak(false);
-  });
+  }, removeTrailingNewLine: removeTrailingNewLine);
 }
 
 /**


### PR DESCRIPTION
@bwilkerson 

A new parameter enables client classes to decide whether they want
a newline char added at the end of a chunk of generated doc
comment text.

In Java, for example, this is not needed because the doc comment is
surrounded by `/** .. */`. In this case, the generator works fine as it is.
However, for Python I'm using `#`, so there's a gap between the
doc comment and the commented item, which looks odd.

The new parameter doesn't alter the default behavior; it must be
explicitly set to `true` if a client class doesn't want newlines at
the end of doc comments.
