### PR TITLE
Mark io/standalone/named_pipe_script_test flaky.

### DIFF
--- a/tests/standalone/standalone.status
+++ b/tests/standalone/standalone.status
@@ -312,6 +312,9 @@ io/directory_list_sync_test: Timeout, Skip # Expects to find the test directory 
 io/http_server_close_response_after_error_test: Pass, Timeout # Issue 28370: timeout.
 io/regress_7191_test: Pass, Timeout # Issue 28374: timeout.
 
+[ $runtime == vm && $system == macos && $mode == release ]
+io/standalone/named_pipe_script_test: Pass, RuntimeError # Issue 28737
+
 [ $runtime == vm && $system == linux && $mode == release && $arch == ia32 && $builder_tag == asan ]
 io/socket_close_test: Pass, Timeout # Issue 28502: timeout.
 


### PR DESCRIPTION
See #28737