### PR TITLE
Fix typos 'overriden' to 'overridden' and '@mustCall super' to '@mustCallSuper'

### DIFF
--- a/pkg/analysis_server/test/integration/analysis/update_content_test.dart
+++ b/pkg/analysis_server/test/integration/analysis/update_content_test.dart
@@ -37,7 +37,7 @@ main() {
         .then((result) => analysisFinished)
         .then((_) {
           // There should be no errors now because the contents on disk have been
-          // overriden with goodText.
+          // overridden with goodText.
           expect(currentAnalysisErrors[pathname], isEmpty);
           return sendAnalysisUpdateContent({
             pathname: new ChangeContentOverlay(

--- a/pkg/analyzer/lib/src/dart/error/hint_codes.dart
+++ b/pkg/analyzer/lib/src/dart/error/hint_codes.dart
@@ -330,7 +330,7 @@ class HintCode extends ErrorCode {
    */
   static const HintCode MUST_CALL_SUPER = const HintCode(
       'MUST_CALL_SUPER',
-      "This method overrides a method annotated as @mustCall super in '{0}', "
+      "This method overrides a method annotated as @mustCallSuper in '{0}', "
       "but does invoke the overridden method.");
 
   /**

--- a/pkg/analyzer/lib/src/dart/error/hint_codes.dart
+++ b/pkg/analyzer/lib/src/dart/error/hint_codes.dart
@@ -326,12 +326,12 @@ class HintCode extends ErrorCode {
    * that do not invoke the overridden super method.
    *
    * Parameters:
-   * 0: the name of the class declaring the overriden method
+   * 0: the name of the class declaring the overridden method
    */
   static const HintCode MUST_CALL_SUPER = const HintCode(
       'MUST_CALL_SUPER',
       "This method overrides a method annotated as @mustCall super in '{0}', "
-      "but does invoke the overriden method.");
+      "but does invoke the overridden method.");
 
   /**
    * A condition in a control flow statement could evaluate to `null` because it

--- a/pkg/analyzer/lib/src/generated/resolver.dart
+++ b/pkg/analyzer/lib/src/generated/resolver.dart
@@ -8669,7 +8669,7 @@ class TypeOverrideManager_TypeOverrideScope {
   /**
    * A table mapping elements to the overridden type of that element.
    */
-  Map<VariableElement, DartType> _overridenTypes =
+  Map<VariableElement, DartType> _overriddenTypes =
       new HashMap<VariableElement, DartType>();
 
   /**
@@ -8685,7 +8685,7 @@ class TypeOverrideManager_TypeOverrideScope {
    * @param overrides the overrides to be applied
    */
   void applyOverrides(Map<VariableElement, DartType> overrides) {
-    _overridenTypes.addAll(overrides);
+    _overriddenTypes.addAll(overrides);
   }
 
   /**
@@ -8694,7 +8694,7 @@ class TypeOverrideManager_TypeOverrideScope {
    *
    * @return the overrides in the current scope
    */
-  Map<VariableElement, DartType> captureLocalOverrides() => _overridenTypes;
+  Map<VariableElement, DartType> captureLocalOverrides() => _overriddenTypes;
 
   /**
    * Return a map from the elements for the variables in the given list that have their types
@@ -8711,7 +8711,7 @@ class TypeOverrideManager_TypeOverrideScope {
       for (VariableDeclaration variable in variableList.variables) {
         VariableElement element = variable.element;
         if (element != null) {
-          DartType type = _overridenTypes[element];
+          DartType type = _overriddenTypes[element];
           if (type != null) {
             overrides[element] = type;
           }
@@ -8731,8 +8731,8 @@ class TypeOverrideManager_TypeOverrideScope {
   DartType getType(Element element) {
     Element nonAccessor =
         element is PropertyAccessorElement ? element.variable : element;
-    DartType type = _overridenTypes[nonAccessor];
-    if (_overridenTypes.containsKey(nonAccessor)) {
+    DartType type = _overriddenTypes[nonAccessor];
+    if (_overriddenTypes.containsKey(nonAccessor)) {
       return type;
     }
     return type ?? _outerScope?.getType(element);
@@ -8742,7 +8742,7 @@ class TypeOverrideManager_TypeOverrideScope {
    * Clears the overridden type of the given [element].
    */
   void resetType(VariableElement element) {
-    _overridenTypes[element] = null;
+    _overriddenTypes[element] = null;
   }
 
   /**
@@ -8752,7 +8752,7 @@ class TypeOverrideManager_TypeOverrideScope {
    * @param type the overridden type of the given element
    */
   void setType(VariableElement element, DartType type) {
-    _overridenTypes[element] = type;
+    _overriddenTypes[element] = type;
   }
 }
 

--- a/pkg/dev_compiler/test/codegen/language/field_test.dart
+++ b/pkg/dev_compiler/test/codegen/language/field_test.dart
@@ -52,11 +52,11 @@ class FieldTest {
     // The tests below are a little cumbersome because not
     // everything is implemented yet.
     var o = new Second();
-    // 'a' getter is overriden, always returns -12.
+    // 'a' getter is overridden, always returns -12.
     Expect.equals(-12, o.a);
     o.a = 2;
     Expect.equals(-12, o.a);
-    // 'b' setter is overriden to write 12 to field 'c'.
+    // 'b' setter is overridden to write 12 to field 'c'.
     o.b = o;
     Expect.equals(12, o.c);
   }

--- a/pkg/dev_compiler/tool/input_sdk/lib/convert/utf.dart
+++ b/pkg/dev_compiler/tool/input_sdk/lib/convert/utf.dart
@@ -37,7 +37,7 @@ class Utf8Codec extends Encoding {
    * The optional [allowMalformed] argument defines how [decoder] (and [decode])
    * deal with invalid or unterminated character sequences.
    *
-   * If it is `true` (and not overriden at the method invocation) [decode] and
+   * If it is `true` (and not overridden at the method invocation) [decode] and
    * the [decoder] replace invalid (or unterminated) octet
    * sequences with the Unicode Replacement character `U+FFFD` (�). Otherwise
    * they throw a [FormatException].

--- a/pkg/dev_compiler/tool/input_sdk/lib/js/dart2js/js_dart2js.dart
+++ b/pkg/dev_compiler/tool/input_sdk/lib/js/dart2js/js_dart2js.dart
@@ -383,7 +383,7 @@ class JsArray<E> extends JsObject with ListMixin<E> {
     super['length'] = length;
   }
 
-  // Methods overriden for better performance
+  // Methods overridden for better performance
 
   void add(E value) {
     callMethod('push', [value]);

--- a/runtime/vm/dart_api_impl.cc
+++ b/runtime/vm/dart_api_impl.cc
@@ -5094,7 +5094,7 @@ RawString* Api::GetEnvironmentValue(Thread* thread, const String& name) {
         }
       }
     }
-    // Check for default VM provided values. If it was not overriden on the
+    // Check for default VM provided values. If it was not overridden on the
     // command line.
     if (Symbols::DartIsVM().Equals(name)) {
       return Symbols::True().raw();

--- a/runtime/vm/flow_graph.cc
+++ b/runtime/vm/flow_graph.cc
@@ -428,7 +428,7 @@ bool FlowGraph::IsReceiver(Definition* def) const {
 
 
 // Use CHA to determine if the call needs a class check: if the callee's
-// receiver is the same as the caller's receiver and there are no overriden
+// receiver is the same as the caller's receiver and there are no overridden
 // callee functions, then no class check is needed.
 bool FlowGraph::InstanceCallNeedsClassCheck(InstanceCallInstr* call,
                                             RawFunction::Kind kind) const {

--- a/sdk/lib/convert/utf.dart
+++ b/sdk/lib/convert/utf.dart
@@ -37,7 +37,7 @@ class Utf8Codec extends Encoding {
    * The optional [allowMalformed] argument defines how [decoder] (and [decode])
    * deal with invalid or unterminated character sequences.
    *
-   * If it is `true` (and not overriden at the method invocation) [decode] and
+   * If it is `true` (and not overridden at the method invocation) [decode] and
    * the [decoder] replace invalid (or unterminated) octet
    * sequences with the Unicode Replacement character `U+FFFD` (�). Otherwise
    * they throw a [FormatException].

--- a/sdk/lib/js/dart2js/js_dart2js.dart
+++ b/sdk/lib/js/dart2js/js_dart2js.dart
@@ -465,7 +465,7 @@ class JsArray<E> extends JsObject with ListMixin<E> {
     super['length'] = length;
   }
 
-  // Methods overriden for better performance
+  // Methods overridden for better performance
 
   void add(E value) {
     callMethod('push', [value]);

--- a/sdk/lib/js/dartium/js_dartium.dart
+++ b/sdk/lib/js/dartium/js_dartium.dart
@@ -1557,7 +1557,7 @@ class JsArray<E> extends JsObject with ListMixin<E> {
     super['length'] = length;
   }
 
-  // Methods overriden for better performance
+  // Methods overridden for better performance
 
   void add(E value) {
     callMethod('push', [value]);

--- a/tests/language/field_test.dart
+++ b/tests/language/field_test.dart
@@ -52,11 +52,11 @@ class FieldTest {
     // The tests below are a little cumbersome because not
     // everything is implemented yet.
     var o = new Second();
-    // 'a' getter is overriden, always returns -12.
+    // 'a' getter is overridden, always returns -12.
     Expect.equals(-12, o.a);
     o.a = 2;
     Expect.equals(-12, o.a);
-    // 'b' setter is overriden to write 12 to field 'c'.
+    // 'b' setter is overridden to write 12 to field 'c'.
     o.b = o;
     Expect.equals(12, o.c);
   }


### PR DESCRIPTION
In reference to this issue: https://github.com/dart-lang/sdk/issues/27851

I am not sure about the fix on _overridenTypes. I'll dive in to be more familiar to the codebase.