### PR TITLE
Fix formatting of comment in HttpHeaders class

### DIFF
--- a/sdk/lib/io/http.dart
+++ b/sdk/lib/io/http.dart
@@ -400,7 +400,7 @@ class HttpConnectionsInfo {
  * To set the value of a header use the `set()` method:
  *
  *     request.headers.set(HttpHeaders.CACHE_CONTROL,
-                           'max-age=3600, must-revalidate');
+ *                         'max-age=3600, must-revalidate');
  *
  * To retrieve the value of a header use the `value()` method:
  *


### PR DESCRIPTION
There's a formatting issue with this sample code in [the docs](https://api.dartlang.org/stable/1.17.1/dart-io/HttpHeaders-class.html). Looks to be caused by a missing `*` on a line of the comment.

![8c9993d0-01af-11e6-8f2d-86d2801d8a4a](https://cloud.githubusercontent.com/assets/1078012/17033314/7b3d2e3a-4f75-11e6-8889-af21484befa8.png)
