### PR TITLE
Updated directory_linux.cc to conform with the deprecation of readdir_r

### DIFF
--- a/runtime/bin/directory_linux.cc
+++ b/runtime/bin/directory_linux.cc
@@ -120,7 +120,7 @@ ListType DirectoryListingEntry::Next(DirectoryListing* listing) {
   dirent* result;
   errno = 0;
   result = readdir(reinterpret_cast<DIR*>(lister_));
-  if (result != NULL) {
+  if ((errno == 0) && (result != NULL)) {
     if (!listing->path_buffer().Add(result->d_name)) {
       done_ = true;
       return kListError;

--- a/runtime/bin/directory_linux.cc
+++ b/runtime/bin/directory_linux.cc
@@ -275,26 +275,26 @@ static bool DeleteRecursively(PathBuffer* path) {
   // Iterate the directory and delete all files and directories.
   int path_length = path->length();
   while (true) {
-    dirent* result = readdir(dir_pointer);
-    if (result == NULL) {
+    dirent* entry = readdir(dir_pointer);
+    if (entry == NULL) {
       // End of directory.
       return (NO_RETRY_EXPECTED(closedir(dir_pointer)) == 0) &&
              (NO_RETRY_EXPECTED(remove(path->AsString())) == 0);
     }
     bool ok = false;
-    switch (result->d_type) {
+    switch (entry->d_type) {
       case DT_DIR:
-        ok = DeleteDir(result->d_name, path);
+        ok = DeleteDir(entry->d_name, path);
         break;
       case DT_REG:
       case DT_LNK:
         // Treat all links as files. This will delete the link which
         // is what we want no matter if the link target is a file or a
         // directory.
-        ok = DeleteFile(result->d_name, path);
+        ok = DeleteFile(entry->d_name, path);
         break;
       case DT_UNKNOWN: {
-        if (!path->Add(result->d_name)) {
+        if (!path->Add(entry->d_name)) {
           break;
         }
         // On some file systems the entry type is not determined by
@@ -306,12 +306,12 @@ static bool DeleteRecursively(PathBuffer* path) {
         }
         path->Reset(path_length);
         if (S_ISDIR(entry_info.st_mode)) {
-          ok = DeleteDir(result->d_name, path);
+          ok = DeleteDir(entry->d_name, path);
         } else if (S_ISREG(entry_info.st_mode) || S_ISLNK(entry_info.st_mode)) {
           // Treat links as files. This will delete the link which is
           // what we want no matter if the link target is a file or a
           // directory.
-          ok = DeleteFile(result->d_name, path);
+          ok = DeleteFile(entry->d_name, path);
         }
         break;
       }

--- a/runtime/bin/directory_linux.cc
+++ b/runtime/bin/directory_linux.cc
@@ -141,7 +141,7 @@ ListType DirectoryListingEntry::Next(DirectoryListing* listing) {
         // Fall through.
       case DT_UNKNOWN: {
         // On some file systems the entry type is not determined by
-        // readdir_r. For those and for links we use stat to determine
+        // readdir. For those and for links we use stat to determine
         // the actual entry type. Notice that stat returns the type of
         // the file pointed to.
         struct stat64 entry_info;
@@ -277,15 +277,15 @@ static bool DeleteRecursively(PathBuffer* path) {
     // In case `readdir()` returns `NULL` we distinguish between end-of-stream and error
     // by looking if `errno` was updated.
     errno = 0;
-    //In glibc 2.24+, readdir_r is deprecated.
-    //According to the man page for readdir:
-    //"readdir(3) is not required to be thread-safe. However, in modern
-    //implementations (including the glibc implementation), concurrent calls to
-    //readdir(3) that specify different directory streams are thread-safe.
-    //Therefore, the use of readdir_r() is generally unnecessary in multithreaded
-    //programs. In cases where multiple threads must read from the same directory
-    //stream, using readdir(3) with external synchronization is still preferable
-    //to the use of readdir_r(), for the reasons given in the points above."
+    // In glibc 2.24+, readdir_r is deprecated.
+    // According to the man page for readdir:
+    // "readdir(3) is not required to be thread-safe. However, in modern
+    // implementations (including the glibc implementation), concurrent calls to
+    // readdir(3) that specify different directory streams are thread-safe.
+    // Therefore, the use of readdir_r() is generally unnecessary in multithreaded
+    // programs. In cases where multiple threads must read from the same directory
+    // stream, using readdir(3) with external synchronization is still preferable
+    // to the use of readdir_r(), for the reasons given in the points above."
     dirent* entry = readdir(dir_pointer);
     if (entry == NULL) {
       // Failed to read next directory entry.

--- a/runtime/bin/directory_linux.cc
+++ b/runtime/bin/directory_linux.cc
@@ -279,7 +279,7 @@ static bool DeleteRecursively(PathBuffer* path) {
     errno = 0;
     dirent* entry = readdir(dir_pointer);
     if (entry == NULL) {
-      // Failed to read next directory entry
+      // Failed to read next directory entry.
       if (errno != 0) break;
       // End of directory.
       return (NO_RETRY_EXPECTED(closedir(dir_pointer)) == 0) &&

--- a/runtime/bin/directory_linux.cc
+++ b/runtime/bin/directory_linux.cc
@@ -277,10 +277,21 @@ static bool DeleteRecursively(PathBuffer* path) {
     // In case `readdir()` returns `NULL` we distinguish between end-of-stream and error
     // by looking if `errno` was updated.
     errno = 0;
+    //In glibc 2.24+, readdir_r is deprecated.
+    //According to the man page for readdir:
+    //"readdir(3) is not required to be thread-safe. However, in modern
+    //implementations (including the glibc implementation), concurrent calls to
+    //readdir(3) that specify different directory streams are thread-safe.
+    //Therefore, the use of readdir_r() is generally unnecessary in multithreaded
+    //programs. In cases where multiple threads must read from the same directory
+    //stream, using readdir(3) with external synchronization is still preferable
+    //to the use of readdir_r(), for the reasons given in the points above."
     dirent* entry = readdir(dir_pointer);
     if (entry == NULL) {
       // Failed to read next directory entry.
-      if (errno != 0) break;
+      if (errno != 0) {
+          break;
+      }
       // End of directory.
       return (NO_RETRY_EXPECTED(closedir(dir_pointer)) == 0) &&
              (NO_RETRY_EXPECTED(remove(path->AsString())) == 0);

--- a/runtime/bin/directory_linux.cc
+++ b/runtime/bin/directory_linux.cc
@@ -119,8 +119,7 @@ ListType DirectoryListingEntry::Next(DirectoryListing* listing) {
   // ports.
   dirent* result;
   errno = 0;
-  result = readdir(
-      reinterpret_cast<DIR*>(lister_));
+  result = readdir(reinterpret_cast<DIR*>(lister_));
   if (result != NULL) {
     if (!listing->path_buffer().Add(result->d_name)) {
       done_ = true;
@@ -275,8 +274,8 @@ static bool DeleteRecursively(PathBuffer* path) {
 
   // Iterate the directory and delete all files and directories.
   int path_length = path->length();
-  dirent* result;
-  while ((result = readdir(dir_pointer)) != NULL) {
+  while (true) {
+    dirent* result = readdir(dir_pointer);
     if (result == NULL) {
       // End of directory.
       return (NO_RETRY_EXPECTED(closedir(dir_pointer)) == 0) &&

--- a/runtime/bin/directory_linux.cc
+++ b/runtime/bin/directory_linux.cc
@@ -117,18 +117,18 @@ ListType DirectoryListingEntry::Next(DirectoryListing* listing) {
 
   // Iterate the directory and post the directories and files to the
   // ports.
-  dirent* result;
+  dirent* entry;
   errno = 0;
-  result = readdir(reinterpret_cast<DIR*>(lister_));
-  if ((errno == 0) && (result != NULL)) {
-    if (!listing->path_buffer().Add(result->d_name)) {
+  entry = readdir(reinterpret_cast<DIR*>(lister_));
+  if (entry != NULL) {
+    if (!listing->path_buffer().Add(entry->d_name)) {
       done_ = true;
       return kListError;
     }
-    switch (result->d_type) {
+    switch (entry->d_type) {
       case DT_DIR:
-        if ((strcmp(result->d_name, ".") == 0) ||
-            (strcmp(result->d_name, "..") == 0)) {
+        if ((strcmp(entry->d_name, ".") == 0) ||
+            (strcmp(entry->d_name, "..") == 0)) {
           return Next(listing);
         }
         return kListDirectory;
@@ -176,16 +176,16 @@ ListType DirectoryListingEntry::Next(DirectoryListing* listing) {
             // Recurse into the subdirectory with current_link added to the
             // linked list of seen file system links.
             link_ = new LinkList(current_link);
-            if ((strcmp(result->d_name, ".") == 0) ||
-                (strcmp(result->d_name, "..") == 0)) {
+            if ((strcmp(entry->d_name, ".") == 0) ||
+                (strcmp(entry->d_name, "..") == 0)) {
               return Next(listing);
             }
             return kListDirectory;
           }
         }
         if (S_ISDIR(entry_info.st_mode)) {
-          if ((strcmp(result->d_name, ".") == 0) ||
-              (strcmp(result->d_name, "..") == 0)) {
+          if ((strcmp(entry->d_name, ".") == 0) ||
+              (strcmp(entry->d_name, "..") == 0)) {
             return Next(listing);
           }
           return kListDirectory;

--- a/runtime/bin/directory_linux.cc
+++ b/runtime/bin/directory_linux.cc
@@ -313,7 +313,7 @@ static bool DeleteRecursively(PathBuffer* path) {
           break;
         }
         // On some file systems the entry type is not determined by
-        // readdir_r. For those we use lstat to determine the entry
+        // readdir. For those we use lstat to determine the entry
         // type.
         struct stat64 entry_info;
         if (TEMP_FAILURE_RETRY(lstat64(path->AsString(), &entry_info)) == -1) {

--- a/runtime/bin/directory_linux.cc
+++ b/runtime/bin/directory_linux.cc
@@ -274,8 +274,10 @@ static bool DeleteRecursively(PathBuffer* path) {
 
   // Iterate the directory and delete all files and directories.
   int path_length = path->length();
-  while (true) {
-    dirent* entry = readdir(dir_pointer);
+  errno = 0;
+  //Initial read
+  dirent* entry = readdir(dir_pointer);
+  while (errno == 0){
     if (entry == NULL) {
       // End of directory.
       return (NO_RETRY_EXPECTED(closedir(dir_pointer)) == 0) &&
@@ -322,6 +324,9 @@ static bool DeleteRecursively(PathBuffer* path) {
       break;
     }
     path->Reset(path_length);
+    errno = 0;
+    //Perform readdir for next loop
+    entry = readdir(dir_pointer);
   }
   // Only happens if an error.
   ASSERT(errno != 0);


### PR DESCRIPTION
Since glibc 2.24, readdir_r is deprecated. According to [the man page](http://man7.org/linux/man-pages/man3/readdir.3.html):

> In the current POSIX.1 specification (POSIX.1-2008), readdir(3) is not required to be thread-safe.  However, in modern implementations (including the glibc implementation), concurrent calls to readdir(3) that specify different directory streams are thread-safe.  Therefore, the use of readdir_r() is generally unnecessary in multithreaded programs.  In cases where multiple threads must read from the same directory stream, using readdir(3) with external synchronization is still preferable to the use of readdir_r(), for the reasons given in the points above.
