### PR TITLE
Bring in the latest stable version of pub.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 1.12.1
+
+### Tool changes
+
+* Pub
+
+  * Pub will now respect `.gitignore` when validating a package before it's
+    published. For example, if a `LICENSE` file exists but is ignored, that is
+    now an error.
+
+  * If the package is in a subdirectory of a Git repository and the entire
+    subdirectory is ignored with `.gitignore`, pub will act as though nothing
+    was ignored instead of uploading an empty package.
+
+  * The heuristics for determining when `pub get` needs to be run before various
+    commands have been improved. There should no longer be false positives when
+    non-dependency sections of the pubspec have been modified.
+
 ## 1.12.0 - 2015-08-31
 
 ### Language changes

--- a/DEPS
+++ b/DEPS
@@ -84,7 +84,7 @@ vars = {
   "ply_rev": "@604b32590ffad5cbb82e4afef1d305512d06ae93",
   "plugin_tag": "@0.1.0",
   "pool_rev": "@e454b4b54d2987e8d2f0fbd3ac519641ada9bd0f",
-  "pub_rev": "@d90268693d1a9dbe5ea11cd9c80b842e3bf1581c",
+  "pub_rev": "@5b06b469abafcf6ab7ef0b6dccf4d50e971ae258",
   "pub_cache_tag": "@v0.1.0",
   "pub_semver_tag": "@1.2.1",
   "quiver_tag": "@0.21.4",


### PR DESCRIPTION
This fixes three issues with the `1.12.0` changes:
- Pub will now respect `.gitignore` when validating a package before it's
  published. For example, if a `LICENSE` file exists but is ignored, that is
  now an error.
- If the package is in a subdirectory of a Git repository and the entire
  subdirectory is ignored with `.gitignore`, pub will act as though nothing
  was ignored instead of uploading an empty package.
- The heuristics for determining when `pub get` needs to be run before various
  commands have been improved. There should no longer be false positives when
  non-dependency sections of the pubspec have been modified.
