### PR TITLE
Fix parameter type of MapMixin.containsValue

### DIFF
--- a/sdk/lib/collection/maps.dart
+++ b/sdk/lib/collection/maps.dart
@@ -60,7 +60,7 @@ abstract class MapMixin<K, V> implements Map<K, V> {
     }
   }
 
-  bool containsValue(V value) {
+  bool containsValue(Object value) {
     for (K key in keys) {
       if (this[key] == value) return true;
     }


### PR DESCRIPTION
Make this method compatible with [`Map.containsValue(Object value)`](https://github.com/dart-lang/sdk/blob/1.12.1/sdk/lib/core/map.dart#L147)
