### PR TITLE
add `not` getter to bool class

### DIFF
--- a/sdk/lib/core/bool.dart
+++ b/sdk/lib/core/bool.dart
@@ -40,7 +40,14 @@ class bool {
    */
   external const factory bool.fromEnvironment(String name,
                                               {bool defaultValue: false});
-
+  
+  /// The negated value. For example:
+  ///
+  ///     if (new File('hello.txt').existsSync().not) {
+  ///       print("hello.txt doesn't exist");
+  ///     }
+  bool get not => !this;
+  
   /**
    * Returns [:"true":] if the receiver is [:true:], or [:"false":] if the
    * receiver is [:false:].


### PR DESCRIPTION
When switching from Python to Dart and back, I notice that Python's negations keyword `not` is often easier to read/scan than dart's `!` operator. I often miss the `!` in a long expression. 

I understand that Dart is not going to adopt the Python syntax. But I think adding a `not` getter to the bool class, would be easy to implement and fits the dart syntax very well (imo).

In expressions like:

``` dart
if (new File(expandPath('myFancyDir/myFancyFile.txt').existsSync())
```

It is easy to oversee the `!` operator:

``` dart
if (!new File(expandPath('myFancyDir/myFancyFile.txt').existsSync())
```

Therefore, I propose the following syntax:

``` dart
if (new File(expandPath('myFancyDir/myFancyFile.txt').existsSync().not)
```

It is not only expressive, but also, easy to type. I rather type an autocompleted `not`, then moving my cursor to the beginning and back.
