### PR TITLE
[Gardening] Mark a test as flaky on Dart2js.

### DIFF
--- a/tests/corelib/corelib.status
+++ b/tests/corelib/corelib.status
@@ -57,6 +57,7 @@ double_parse_test/01: Pass, Fail # JS implementations disagree on U+0085 being w
 integer_to_radix_string_test: RuntimeError # issue 22045
 int_modulo_arith_test/bignum: RuntimeError # No bigints.
 int_modulo_arith_test/modPow: RuntimeError # No bigints.
+list_unmodifiable_test: Pass, RuntimeError # Issue 28712
 
 [ $compiler == dart2js && $fast_startup ]
 apply3_test: Fail # mirrors not supported


### PR DESCRIPTION
corelib/list_unmodifiable_test fails flakily on dart2js.

See #28712