### PR TITLE
Mark a dart2js test flaky on Linux.

### DIFF
--- a/tests/compiler/dart2js/dart2js.status
+++ b/tests/compiler/dart2js/dart2js.status
@@ -99,3 +99,6 @@ analyze_dart2js_test: Pass, Slow # DON'T CHANGE THIS LINE -- SEE ABOVE.
 
 [ $jscl || $runtime == drt || $runtime == dartium || $runtime == ff || $runtime == firefox || $runtime == chrome || $runtime == safari || $runtime == opera ]
 *: Skip # dart2js uses #import('dart:io'); and it is not self-hosted (yet).
+
+[ $system == linux ]
+dart2js_batch2_test: Pass, RuntimeError # Issue 29021


### PR DESCRIPTION
See #29021