### PR TITLE
Account for alternate "SDK" layouts.

### DIFF
--- a/pkg/analysis_server/lib/src/plugin/plugin_watcher.dart
+++ b/pkg/analysis_server/lib/src/plugin/plugin_watcher.dart
@@ -124,7 +124,8 @@ class PluginWatcher implements DriverWatcher {
   String _getSdkPath(AnalysisDriver driver) {
     AbsolutePathContext context = resourceProvider.absolutePathContext;
     String sdkRoot = driver.sourceFactory.forUri('dart:core').fullName;
-    while (sdkRoot.isNotEmpty && context.basename(sdkRoot) != 'lib') {
+    while (sdkRoot.isNotEmpty && context.basename(sdkRoot) != 'lib' &&
+        context.basename(sdkRoot) != 'dart_sdk') {
       sdkRoot = context.dirname(sdkRoot);
     }
     return sdkRoot;


### PR DESCRIPTION
The sources for standard Dart libraries are coming via an embedder (Flutter) in Fuchsia, with a slightly different tree layout.