### PR TITLE
[Gardening] Mark a test as flaky on SIMDBC.

### DIFF
--- a/tests/standalone/standalone.status
+++ b/tests/standalone/standalone.status
@@ -350,6 +350,8 @@ link_natives_lazily_test: SkipByDesign
 # SIMDBC interpreter doesn't support --no_lazy_dispatchers
 no_lazy_dispatchers_test: SkipByDesign
 
+io/secure_unauthorized_test: Pass, RuntimeError # Issue 28719
+
 [ $system == android ]
 # Issue 26376
 io/platform_resolved_executable_test: RuntimeError


### PR DESCRIPTION
standalone/io/secure_unauthorized_test flakily failed.

See #28719