### PR TITLE
replace `/` with `.` in sourceUrl

### DIFF
--- a/pkg/dev_compiler/lib/src/compiler/compiler.dart
+++ b/pkg/dev_compiler/lib/src/compiler/compiler.dart
@@ -495,7 +495,11 @@ class JSModuleFile {
       // In singleOutFile mode we wrap each module in an eval statement to
       // leverage sourceURL to improve the debugging experience when source maps
       // are not enabled.
-      c += '\n//# sourceURL=${name}.js\n';
+      //
+      // Note: We replace all `/` with `.` so that we don't break relative urls
+      // to sources in the original sourcemap. The name of this file is bogus
+      // anyways, so it has very little effect on things.
+      c += '\n//# sourceURL=${name.replaceAll("/", ".")}.js\n';
       c = 'eval(${JSON.encode(c)});\n';
     }
     new File(jsPath).writeAsStringSync(c);


### PR DESCRIPTION
This prevents breaking relative source uris in source maps. If the sourceUrl looks like a real path then all relative source uris become relative to that path.