### PR TITLE
Mark an analyzer test as slow on Windows.

### DIFF
--- a/pkg/pkg.status
+++ b/pkg/pkg.status
@@ -196,6 +196,7 @@ kernel/test/*: SkipByDesign # Uses dart:io and bigints.
 
 [ $runtime == vm ]
 analyzer/test/file_system/physical_resource_provider_test: Pass, Fail # Issue 25472
+analyzer/test/src/task/strong/inferred_type_test: Pass, Slow
 # Skip tests on the VM if the package depends on dart:html
 mutation_observer: Skip
 


### PR DESCRIPTION
analyzer/test/src/task/strong/inferred_type_test was timing out in the
log linked below, and among the slower tests in other logs.

https://build.chromium.org/p/client.dart/builders/pkg-mac10.11-release-be/builds/3308/steps/package%20unit%20tests/logs/stdio