### PR TITLE
Fix a compilation error on GCC4.8

### DIFF
--- a/runtime/bin/builtin_gen_snapshot.cc
+++ b/runtime/bin/builtin_gen_snapshot.cc
@@ -77,7 +77,8 @@ void FUNCTION_NAME(Builtin_PrintString)(Dart_NativeArguments args) {
     // interrupt.
     fputs(Dart_GetError(result), stdout);
   } else {
-    fwrite(chars, sizeof(*chars), length, stdout);
+    intptr_t res = fwrite(chars, sizeof(*chars), length, stdout);
+    ASSERT(res == length);
   }
   fputc('\n', stdout);
   fflush(stdout);


### PR DESCRIPTION
`dart-sdk` compile failed on GCC4.8.2 due to unused return value.

```
runtime/bin/builtin_gen_snapshot.cc:80:50: error: ignoring return value of ‘size_t fwrite(const void*, size_t, size_t, FILE*)’, declared with attribute warn_unused_result [-Werror=unused-result]
     fwrite(chars, sizeof(*chars), length, stdout);
                                                  ^
cc1plus: all warnings being treated as errors
make: *** [out/ReleaseX64/obj.host/gen_snapshot/runtime/bin/builtin_gen_snapshot.o] Error 1
make: *** Waiting for unfinished jobs....
```
