### PR TITLE
Mark an analyzer test as slow on Windows.

### DIFF
--- a/pkg/pkg.status
+++ b/pkg/pkg.status
@@ -211,3 +211,4 @@ kernel/test/closures_test: Fail
 
 [ $runtime == vm && $system == windows ]
 analyzer_cli/test/driver_test: Pass, Slow
+analyzer/test/src/task/strong/checker_test: Pass, Slow


### PR DESCRIPTION
analyzer/test/src/task/strong/checker_test was timing out in the log
linked below, and among the slower tests in other logs.

https://build.chromium.org/p/client.dart/builders/pkg-win7-release-be/builds/2933/steps/package%20unit%20tests/logs/stdio