### PR TITLE
Fix comment removal regex

### DIFF
--- a/pkg/compiler/lib/src/js_backend/constant_emitter.dart
+++ b/pkg/compiler/lib/src/js_backend/constant_emitter.dart
@@ -18,10 +18,10 @@ typedef jsAst.Expression _ConstantListGenerator(jsAst.Expression array);
 class ConstantEmitter
     implements ConstantValueVisitor<jsAst.Expression, Null> {
 
-  // Matches blank lines, comment lines and trailing comments that can't be part
-  // of a string.
+  // Matches blank lines, comment lines and trailing comments.
+  // Note: this will include slashes in strings!
   static final RegExp COMMENT_RE =
-      new RegExp(r'''^ *(//.*)?\n|  *//[^''"\n]*$''' , multiLine: true);
+      new RegExp(r'''^ *(//.*)?\n|  *//[^\n]*$''' , multiLine: true);
 
   final Compiler compiler;
   final Namer namer;


### PR DESCRIPTION
While this would also remove comments inside strings, this fix fixes generation of JS_CONST's to JavaScript.

Lines that created issues in the compiled result:

https://github.com/dart-lang/sdk/blob/7b48eb2b7fbcf6b7ee40372e31addec64d4c8d8f/sdk/lib/_internal/js_runtime/lib/native_helper.dart#L601

```
  C.JS_CONST_EyN = function(hooks) {  var getTag = hooks.getTag;  var prototypeForTag = hooks.prototypeForTag;  function getTagFixed(o) {    var tag = getTag(o);    if (tag == "Document") {      // "Document", so we check for the xmlVersion property, which is the empty      if (!!o.xmlVersion) return "!Document";      return "!HTMLDocument";    }    return tag;  }  function prototypeForTagFixed(tag) {    if (tag == "Document") return null;    return prototypeForTag(tag);  }  hooks.getTag = getTagFixed;  hooks.prototypeForTag = prototypeForTagFixed;};
```

https://github.com/dart-lang/sdk/blob/7b48eb2b7fbcf6b7ee40372e31addec64d4c8d8f/sdk/lib/_internal/js_runtime/lib/native_helper.dart#L515
https://github.com/dart-lang/sdk/blob/7b48eb2b7fbcf6b7ee40372e31addec64d4c8d8f/sdk/lib/_internal/js_runtime/lib/native_helper.dart#L519

```
  C.JS_CONST_jzj = function getTagFallback(o) {  var constructor = o.constructor;  if (typeof constructor == "function") {    var name = constructor.name;    if (typeof name == "string" &&        // constructor name does not 'stick'.  The shortest real DOM object        name.length > 2 &&        // On Firefox we often get "Object" as the constructor name, even for        name !== "Object" &&        name !== "Function.prototype") {      return name;    }  }  var s = Object.prototype.toString.call(o);  return s.substring(8, s.length - 1);};
```

Another workaround would be changing the comments to _not_ include quotes, but as the regex is only used (as far as I have seen) in blocks of code that do not include slashes inside strings, this fix should be fine.
