### PR TITLE
StreamIterator docs update with pause/resume behavior

### DIFF
--- a/sdk/lib/async/stream.dart
+++ b/sdk/lib/async/stream.dart
@@ -1761,6 +1761,8 @@ abstract class StreamTransformer<S, T> {
  * This wraps a [Stream] and a subscription on the stream. It listens
  * on the stream, and completes the future returned by [moveNext] when the
  * next value becomes available.
+ *
+ * Pauses the stream between calls to [moveNext].
  */
 abstract class StreamIterator<T> {
 
@@ -1776,10 +1778,13 @@ abstract class StreamIterator<T> {
    * Returns a future which will complete with either `true` or `false`.
    * Completing with `true` means that another event has been received and
    * can be read as [current].
-   * Completing with `false` means that the stream itearation is done and
+   * Completing with `false` means that the stream iteration is done and
    * no further events will ever be available.
    * The future may complete with an error, if the stream produces an error,
    * which also ends iteration.
+   *
+   * The stream is paused when the future completes with `true` and
+   * resumed on the next call to `moveNext`.
    *
    * The function must not be called again until the future returned by a
    * previous call is completed.

--- a/sdk/lib/async/stream.dart
+++ b/sdk/lib/async/stream.dart
@@ -1762,7 +1762,7 @@ abstract class StreamTransformer<S, T> {
  * on the stream, and completes the future returned by [moveNext] when the
  * next value becomes available.
  *
- * Pauses the stream between calls to [moveNext].
+ * The stream may be paused between calls to [moveNext].
  */
 abstract class StreamIterator<T> {
 
@@ -1782,9 +1782,6 @@ abstract class StreamIterator<T> {
    * no further events will ever be available.
    * The future may complete with an error, if the stream produces an error,
    * which also ends iteration.
-   *
-   * The stream is paused when the future completes with `true` and
-   * resumed on the next call to `moveNext`.
    *
    * The function must not be called again until the future returned by a
    * previous call is completed.


### PR DESCRIPTION
Hi team!

I just discovered `StreamIterator` class in the SDK and it turned out to be perfect for my use case, so thanks again for awesome work!

I wasn't sure how it behaves in between calls to `moveNext()` though, so I had to go and look how it's implemented in `_StreamIteratorImpl`.

I thought docs can do a better jobs with that so I added a few words in this PR.