### PR TITLE
suggest argument name completions for annotations that are imported

### DIFF
--- a/pkg/analysis_server/lib/src/services/completion/arglist_contributor.dart
+++ b/pkg/analysis_server/lib/src/services/completion/arglist_contributor.dart
@@ -198,6 +198,12 @@ class _ArgSuggestionBuilder {
         }
       }
     }
+    if (parent is Annotation) {
+      Element element = parent.element;
+      if (element is ExecutableElement) {
+        _addSuggestions(element.parameters);
+      }
+    }
     return new Future.value(false);
   }
 

--- a/pkg/analysis_server/test/services/completion/arglist_contributor_test.dart
+++ b/pkg/analysis_server/test/services/completion/arglist_contributor_test.dart
@@ -91,13 +91,22 @@ class ArgListContributorTest extends AbstractCompletionTest {
   }
 
   test_Annotation_local_constructor_named_param() {
-    //
     addTestSource('''
 class A { A({int one, String two: 'defaultValue'}) { } }
 @A(^) main() { }''');
     computeFast();
     return computeFull((bool result) {
       assertSuggestArguments(namedArguments: ['one', 'two']);
+    });
+  }
+
+  test_Annotation_imported_constructor_named_param() {
+    addSource('/libA.dart', '''
+library libA; class A { A({int one, String two: 'defaultValue'}) { } }''');
+    addTestSource('import "/libA.dart"; @A(^) main() { }');
+    computeFast();
+    return computeFull((bool result) {
+      assertSuggestArguments(namedArguments: ['one','two']);
     });
   }
 


### PR DESCRIPTION
suggest argument name completions for annotations that are imported

addresses #25089, but doesn't fix it entirely

changed a typo in the test compared to #25098 
