### PR TITLE
Update generic methods docs to use the new syntax.

### DIFF
--- a/pkg/dev_compiler/doc/GENERIC_METHODS.md
+++ b/pkg/dev_compiler/doc/GENERIC_METHODS.md
@@ -1,229 +1,164 @@
-# Prototype Syntax for Generic Methods
+# Using Generic Methods
 
-Generic methods are a [proposed addition to the Dart language](https://github.com/leafpetersen/dep-generic-methods/blob/master/proposal.md).
+Initially a [proposal][], generic methods are on their way to being fully
+supported in Dart. Here is how to use them.
 
-This is a summary of the current (as of January 2016) comment-based generic
-method syntax supported by the analyzer strong mode and the Dart Dev Compiler.
-The comment-based syntax essentially uses the proposed actual generic method
-syntax, but wraps it in comments.  This allows developers to experiment with
-generic methods while still ensuring that their code runs on all platforms while
-generic methods are still being evaluated for inclusion into the language.
+[proposal]: https://github.com/leafpetersen/dep-generic-methods/blob/master/proposal.md
 
-## Declaring generic method parameters
+When they were still being prototyped, and [older comment-based syntax was
+designed][old] so that the static analysis could be implemented and tested
+before the VM and compilers needed to worry about the syntax. Now that real
+syntax is allowed everywhere, this doc has been updated.
 
-Generic method parameters are listed using a block comment after the method or
-function name, inside of angle brackets.
+[old]: GENERIC_METHOD_COMMENTS.md
+
+## Declaring generic methods
+
+Type parameters for generic methods are listed after the method or function
+name, inside angle brackets:
 
 ```dart
-// This declares a function which takes two unused generic method parameters
-int f/*<S, T>*/(int x) => 3;
+/// Takes two type parameters, [K] and [V].
+Map<K, V> singletonMap<K, V>(K key, V value) {
+  return <K, V>{ key, value };
+}
 ```
 
-As with classes, you can put bounds on type parameters.
+As with classes, you can put bounds on type parameters:
 
 ```dart
-// This declares a function which takes two unused generic method parameters
-// The first parameter (S) must extend num
-// The second parameter (T) must extend List<S>
-int f/*<S extends num, T extends List<S>>*/(int x) => 3;
+/// Takes a list of two numbers of some num-derived type [T].
+T sumPair<T extends num>(List<T> items) {
+  return items[0] + items[1];
+}
 ```
 
 Class methods (instance and static) can be declared to take generic parameters
-in the same way.
+in the same way:
 
 ```dart
 class C {
-  static int f/*<S, T>*/(int x) => 3;
-  int m/*<S, T>*/(int x) => 3;
+  static int f<S, T>(int x) => 3;
+  int m<S, T>(int x) => 3;
 }
 ```
 
-Function typed parameters, local functions, and function expressions can also be
-declared to take generic parameters.
+This even works for function-typed parameters, local functions, and function
+expressions:
 
 ```dart
-// foo takes a generic method as a parameter
-void foo(int f/*<S>*/(int x)) {}
+/// Takes a generic method as a parameter [callback].
+void functionTypedParameter(T callback<T>(T thing)) {}
 
-// foo declares a local generic function
-void foo() {
-  int f/*<S>*/(int x) => 3;
-  return;
+// Declares a local generic function `itself`.
+void localFunction() {
+  T itself<T>(T thing) => thing;
 }
 
-// foo binds a generic function expression to a local variable.
-void foo() {
-  var x = /*<S>*/(int x) => x;
+// Binds a generic function expression to a local variable.
+void functionExpression() {
+  var lambda = <T>(T thing) => thing;
 }
 ```
 
-We do not currently support a way to declare a function as returning a generic
-function.  This will eventually be supported using something analogous to Dart
-typedefs.
+We do not currently support a way to declare a function as *returning* a generic
+function. This will eventually be supported using a `typedef`.
 
-## Using generic method parameters
+## Using generic method type parameters
 
-The previous examples declared generic method parameters, but did not use them.
-You can use a generic method parameter `T` anywhere that a type is expected in
-Dart by writing a type followed by `/*=T*/`.  So for example, `dynamic /*=T*/`
-will be interpreted as `dynamic` by all non-strong mode tools, but will be
-interpreted as `T` by strong mode.  In places where it is valid to leave off a
-type, simply writing `/*=T*/` will be interpreted as `dynamic` by non-strong
-mode tools, but will be interpreted as `T` by strong mode.  For example:
+You've seen some examples already, but you can use a generic type parameter
+anywhere you would expect in a generic method.
+
+* Inside the method's parameter list:
+
+    ```dart
+    takeThing<T>(T thing) { ... }
+    //           ^-- here
+    ```
+
+* Inside type annotations in the body of the method:
+
+    ```dart
+    useThing<T>() {
+      T thing = getThing();
+    //^-- here
+      List<T> pair = [thing, thing];
+      //   ^-- and here
+    }
+    ```
+
+* In the return type of the method:
+
+    ```dart
+      T itself<T>(T thing) => thing;
+    //^-- here
+    ```
+
+* As type arguments in generic classes and method calls:
+
+    ```dart
+    useThing<T>(T thing) {
+      var pair = <T>[thing, thing];
+      //          ^-- here
+      var set = new Set<T>()..add(thing);
+      //                ^-- here
+    }
+    ```
+
+    Note that generic methods are not yet supported *at runtime* on the VM and
+    dartjs. On those platforms, uses of generic method type arguments are
+    treated like `dynamic` today. So in this example, `pair`'s reified type at
+    runtime will be `List<dynamic>` and `set` will be `Set<dynamic>`.
+
+* As a type literal:
+
+    ```dart
+    printType<T>() {
+      Type t = T;
+      //       ^-- here
+      print(t);
+    }
+    ```
+
+    Again, note that on the VM and dart2js, this will currently print "dynamic".
+
+## Calling generic methods
+
+Most of the time, when you call a generic method, you can leave off the type
+arguments and strong mode's type inference will fill them in for you
+automatically. For example:
 
 ```dart
-// foo is a generic method which takes a single generic method parameter S.
-// In strong mode, the parameter x will have type S, and the return type will
-// be S
-// In normal mode, the parameter x will have type dynamic, and the return
-// type will be dynamic.
-dynamic/*=S*/ foo/*<S>*/(dynamic/*=S*/ x) { return x; }
+var fruits = ["apple", "banana", "cherry"];
+var lengths = fruits.map((fruit) => fruit.length);
 ```
 
-This can be written more concisely by leaving off the `dynamic`.
+`Iterable.map<S>(S transform(T` is now a generic method that takes a type
+parameter for the element type of the returned sequence:
 
 ```dart
-/*=S*/ foo/*<S>*/(/*=S*/ x) {return x;}
+Iterable.map<S>(S transform(T element))
 ```
 
-You can also put a type to the left of the `/*=T/`. This type will be used
-for all non-strong mode tools. For example:
+In this example, the type checker:
+
+1. Infers `List<String>` for the type of `fruits` based on the elements in the
+   list literal.
+2. That lets it infer `String` for the type of the lambda parameter `fruit`
+   passed to `map`.
+3. Then, from the result of calling `.length`, it infers the return type of the
+   lambda to be `int`.
+4. That in turn is used to fill in the type argument to the call to `map` as
+   `int`, and the resulting sequence is an `Iterable<int>`.
+
+If inference *isn't* able to fill in a type argument for you, it uses `dynamic`
+instead. If that isn't what you want, or it infers a type you don't want, you
+can always pass them explicitly:
 
 ```dart
-// This method works with `int`, `double`, or `num`. The return type will
-// match the type of the parameters.
-num/*=T*/ pickAtRandom/*<T extends num>*/(num/*=T*/ x, num/*=T*/ y) { ... }
-```
+// Explicitly give a type so that we don't infer "int".
+var lengths = fruits.map<num>((fruit) => fruit.length).toList();
 
-
-Note that the generic parameter is in scope in the return type of the function,
-in the argument list of the function, and in the body of the function.  When
-declaring local variables and parameters, you can also use the `/*=T*/` syntax with `var`.
-
-```dart
-// foo is a generic method that takes a single generic parameter S, and a value
-// x of type S
-void foo/*<S>*/(var /*=S*/ x) {
-  // In strong mode, y will also have type S
-  var /*=S*/ y = x;
-
-  // In strong mode, z will also have type S
-  dynamic /*=S*/ z = y;
-}
-```
-
-Anywhere that a type literal is expected, you can also use the `/*=T*/` syntax to
-produce a type literal from the generic method parameter.
-
-```dart
-void foo/*<S>*/(/*=S*/ x) {
-  // In strong mode, s will get the type literal for S
-  Type s = dynamic /*=S*/;
-
-  // In strong mode, this attempts to cast 3 as type S
-  var y = (3 as dynamic /*=S*/);
-}
-```
-
-You can use the `/*=T*/` syntax to replace any type with a generic type
-parameter, but you will usually want to replace `dynamic`. Otherwise, since the
-original type is used at runtime, it may cause checked mode errors:
-
-```dart
-List/*<T>*/ makeList/*<T extends num>*/() {
-  return new List<num /*=T*/>();
-}
-
-void main() {
-  List<int> list = makeList/*<int>*/(); // <-- Fails here.
-}
-```
-
-This program checks without error in strong mode but fails at runtime in checked
-mode since the list that gets created is a `List<num>`. A better choice is:
-
-```dart
-List/*<T>*/ makeList/*<T extends num>*/() {
-  return new List/*<T>*/();
-}
-
-void main() {
-  List<int> list = makeList/*<int>*/();
-}
-```
-
-## Instantiating generic classes with generic method parameters
-
-You can use generic method parameters to instantiate generic classes using the
-same `/*=T*/` syntax.
-
-```dart
-// foo is a generic method which returns a List<S> in strong mode,
-// but which returns List<dynamic> in normal mode.
-List<dynamic /*=S*/> foo/*<S>*/(/*=S*/ x) {
-   // l0 is a list literal whose reified type will be List<S> in strong mode,
-   // and List<dynamic> in normal mode.
-   var l0 = <dynamic /*=S*/>[x];
-
-   // as above, but with a regular constructor.
-   var l1 = new List<dynamic /*=S*/>();
-   return l1;
-}
-```
-
-In most cases, the entire type argument list to the generic class can be
-enclosed in parentheses, eliminating the need for explicitly writing `dynamic`.
-
-```dart
-// This is another way of writing the same code as above
-List/*<S>*/ foo/*<S>*/(/*=S*/ x) {
-   // The shorthand syntax is not yet supported for list and map literals
-   var l0 = <dynamic /*=S*/>[x];
-
-   // but with regular constructors you can use it
-   var l1 = new List/*<S>*/();
-   return l1;
-}
-```
-
-## Instantiating generic methods
-
-Generic methods can be called without passing type arguments.  Strong mode will
-attempt to infer the type arguments automatically.  If it is unable to do so,
-then the type arguments will be filled in with whatever their declared bounds
-are (by default, `dynamic`).
-
-```dart
-class C {
-  /*=S*/ inferableFromArgument/*<S>*/(/*=S*/ x) { return null;}
-  /*=S*/ notInferable/*<S>*/(int x) { return null;}
-}
-
-void main() {
-  C c = new C();
-  // This line will produce a type error, because strong mode will infer
-  // `int` as the generic argument to fill in for S
-  String x = c.inferableFromArgument(3);
-
-  // This line will not produce a type error, because strong mode is unable
-  // to infer a type and will fill in the type argument with `dynamic`.
-  String y = c.notInferable(3);
-}
-```
-
-In the case that strong mode cannot infer the generic type arguments, the same
-syntax that was shown above for instantiating generic classes can be used to
-instantiate generic methods explicitly.
-
-```dart
-void main() {
-  C c = new C();
-  // This line will produce a type error, because strong mode will infer
-  // `int` as the generic argument to fill in for S
-  String x = c.inferableFromArgument(3);
-
-  // This line will produce a type error in strong mode, because `int` is
-  // explicitly passed in as the argument to use for S
-  String y = c.notInferable/*<int>*/(3);
-}
+// So that we can later add doubles to the result.
+lengths.add(1.2);
 ```

--- a/pkg/dev_compiler/doc/GENERIC_METHODS.md
+++ b/pkg/dev_compiler/doc/GENERIC_METHODS.md
@@ -5,7 +5,7 @@ supported in Dart. Here is how to use them.
 
 [proposal]: https://github.com/leafpetersen/dep-generic-methods/blob/master/proposal.md
 
-When they were still being prototyped, and [older comment-based syntax was
+When they were still being prototyped, an [older comment-based syntax was
 designed][old] so that the static analysis could be implemented and tested
 before the VM and compilers needed to worry about the syntax. Now that real
 syntax is allowed everywhere, this doc has been updated.
@@ -67,13 +67,13 @@ function. This will eventually be supported using a `typedef`.
 ## Using generic method type parameters
 
 You've seen some examples already, but you can use a generic type parameter
-anywhere you would expect in a generic method.
+almost anywhere you would expect in a generic method.
 
 * Inside the method's parameter list:
 
     ```dart
     takeThing<T>(T thing) { ... }
-    //           ^-- here
+    //           ^-- Here.
     ```
 
 * Inside type annotations in the body of the method:
@@ -81,9 +81,9 @@ anywhere you would expect in a generic method.
     ```dart
     useThing<T>() {
       T thing = getThing();
-    //^-- here
+    //^-- Here.
       List<T> pair = [thing, thing];
-      //   ^-- and here
+      //   ^-- And here.
     }
     ```
 
@@ -91,7 +91,7 @@ anywhere you would expect in a generic method.
 
     ```dart
       T itself<T>(T thing) => thing;
-    //^-- here
+    //^-- Here.
     ```
 
 * As type arguments in generic classes and method calls:
@@ -99,9 +99,9 @@ anywhere you would expect in a generic method.
     ```dart
     useThing<T>(T thing) {
       var pair = <T>[thing, thing];
-      //          ^-- here
+      //          ^-- Here.
       var set = new Set<T>()..add(thing);
-      //                ^-- here
+      //                ^-- And here.
     }
     ```
 
@@ -115,12 +115,24 @@ anywhere you would expect in a generic method.
     ```dart
     printType<T>() {
       Type t = T;
-      //       ^-- here
+      //       ^-- Here.
       print(t);
     }
     ```
 
     Again, note that on the VM and dart2js, this will currently print "dynamic".
+
+The one place you cannot currently use a generic method type parameter is in an
+`is` expression. Since the VM and dart2js don't reify generic method type
+arguments yet, those expressions wouldn't do what you want. Instead, this is
+currently an error:
+
+```dart
+testType<T>(object) {
+  print(object is T);
+  //              ^-- Error!
+}
+```
 
 ## Calling generic methods
 
@@ -133,11 +145,15 @@ var fruits = ["apple", "banana", "cherry"];
 var lengths = fruits.map((fruit) => fruit.length);
 ```
 
-`Iterable.map<S>(S transform(T` is now a generic method that takes a type
-parameter for the element type of the returned sequence:
+The `map()` method on Iterable is now generic and takes a type parameter for the
+element type of the returned sequence:
 
 ```dart
-Iterable.map<S>(S transform(T element))
+class Iterable<T> {
+  Iterable<S> map<S>(S transform(T element)) { ... }
+
+  // Other stuff...
+}
 ```
 
 In this example, the type checker:
@@ -145,10 +161,10 @@ In this example, the type checker:
 1. Infers `List<String>` for the type of `fruits` based on the elements in the
    list literal.
 2. That lets it infer `String` for the type of the lambda parameter `fruit`
-   passed to `map`.
+   passed to `map()`.
 3. Then, from the result of calling `.length`, it infers the return type of the
    lambda to be `int`.
-4. That in turn is used to fill in the type argument to the call to `map` as
+4. That in turn is used to fill in the type argument to the call to `map()` as
    `int`, and the resulting sequence is an `Iterable<int>`.
 
 If inference *isn't* able to fill in a type argument for you, it uses `dynamic`

--- a/pkg/dev_compiler/doc/GENERIC_METHOD_COMMENTS.md
+++ b/pkg/dev_compiler/doc/GENERIC_METHOD_COMMENTS.md
@@ -1,0 +1,237 @@
+# Prototype Syntax for Generic Methods
+
+**Note:** This documents the deprecated comment-based syntax for generic
+methods. New code should use the [much better real syntax][real]. This document
+is preserved in case you run into existing code still using the old syntax.
+
+[real]: GENERIC_METHODS.md
+
+---
+
+Generic methods are a [proposed addition to the Dart language](https://github.com/leafpetersen/dep-generic-methods/blob/master/proposal.md).
+
+This is a summary of the current (as of January 2016) comment-based generic
+method syntax supported by the analyzer strong mode and the Dart Dev Compiler.
+The comment-based syntax essentially uses the proposed actual generic method
+syntax, but wraps it in comments.  This allows developers to experiment with
+generic methods while still ensuring that their code runs on all platforms while
+generic methods are still being evaluated for inclusion into the language.
+
+## Declaring generic method parameters
+
+Generic method parameters are listed using a block comment after the method or
+function name, inside of angle brackets.
+
+```dart
+// This declares a function which takes two unused generic method parameters
+int f/*<S, T>*/(int x) => 3;
+```
+
+As with classes, you can put bounds on type parameters.
+
+```dart
+// This declares a function which takes two unused generic method parameters
+// The first parameter (S) must extend num
+// The second parameter (T) must extend List<S>
+int f/*<S extends num, T extends List<S>>*/(int x) => 3;
+```
+
+Class methods (instance and static) can be declared to take generic parameters
+in the same way.
+
+```dart
+class C {
+  static int f/*<S, T>*/(int x) => 3;
+  int m/*<S, T>*/(int x) => 3;
+}
+```
+
+Function typed parameters, local functions, and function expressions can also be
+declared to take generic parameters.
+
+```dart
+// foo takes a generic method as a parameter
+void foo(int f/*<S>*/(int x)) {}
+
+// foo declares a local generic function
+void foo() {
+  int f/*<S>*/(int x) => 3;
+  return;
+}
+
+// foo binds a generic function expression to a local variable.
+void foo() {
+  var x = /*<S>*/(int x) => x;
+}
+```
+
+We do not currently support a way to declare a function as returning a generic
+function.  This will eventually be supported using something analogous to Dart
+typedefs.
+
+## Using generic method parameters
+
+The previous examples declared generic method parameters, but did not use them.
+You can use a generic method parameter `T` anywhere that a type is expected in
+Dart by writing a type followed by `/*=T*/`.  So for example, `dynamic /*=T*/`
+will be interpreted as `dynamic` by all non-strong mode tools, but will be
+interpreted as `T` by strong mode.  In places where it is valid to leave off a
+type, simply writing `/*=T*/` will be interpreted as `dynamic` by non-strong
+mode tools, but will be interpreted as `T` by strong mode.  For example:
+
+```dart
+// foo is a generic method which takes a single generic method parameter S.
+// In strong mode, the parameter x will have type S, and the return type will
+// be S
+// In normal mode, the parameter x will have type dynamic, and the return
+// type will be dynamic.
+dynamic/*=S*/ foo/*<S>*/(dynamic/*=S*/ x) { return x; }
+```
+
+This can be written more concisely by leaving off the `dynamic`.
+
+```dart
+/*=S*/ foo/*<S>*/(/*=S*/ x) {return x;}
+```
+
+You can also put a type to the left of the `/*=T/`. This type will be used
+for all non-strong mode tools. For example:
+
+```dart
+// This method works with `int`, `double`, or `num`. The return type will
+// match the type of the parameters.
+num/*=T*/ pickAtRandom/*<T extends num>*/(num/*=T*/ x, num/*=T*/ y) { ... }
+```
+
+
+Note that the generic parameter is in scope in the return type of the function,
+in the argument list of the function, and in the body of the function.  When
+declaring local variables and parameters, you can also use the `/*=T*/` syntax with `var`.
+
+```dart
+// foo is a generic method that takes a single generic parameter S, and a value
+// x of type S
+void foo/*<S>*/(var /*=S*/ x) {
+  // In strong mode, y will also have type S
+  var /*=S*/ y = x;
+
+  // In strong mode, z will also have type S
+  dynamic /*=S*/ z = y;
+}
+```
+
+Anywhere that a type literal is expected, you can also use the `/*=T*/` syntax to
+produce a type literal from the generic method parameter.
+
+```dart
+void foo/*<S>*/(/*=S*/ x) {
+  // In strong mode, s will get the type literal for S
+  Type s = dynamic /*=S*/;
+
+  // In strong mode, this attempts to cast 3 as type S
+  var y = (3 as dynamic /*=S*/);
+}
+```
+
+You can use the `/*=T*/` syntax to replace any type with a generic type
+parameter, but you will usually want to replace `dynamic`. Otherwise, since the
+original type is used at runtime, it may cause checked mode errors:
+
+```dart
+List/*<T>*/ makeList/*<T extends num>*/() {
+  return new List<num /*=T*/>();
+}
+
+void main() {
+  List<int> list = makeList/*<int>*/(); // <-- Fails here.
+}
+```
+
+This program checks without error in strong mode but fails at runtime in checked
+mode since the list that gets created is a `List<num>`. A better choice is:
+
+```dart
+List/*<T>*/ makeList/*<T extends num>*/() {
+  return new List/*<T>*/();
+}
+
+void main() {
+  List<int> list = makeList/*<int>*/();
+}
+```
+
+## Instantiating generic classes with generic method parameters
+
+You can use generic method parameters to instantiate generic classes using the
+same `/*=T*/` syntax.
+
+```dart
+// foo is a generic method which returns a List<S> in strong mode,
+// but which returns List<dynamic> in normal mode.
+List<dynamic /*=S*/> foo/*<S>*/(/*=S*/ x) {
+   // l0 is a list literal whose reified type will be List<S> in strong mode,
+   // and List<dynamic> in normal mode.
+   var l0 = <dynamic /*=S*/>[x];
+
+   // as above, but with a regular constructor.
+   var l1 = new List<dynamic /*=S*/>();
+   return l1;
+}
+```
+
+In most cases, the entire type argument list to the generic class can be
+enclosed in parentheses, eliminating the need for explicitly writing `dynamic`.
+
+```dart
+// This is another way of writing the same code as above
+List/*<S>*/ foo/*<S>*/(/*=S*/ x) {
+   // The shorthand syntax is not yet supported for list and map literals
+   var l0 = <dynamic /*=S*/>[x];
+
+   // but with regular constructors you can use it
+   var l1 = new List/*<S>*/();
+   return l1;
+}
+```
+
+## Instantiating generic methods
+
+Generic methods can be called without passing type arguments.  Strong mode will
+attempt to infer the type arguments automatically.  If it is unable to do so,
+then the type arguments will be filled in with whatever their declared bounds
+are (by default, `dynamic`).
+
+```dart
+class C {
+  /*=S*/ inferableFromArgument/*<S>*/(/*=S*/ x) { return null;}
+  /*=S*/ notInferable/*<S>*/(int x) { return null;}
+}
+
+void main() {
+  C c = new C();
+  // This line will produce a type error, because strong mode will infer
+  // `int` as the generic argument to fill in for S
+  String x = c.inferableFromArgument(3);
+
+  // This line will not produce a type error, because strong mode is unable
+  // to infer a type and will fill in the type argument with `dynamic`.
+  String y = c.notInferable(3);
+}
+```
+
+In the case that strong mode cannot infer the generic type arguments, the same
+syntax that was shown above for instantiating generic classes can be used to
+instantiate generic methods explicitly.
+
+```dart
+void main() {
+  C c = new C();
+  // This line will produce a type error, because strong mode will infer
+  // `int` as the generic argument to fill in for S
+  String x = c.inferableFromArgument(3);
+
+  // This line will produce a type error in strong mode, because `int` is
+  // explicitly passed in as the argument to use for S
+  String y = c.notInferable/*<int>*/(3);
+}
+```


### PR DESCRIPTION
- Move the old doc to a separate file and link to it.
- Update the new doc to use the new syntax.

I also took the liberty of trying to make it a little shorter and use
more concrete examples. I hope I still cover the same bases. If not,
let me know what I missed.