### PR TITLE
Add missing cli_util pub dependency to analyzer

### DIFF
--- a/pkg/analyzer/pubspec.yaml
+++ b/pkg/analyzer/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
   plugin: ^0.2.0
   watcher: '>=0.9.6 <0.10.0'
   yaml: ^2.1.2
+  cli_util: ^0.0.1
 dev_dependencies:
   test_reflective_loader: ^0.1.0
   typed_mock: '>=0.0.4 <1.0.0'


### PR DESCRIPTION
Found this while working on the angular analyzer.

Not sure if somebody already caught this and its working its way out to master, but its breaking my angular-analyzer build.