### PR TITLE
Analyzer 0.29 strong mode fixes

### DIFF
--- a/pkg/analyzer/CHANGELOG.md
+++ b/pkg/analyzer/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.29.9
+
+* Strong mode fixes so all of analyzer can be compiled with dartdevc.
+
 ## 0.29.8
 
 * Add toSource() to ElementAnnotation.

--- a/pkg/analyzer/lib/src/generated/java_core.dart
+++ b/pkg/analyzer/lib/src/generated/java_core.dart
@@ -126,7 +126,7 @@ class Character {
 }
 
 @deprecated
-abstract class Enum<E extends Enum> implements Comparable<E> {
+abstract class Enum<E extends Enum<E>> implements Comparable<E> {
   /// The name of this enum constant, as declared in the enum declaration.
   final String name;
 

--- a/pkg/analyzer/lib/src/util/fast_uri.dart
+++ b/pkg/analyzer/lib/src/util/fast_uri.dart
@@ -87,7 +87,9 @@ class FastUri implements Uri {
 
   @override
   bool isScheme(String scheme) {
-    if (scheme == null || scheme.isEmpty) return !hasScheme;
+    if (scheme == null || scheme.isEmpty) {
+      return !hasScheme;
+    }
     return scheme.toLowerCase() == this.scheme.toLowerCase();
   }
 

--- a/pkg/analyzer/lib/src/util/fast_uri.dart
+++ b/pkg/analyzer/lib/src/util/fast_uri.dart
@@ -87,7 +87,7 @@ class FastUri implements Uri {
 
   @override
   bool isScheme(String scheme) {
-    if (scheme == null || scheme.isEmpty) return hasScheme;
+    if (scheme == null || scheme.isEmpty) return !hasScheme;
     return scheme.toLowerCase() == this.scheme.toLowerCase();
   }
 

--- a/pkg/analyzer/lib/src/util/fast_uri.dart
+++ b/pkg/analyzer/lib/src/util/fast_uri.dart
@@ -86,6 +86,12 @@ class FastUri implements Uri {
   bool get isAbsolute => hasScheme;
 
   @override
+  bool isScheme(String scheme) {
+    if (scheme == null || scheme.isEmpty) return hasScheme;
+    return scheme.toLowerCase() == this.scheme.toLowerCase();
+  }
+
+  @override
   String get origin => _fallbackUri.origin;
 
   @override

--- a/pkg/analyzer/pubspec.yaml
+++ b/pkg/analyzer/pubspec.yaml
@@ -1,5 +1,5 @@
 name: analyzer
-version: 0.29.8
+version: 0.29.9
 author: Dart Team <misc@dartlang.org>
 description: Static analyzer for Dart.
 homepage: https://github.com/dart-lang/sdk/tree/master/pkg/analyzer


### PR DESCRIPTION
Note that dartdevc does still have two errors:

```
[error] The named parameter 'growable' isn't defined. (package:analyzer/src/generated/static_type_analyzer.dart, line 728, col 58)
[error] The named parameter 'growable' isn't defined. (package:analyzer/src/generated/type_system.dart, line 1536, col 9)
```

However that looks like an issue with the ddc sdk summaries not the analyzer.

Fixes https://github.com/dart-lang/sdk/issues/29150