### PR TITLE
Wrong heap space data in Observatory

### DIFF
--- a/runtime/observatory/lib/src/elements/allocation_profile.dart
+++ b/runtime/observatory/lib/src/elements/allocation_profile.dart
@@ -226,7 +226,7 @@ class AllocationProfileElement extends HtmlElement implements Renderable {
               ..children = _isCompacted
                   ? [
                       new HeadingElement.h2()
-                        ..text = '(${_usedCaption(_profile.newSpace)}) '
+                        ..text = '(${_usedCaption(_profile.oldSpace)}) '
                             'Old Generation',
                     ]
                   : [


### PR DESCRIPTION
Fixed situation when compacted heap space contains a wrong data (new space instead of an old space)

![image](https://cloud.githubusercontent.com/assets/5549148/24806002/b451d15c-1bb3-11e7-82c1-f5ea61c05269.png)

-------------------------

![image](https://cloud.githubusercontent.com/assets/5549148/24806006/be4287b0-1bb3-11e7-8a64-b4ed91f73707.png)
