### PR TITLE
Mark an IO test as flaky on simmips.

### DIFF
--- a/tests/standalone/standalone.status
+++ b/tests/standalone/standalone.status
@@ -168,6 +168,7 @@ oom_error_stacktrace_test: Skip # Fails on Linux
 
 [ $arch == simmips ]
 io/socket_bind_test: Pass, Fail # Issue 28315
+io/http_server_response_test: Pass, Crash # Issue 29012
 
 [ ($arch == simarm || $arch == simdbc || $arch == simdbc64) && $mode == debug && $checked ]
 io/web_socket_test: Pass, Fail # Issue 26814


### PR DESCRIPTION
See #29012