### PR TITLE
Removing overriden field from _HttpInboundMessage.

### DIFF
--- a/sdk/lib/io/http_impl.dart
+++ b/sdk/lib/io/http_impl.dart
@@ -182,8 +182,6 @@ class _HttpClientResponse
   // The HttpClientRequest of this response.
   final _HttpClientRequest _httpRequest;
 
-  List<Cookie> _cookies;
-
   _HttpClientResponse(_HttpIncoming _incoming, this._httpRequest,
                       this._httpClient) : super(_incoming) {
     // Set uri for potential exceptions.


### PR DESCRIPTION
Since the field is accessible from the derived class, there
is no need to override it.
Found via dart-lang/linter
