### PR TITLE
added Range.toString() to dart:html

### DIFF
--- a/sdk/lib/html/dart2js/html_dart2js.dart
+++ b/sdk/lib/html/dart2js/html_dart2js.dart
@@ -27863,6 +27863,10 @@ class Range extends Interceptor {
   @DocsEditable()
   void surroundContents(Node newParent) native;
 
+  @DomName('Range.toString')
+  @DocsEditable()
+  String toString() native;
+
 
   /**
    * Checks if createContextualFragment is supported.

--- a/tools/dom/templates/html/impl/impl_Range.darttemplate
+++ b/tools/dom/templates/html/impl/impl_Range.darttemplate
@@ -13,6 +13,12 @@ $(ANNOTATIONS)$(NATIVESPEC)$(CLASS_MODIFIERS)class $CLASSNAME$EXTENDS$IMPLEMENTS
       document._caretRangeFromPoint(point.x, point.y);
 $!MEMBERS
 
+$if DART2JS
+  @DomName('Range.toString')
+  @DocsEditable()
+  String toString() native;
+$endif
+
   /**
    * Checks if createContextualFragment is supported.
    *


### PR DESCRIPTION
Added missing `toString()` method to Range.

https://developer.mozilla.org/en-US/docs/Web/API/Range/toString