### PR TITLE
[Gardening] Mark a Dartium co19 test flaky.

### DIFF
--- a/tests/co19/co19-dartium.status
+++ b/tests/co19/co19-dartium.status
@@ -543,6 +543,7 @@ LayoutTests/fast/forms/formmethod-attribute-input-2_t01: Skip # Test reloads its
 LayoutTests/fast/forms/formmethod-attribute-input-html_t01: Pass, RuntimeError # co19-roll r801: Please triage this failure.
 LayoutTests/fast/forms/formmethod-attribute-input-html_t01: Skip # Test reloads itself. Issue 18558.
 LayoutTests/fast/forms/HTMLOptionElement_selected2_t01: Skip # Times out. co19-roll r801: Please triage this failure.
+LayoutTests/fast/forms/input-appearance-elementFromPoint_t01: Pass, RuntimeError # Issue 28710
 LayoutTests/fast/forms/input-hit-test-border_t01: Pass, RuntimeError # co19-roll r801: Please triage this failure.
 LayoutTests/fast/forms/input-inputmode_t01: RuntimeError # Experimental feature not exposed in Chrome yet
 LayoutTests/fast/forms/input-value-sanitization_t01: RuntimeError # 45 roll issue


### PR DESCRIPTION
co19/LayoutTests/fast/forms/input-appearance-elementFromPoint_t01 is
flaking on Dartium.

See #28710