### PR TITLE
Added js import to sample code.

### DIFF
--- a/pkg/js/README.md
+++ b/pkg/js/README.md
@@ -34,6 +34,8 @@ external String stringify(obj);
 @JS('google.maps')
 library maps;
 
+import "package:js/js.dart";
+
 // Invokes the JavaScript getter `google.maps.map`.
 external Map get map;
 


### PR DESCRIPTION
This import is required for the sample code to pass the analyzer, otherwise you'll get an error on the first line.

```
[error] Annotation can be only constant variable or constant constructor invocation
```
