### PR TITLE
Remove mojo shell download from dartium DEPS

### DIFF
--- a/tools/deps/dartium.deps/DEPS.chromium
+++ b/tools/deps/dartium.deps/DEPS.chromium
@@ -623,17 +623,6 @@ hooks = [
   {
     'action': [
       'python',
-      'src/third_party/mojo/src/mojo/public/tools/download_shell_binary.py',
-      '--tools-directory=../../../../../../tools'
-    ],
-    'pattern':
-      '',
-    'name':
-      'download_mojo_shell'
-  },
-  {
-    'action': [
-      'python',
       'src/third_party/instrumented_libraries/scripts/download_binaries.py'
     ],
     'pattern':


### PR DESCRIPTION
This is failing on the buildbots.
Creating a temporary branch with the change, to try it on the buildbot.
Do not merge this pull request.