### PR TITLE
Updated file path logic to work with Windows systems.

### DIFF
--- a/pkg/dev_compiler/tool/global_compile.dart
+++ b/pkg/dev_compiler/tool/global_compile.dart
@@ -33,7 +33,7 @@ void main(List<String> args) {
     ..addOption('package-root',
         help: 'Directory containing packages',
         abbr: 'p',
-        defaultsTo: 'packages/')
+        defaultsTo: 'packages${path.separator}')
     ..addFlag('log', help: 'Show individual build commands')
     ..addOption('tmp',
         help:
@@ -239,14 +239,13 @@ void processDependence(String from, String to) {
   dependenceMap[fromModule].add(toModule);
 }
 
-String canonicalize(String uri, String root) {
-  var sourceUri = Uri.parse(uri);
-  if (sourceUri.scheme == '') {
-    sourceUri = path.toUri(
-        path.isAbsolute(uri) ? path.absolute(uri) : path.join(root, uri));
-    return sourceUri.path;
+String canonicalize(String uri, String root, String packageRoot) {
+  if (uri.startsWith('package:')) {
+    uri = path.join(packageRoot, uri.substring(8));
   }
-  return sourceUri.toString();
+  String sourcePath = path.isAbsolute(uri) ? uri : path.join(root, uri);
+  sourcePath = path.normalize(sourcePath);
+  return sourcePath;
 }
 
 /// Simplified from ParseDartTask.resolveDirective.
@@ -260,25 +259,22 @@ String _resolveDirective(UriBasedDirective directive) {
   return directive.validate() == null ? uriContent : null;
 }
 
-String _loadFile(String uri, String packageRoot) {
-  if (uri.startsWith('package:')) {
-    uri = path.join(packageRoot, uri.substring(8));
-  }
+String _loadFile(String uri) {
   return new File(uri).readAsStringSync();
 }
 
 void transitiveFiles(String entryPoint, String root, String packageRoot) {
-  entryPoint = canonicalize(entryPoint, root);
   if (entryPoint.startsWith('dart:')) return;
+  entryPoint = canonicalize(entryPoint, root, packageRoot);
   if (processFile(entryPoint)) {
     // Process this
-    var source = _loadFile(entryPoint, packageRoot);
+    var source = _loadFile(entryPoint);
     var entryDir = path.dirname(entryPoint);
     var unit = parseDirectives(source, name: entryPoint, suppressErrors: true);
     for (var d in unit.directives) {
       if (d is ImportDirective || d is ExportDirective) {
         var uri = _resolveDirective(d);
-        processDependence(entryPoint, canonicalize(uri, entryDir));
+        processDependence(entryPoint, canonicalize(uri, entryDir, packageRoot));
         transitiveFiles(uri, entryDir, packageRoot);
       } else if (d is PartDirective) {
         var uri = _resolveDirective(d);


### PR DESCRIPTION
This branch has the changes that make global_complie.dart work with windows paths. My demo still builds on linux with the changes.
