### PR TITLE
tools/create_pkg_manifest.py: Sort manifest entries for reproducibility

### DIFF
--- a/tools/create_pkg_manifest.py
+++ b/tools/create_pkg_manifest.py
@@ -70,7 +70,7 @@ def WriteManifest(deps, manifest_file):
     manifest.write('<?xml version="1.0" encoding="UTF-8"?>\n')
     manifest.write('<manifest>\n')
     manifest.write('  <projects>\n')
-    for path, remote in deps.iteritems():
+    for path, remote in sorted(deps.iteritems()):
       remote_components = remote.split('@')
       remote_url = remote_components[0]
       remote_version = remote_components[1]


### PR DESCRIPTION
tools/create_pkg_manifest.py currently outputs manifest entries in hash
order, which results in spurious reordering on updates, making it harder
to see the actual changes.  Sort the manifest entries, to make the
output reproducible.

This will result in a large diff for the next manifest update, but every
subsequent update should have a minimal diff showing only the actual
changes, with no spurious reordering.