### PR TITLE
Fix ConstantEvaluator's doc comment

### DIFF
--- a/pkg/analyzer/lib/src/generated/ast.dart
+++ b/pkg/analyzer/lib/src/generated/ast.dart
@@ -5117,47 +5117,81 @@ class ConditionalExpression extends Expression {
   }
 }
 
-/**
- * An object that can be used to evaluate constant expressions to produce their
- * compile-time value. According to the Dart Language Specification:
- * <blockquote>
- * A constant expression is one of the following:
- * * A literal number.
- * * A literal boolean.
- * * A literal string where any interpolated expression is a compile-time
- *   constant that evaluates to a numeric, string or boolean value or to `null`.
- * * `null`.
- * * A reference to a static constant variable.
- * * An identifier expression that denotes a constant variable, a class or a
- *   type parameter.
- * * A constant constructor invocation.
- * * A constant list literal.
- * * A constant map literal.
- * * A simple or qualified identifier denoting a top-level function or a static
- *   method.
- * * A parenthesized expression `(e)` where `e` is a constant expression.
- * * An expression of one of the forms `identical(e1, e2)`, `e1 == e2`,
- *   `e1 != e2` where `e1` and `e2` are constant expressions that evaluate to a
- *   numeric, string or boolean value or to `null`.
- * * An expression of one of the forms `!e`, `e1 && e2` or `e1 || e2`, where
- *   `e`, `e1` and `e2` are constant expressions that evaluate to a boolean
- *   value or to `null`.
- * * An expression of one of the forms `~e`, `e1 ^ e2`, `e1 & e2`, `e1 | e2`,
- *   `e1 >> e2` or `e1 << e2`, where `e`, `e1` and `e2` are constant expressions
- *   that evaluate to an integer value or to `null`.
- * * An expression of one of the forms `-e`, `e1 + e2`, `e1 - e2`, `e1 * e2`,
- *   `e1 / e2`, `e1 ~/ e2`, `e1 > e2`, `e1 < e2`, `e1 >= e2`, `e1 <= e2` or
- *   `e1 % e2`, where `e`, `e1` and `e2` are constant expressions that evaluate
- *   to a numeric value or to `null`.
- * </blockquote>
- * The values returned by instances of this class are therefore `null` and
- * instances of the classes `Boolean`, `BigInteger`, `Double`, `String`, and
- * `DartObject`.
- *
- * In addition, this class defines several values that can be returned to
- * indicate various conditions encountered during evaluation. These are
- * documented with the static fields that define those values.
- */
+/// Instances of the class [ConstantEvaluator] evaluate constant expressions to
+/// produce their compile-time value.
+///
+/// According to the Dart Language Specification:
+///
+/// > A constant expression is one of the following:
+/// >
+/// > * A literal number.
+/// > * A literal boolean.
+/// > * A literal string where any interpolated expression is a compile-time
+/// >   constant that evaluates to a numeric, string or boolean value or to
+/// >   **null**.
+/// > * A literal symbol.
+/// > * **null**.
+/// > * A qualified reference to a static constant variable.
+/// > * An identifier expression that denotes a constant variable, class or type
+/// >   alias.
+/// > * A constant constructor invocation.
+/// > * A constant list literal.
+/// > * A constant map literal.
+/// > * A simple or qualified identifier denoting a top-level function or a
+/// >   static method.
+/// > * A parenthesized expression _(e)_ where _e_ is a constant expression.
+/// > * <span>
+/// >   An expression of the form <i>identical(e<sub>1</sub>, e<sub>2</sub>)</i>
+/// >   where <i>e<sub>1</sub></i> and <i>e<sub>2</sub></i> are constant
+/// >   expressions and <i>identical()</i> is statically bound to the predefined
+/// >   dart function <i>identical()</i> discussed above.
+/// >   </span>
+/// > * <span>
+/// >   An expression of one of the forms <i>e<sub>1</sub> == e<sub>2</sub></i>
+/// >   or <i>e<sub>1</sub> != e<sub>2</sub></i> where <i>e<sub>1</sub></i> and
+/// >   <i>e<sub>2</sub></i> are constant expressions that evaluate to a
+/// >   numeric, string or boolean value.
+/// >   </span>
+/// > * <span>
+/// >   An expression of one of the forms <i>!e</i>, <i>e<sub>1</sub> &amp;&amp;
+/// >   e<sub>2</sub></i> or <i>e<sub>1</sub> || e<sub>2</sub></i>, where
+/// >   <i>e</i>, <i>e<sub>1</sub></i> and <i>e<sub>2</sub></i> are constant
+/// >   expressions that evaluate to a boolean value.
+/// >   </span>
+/// > * <span>
+/// >   An expression of one of the forms <i>~e</i>, <i>e<sub>1</sub> ^
+/// >   e<sub>2</sub></i>, <i>e<sub>1</sub> &amp; e<sub>2</sub></i>,
+/// >   <i>e<sub>1</sub> | e<sub>2</sub></i>, <i>e<sub>1</sub> &gt;&gt;
+/// >   e<sub>2</sub></i> or <i>e<sub>1</sub> &lt;&lt; e<sub>2</sub></i>, where
+/// >   <i>e</i>, <i>e<sub>1</sub></i> and <i>e<sub>2</sub></i> are constant
+/// >   expressions that evaluate to an integer value or to <b>null</b>.
+/// >   </span>
+/// > * <span>
+/// >   An expression of one of the forms <i>-e</i>, <i>e<sub>1</sub> +
+/// >   e<sub>2</sub></i>, <i>e<sub>1</sub> -e<sub>2</sub></i>,
+/// >   <i>e<sub>1</sub> * e<sub>2</sub></i>, <i>e<sub>1</sub> /
+/// >   e<sub>2</sub></i>, <i>e<sub>1</sub> ~/ e<sub>2</sub></i>,
+/// >   <i>e<sub>1</sub> &gt; e<sub>2</sub></i>, <i>e<sub>1</sub> &lt;
+/// >   e<sub>2</sub></i>, <i>e<sub>1</sub> &gt;= e<sub>2</sub></i>,
+/// >   <i>e<sub>1</sub> &lt;= e<sub>2</sub></i> or <i>e<sub>1</sub> %
+/// >   e<sub>2</sub></i>, where <i>e</i>, <i>e<sub>1</sub></i> and
+/// >   <i>e<sub>2</sub></i> are constant expressions that evaluate to a numeric
+/// >   value or to <b>null</b>.
+/// >   </span>
+/// > * <span>
+/// >   An expression of the form <i>e<sub>1</sub> ? e<sub>2</sub> :
+/// >   e<sub>3</sub></i> where <i>e<sub>1</sub></i>, <i>e<sub>2</sub></i> and
+/// >   <i>e<sub>3</sub></i> are constant expressions, and <i>e<sub>1</sub></i>
+/// >   evaluates to a boolean value.
+/// >   </span>
+///
+/// The values returned by instances of this class are therefore `null` and
+/// instances of the classes `Boolean`, `BigInteger`, `Double`, `String`, and
+/// `DartObject`.
+///
+/// In addition, this class defines several values that can be returned to
+/// indicate various conditions encountered during evaluation. These are
+/// documented with the static fields that define those values.
 class ConstantEvaluator extends GeneralizingAstVisitor<Object> {
   /**
    * The value returned for expressions (or non-expression nodes) that are not

--- a/pkg/analyzer/lib/src/generated/constant.dart
+++ b/pkg/analyzer/lib/src/generated/constant.dart
@@ -1082,62 +1082,81 @@ class ConstantEvaluationValidator_ForProduction
   void beforeGetParameterDefault(ParameterElement parameter) {}
 }
 
-/**
- * Instances of the class `ConstantEvaluator` evaluate constant expressions to
- * produce their compile-time value. According to the Dart Language
- * Specification:
- * <blockquote>
- * A constant expression is one of the following:
- * * A literal number.
- * * A literal boolean.
- * * A literal string where any interpolated expression is a compile-time
- *   constant that evaluates to a numeric, string or boolean value or to
- *   <b>null</b>.
- * * A literal symbol.
- * * <b>null</b>.
- * * A qualified reference to a static constant variable.
- * * An identifier expression that denotes a constant variable, class or type
- *   alias.
- * * A constant constructor invocation.
- * * A constant list literal.
- * * A constant map literal.
- * * A simple or qualified identifier denoting a top-level function or a static
- *   method.
- * * A parenthesized expression <i>(e)</i> where <i>e</i> is a constant
- *   expression.
- * * An expression of the form <i>identical(e<sub>1</sub>, e<sub>2</sub>)</i>
- *   where <i>e<sub>1</sub></i> and <i>e<sub>2</sub></i> are constant
- *   expressions and <i>identical()</i> is statically bound to the predefined
- *   dart function <i>identical()</i> discussed above.
- * * An expression of one of the forms <i>e<sub>1</sub> == e<sub>2</sub></i> or
- *   <i>e<sub>1</sub> != e<sub>2</sub></i> where <i>e<sub>1</sub></i> and
- *   <i>e<sub>2</sub></i> are constant expressions that evaluate to a numeric,
- *   string or boolean value.
- * * An expression of one of the forms <i>!e</i>, <i>e<sub>1</sub> &amp;&amp;
- *   e<sub>2</sub></i> or <i>e<sub>1</sub> || e<sub>2</sub></i>, where <i>e</i>,
- *   <i>e1</sub></i> and <i>e2</sub></i> are constant expressions that evaluate
- *   to a boolean value.
- * * An expression of one of the forms <i>~e</i>, <i>e<sub>1</sub> ^
- *   e<sub>2</sub></i>, <i>e<sub>1</sub> &amp; e<sub>2</sub></i>,
- *   <i>e<sub>1</sub> | e<sub>2</sub></i>, <i>e<sub>1</sub> &gt;&gt;
- *   e<sub>2</sub></i> or <i>e<sub>1</sub> &lt;&lt; e<sub>2</sub></i>, where
- *   <i>e</i>, <i>e<sub>1</sub></i> and <i>e<sub>2</sub></i> are constant
- *   expressions that evaluate to an integer value or to <b>null</b>.
- * * An expression of one of the forms <i>-e</i>, <i>e<sub>1</sub> +
- *   e<sub>2</sub></i>, <i>e<sub>1</sub> -e<sub>2</sub></i>, <i>e<sub>1</sub> *
- *   e<sub>2</sub></i>, <i>e<sub>1</sub> / e<sub>2</sub></i>, <i>e<sub>1</sub>
- *   ~/ e<sub>2</sub></i>, <i>e<sub>1</sub> &gt; e<sub>2</sub></i>,
- *   <i>e<sub>1</sub> &lt; e<sub>2</sub></i>, <i>e<sub>1</sub> &gt;=
- *   e<sub>2</sub></i>, <i>e<sub>1</sub> &lt;= e<sub>2</sub></i> or
- *   <i>e<sub>1</sub> % e<sub>2</sub></i>, where <i>e</i>, <i>e<sub>1</sub></i>
- *   and <i>e<sub>2</sub></i> are constant expressions that evaluate to a
- *   numeric value or to <b>null</b>.
- * * An expression of the form <i>e<sub>1</sub> ? e<sub>2</sub> :
- *   e<sub>3</sub></i> where <i>e<sub>1</sub></i>, <i>e<sub>2</sub></i> and
- *   <i>e<sub>3</sub></i> are constant expressions, and <i>e<sub>1</sub></i>
- *   evaluates to a boolean value.
- * </blockquote>
- */
+/// Instances of the class [ConstantEvaluator] evaluate constant expressions to
+/// produce their compile-time value.
+///
+/// According to the Dart Language Specification:
+///
+/// > A constant expression is one of the following:
+/// >
+/// > * A literal number.
+/// > * A literal boolean.
+/// > * A literal string where any interpolated expression is a compile-time
+/// >   constant that evaluates to a numeric, string or boolean value or to
+/// >   **null**.
+/// > * A literal symbol.
+/// > * **null**.
+/// > * A qualified reference to a static constant variable.
+/// > * An identifier expression that denotes a constant variable, class or type
+/// >   alias.
+/// > * A constant constructor invocation.
+/// > * A constant list literal.
+/// > * A constant map literal.
+/// > * A simple or qualified identifier denoting a top-level function or a
+/// >   static method.
+/// > * A parenthesized expression _(e)_ where _e_ is a constant expression.
+/// > * <span>
+/// >   An expression of the form <i>identical(e<sub>1</sub>, e<sub>2</sub>)</i>
+/// >   where <i>e<sub>1</sub></i> and <i>e<sub>2</sub></i> are constant
+/// >   expressions and <i>identical()</i> is statically bound to the predefined
+/// >   dart function <i>identical()</i> discussed above.
+/// >   </span>
+/// > * <span>
+/// >   An expression of one of the forms <i>e<sub>1</sub> == e<sub>2</sub></i>
+/// >   or <i>e<sub>1</sub> != e<sub>2</sub></i> where <i>e<sub>1</sub></i> and
+/// >   <i>e<sub>2</sub></i> are constant expressions that evaluate to a
+/// >   numeric, string or boolean value.
+/// >   </span>
+/// > * <span>
+/// >   An expression of one of the forms <i>!e</i>, <i>e<sub>1</sub> &amp;&amp;
+/// >   e<sub>2</sub></i> or <i>e<sub>1</sub> || e<sub>2</sub></i>, where
+/// >   <i>e</i>, <i>e<sub>1</sub></i> and <i>e<sub>2</sub></i> are constant
+/// >   expressions that evaluate to a boolean value.
+/// >   </span>
+/// > * <span>
+/// >   An expression of one of the forms <i>~e</i>, <i>e<sub>1</sub> ^
+/// >   e<sub>2</sub></i>, <i>e<sub>1</sub> &amp; e<sub>2</sub></i>,
+/// >   <i>e<sub>1</sub> | e<sub>2</sub></i>, <i>e<sub>1</sub> &gt;&gt;
+/// >   e<sub>2</sub></i> or <i>e<sub>1</sub> &lt;&lt; e<sub>2</sub></i>, where
+/// >   <i>e</i>, <i>e<sub>1</sub></i> and <i>e<sub>2</sub></i> are constant
+/// >   expressions that evaluate to an integer value or to <b>null</b>.
+/// >   </span>
+/// > * <span>
+/// >   An expression of one of the forms <i>-e</i>, <i>e<sub>1</sub> +
+/// >   e<sub>2</sub></i>, <i>e<sub>1</sub> -e<sub>2</sub></i>,
+/// >   <i>e<sub>1</sub> * e<sub>2</sub></i>, <i>e<sub>1</sub> /
+/// >   e<sub>2</sub></i>, <i>e<sub>1</sub> ~/ e<sub>2</sub></i>,
+/// >   <i>e<sub>1</sub> &gt; e<sub>2</sub></i>, <i>e<sub>1</sub> &lt;
+/// >   e<sub>2</sub></i>, <i>e<sub>1</sub> &gt;= e<sub>2</sub></i>,
+/// >   <i>e<sub>1</sub> &lt;= e<sub>2</sub></i> or <i>e<sub>1</sub> %
+/// >   e<sub>2</sub></i>, where <i>e</i>, <i>e<sub>1</sub></i> and
+/// >   <i>e<sub>2</sub></i> are constant expressions that evaluate to a numeric
+/// >   value or to <b>null</b>.
+/// >   </span>
+/// > * <span>
+/// >   An expression of the form <i>e<sub>1</sub> ? e<sub>2</sub> :
+/// >   e<sub>3</sub></i> where <i>e<sub>1</sub></i>, <i>e<sub>2</sub></i> and
+/// >   <i>e<sub>3</sub></i> are constant expressions, and <i>e<sub>1</sub></i>
+/// >   evaluates to a boolean value.
+/// >   </span>
+///
+/// The values returned by instances of this class are therefore `null` and
+/// instances of the classes `Boolean`, `BigInteger`, `Double`, `String`, and
+/// `DartObject`.
+///
+/// In addition, this class defines several values that can be returned to
+/// indicate various conditions encountered during evaluation. These are
+/// documented with the static fields that define those values.
 class ConstantEvaluator {
   /**
    * The source containing the expression(s) that will be evaluated.


### PR DESCRIPTION
ConstantEvalulator's doc comment, when parsed as Markdown and rendered at [dartdocs.org](http://www.dartdocs.org/documentation/analyzer/0.26.1%2B3/index.html#analyzer/analyzer.ConstantEvaluator), looks terrible.

I think there was a valiant effort to make it render ok, what with the &lt;blockquote>, but in any case, it was just a blob. This fixes a few things:
- One summary sentence first paragraph.
- Make the blockquote and list into an actual blockquote and an actual list.
- Fix some un-subscripted subscripts.
- Render the HTML that was attempted by making certain list items _blocks_, by starting out with the span tags.

Here's a screen of the new docs:

![screen shot 2015-09-13 at 3 03 26 pm](https://cloud.githubusercontent.com/assets/103167/9839272/2a0f4652-5a29-11e5-91d6-64161ded2e6c.png)
