### PR TITLE
Minor change to fix some strong-mode errors

### DIFF
--- a/pkg/analysis_server/lib/src/services/refactoring/rename.dart
+++ b/pkg/analysis_server/lib/src/services/refactoring/rename.dart
@@ -128,10 +128,11 @@ bool isVisibleInLibrary(
 abstract class RenameRefactoringImpl extends RefactoringImpl
     implements RenameRefactoring {
   final SearchEngine searchEngine;
-  final Element element;
+  final Element _element;
   final AnalysisContext context;
   final String elementKindName;
   final String oldName;
+  Element get element => _element;
 
   SourceChange change;
 
@@ -139,7 +140,7 @@ abstract class RenameRefactoringImpl extends RefactoringImpl
 
   RenameRefactoringImpl(SearchEngine searchEngine, Element element)
       : searchEngine = searchEngine,
-        element = element,
+        _element = element,
         context = element.context,
         elementKindName = element.kind.displayName,
         oldName = _getDisplayName(element);


### PR DESCRIPTION
@bwilkerson @scheglov 
Subclasses that override `element` generated an error in strong-mode because the field could not be overridden. Changing it o a getter eliminates the error. All 3540 tests pass.
