### PR TITLE
GN workspaces now use packages files.

### DIFF
--- a/pkg/analyzer/lib/src/generated/gn.dart
+++ b/pkg/analyzer/lib/src/generated/gn.dart
@@ -8,136 +8,15 @@ import 'dart:collection';
 import 'dart:core';
 
 import 'package:analyzer/file_system/file_system.dart';
+import 'package:analyzer/source/package_map_resolver.dart';
 import 'package:analyzer/src/generated/sdk.dart';
 import 'package:analyzer/src/generated/source.dart';
 import 'package:analyzer/src/generated/source_io.dart';
 import 'package:analyzer/src/generated/workspace.dart';
+import 'package:package_config/packages.dart';
+import 'package:package_config/packages_file.dart';
+import 'package:package_config/src/packages_impl.dart';
 import 'package:path/path.dart';
-
-/**
- * Similar to Map#putIfAbsent, except that a value is stored only if it is not
- * null.
- */
-V _putIfNotNull<K, V>(Map<K, V> map, K key, V ifAbsent()) {
-  if (map.containsKey(key)) {
-    return map[key];
-  }
-  V computed = ifAbsent();
-  if (computed != null) {
-    map[key] = computed;
-  }
-  return computed;
-}
-
-/**
- * The [UriResolver] used to resolve `file` URIs in a [GnWorkspace].
- */
-class GnFileUriResolver extends ResourceUriResolver {
-  /**
-   * The workspace associated with this resolver.
-   */
-  final GnWorkspace workspace;
-
-  /**
-   * Initialize a newly created resolver to be associated with the given
-   * [workspace].
-   */
-  GnFileUriResolver(GnWorkspace workspace)
-      : workspace = workspace,
-        super(workspace.provider);
-
-  @override
-  Source resolveAbsolute(Uri uri, [Uri actualUri]) {
-    if (!ResourceUriResolver.isFileUri(uri)) {
-      return null;
-    }
-    String path = provider.pathContext.fromUri(uri);
-    File file = workspace.findFile(path);
-    if (file != null) {
-      return file.createSource(actualUri ?? uri);
-    }
-    return null;
-  }
-}
-
-/**
- * The [UriResolver] used to resolve `package` URIs in a [GnWorkspace].
- */
-class GnPackageUriResolver extends UriResolver {
-  /**
-   * The workspace associated with this resolver.
-   */
-  final GnWorkspace workspace;
-
-  /**
-   * The path context that should be used to manipulate file system paths.
-   */
-  final Context pathContext;
-
-  /**
-   * The cache of absolute [Uri]s to [Source]s mappings.
-   */
-  final Map<Uri, Source> _sourceCache = new HashMap<Uri, Source>();
-
-  /**
-   * Initialize a newly created resolver to be associated with the given
-   * [workspace].
-   */
-  GnPackageUriResolver(GnWorkspace workspace)
-      : workspace = workspace,
-        pathContext = workspace.provider.pathContext;
-
-  @override
-  Source resolveAbsolute(Uri uri, [Uri actualUri]) {
-    return _putIfNotNull(_sourceCache, uri, () {
-      if (uri.scheme != 'package') {
-        return null;
-      }
-
-      String uriPath = uri.path;
-      int slash = uriPath.indexOf('/');
-
-      // If the path either starts with a slash or has no slash, it is invalid.
-      if (slash < 1) {
-        return null;
-      }
-
-      String packageName = uriPath.substring(0, slash);
-      String fileUriPart = uriPath.substring(slash + 1);
-      String filePath = fileUriPart.replaceAll('/', pathContext.separator);
-
-      String packageBase = workspace.getPackageSource(packageName);
-      if (packageBase == null) {
-        return null;
-      }
-      String path = pathContext.join(packageBase, filePath);
-      File file = workspace.findFile(path);
-      return file?.createSource(uri);
-    });
-  }
-
-  @override
-  Uri restoreAbsolute(Source source) {
-    Context context = workspace.provider.pathContext;
-    String path = source.fullName;
-
-    if (!context.isWithin(workspace.root, path)) {
-      return null;
-    }
-
-    String package = workspace.packages.keys.firstWhere(
-        (key) => context.isWithin(workspace.packages[key], path),
-        orElse: () => null);
-    if (package == null) {
-      return null;
-    }
-
-    String sourcePath =
-        context.relative(path, from: workspace.packages[package]);
-
-    return Uri.parse('package:$package/$sourcePath');
-  }
-}
 
 /**
  * Information about a Gn workspace.
@@ -160,50 +39,87 @@ class GnWorkspace extends Workspace {
   final String root;
 
   /**
-   * The path to the directory with source locations.
-   *
-   * Each file in this directory is named after a Dart package and contains the
-   * path to the package's sources.
+   * The path to the .packages file.
    */
-  final String _packagesDirectoryPath;
+  String _packagesFilePath;
 
   /**
-   * The cache of package locations indexed by package name.
+   * The map of package locations indexed by package name.
+   *
+   * This is a cached field.
    */
-  final Map<String, String> _packageCache = new HashMap<String, String>();
+  Map<String, List<Folder>> _packageMap;
 
-  GnWorkspace._internal(this.provider, this.root, this._packagesDirectoryPath);
+  /**
+   * The package location strategy.
+   *
+   * This is a cached field.
+   */
+  Packages _packages;
 
-  factory GnWorkspace._(
-      ResourceProvider provider, String root, String packagesDirectoryPath) {
-    GnWorkspace workspace =
-        new GnWorkspace._internal(provider, root, packagesDirectoryPath);
-    // Preload known packages.
-    provider
-        .getFolder(packagesDirectoryPath)
-        .getChildren()
-        .where((resource) => resource is File)
-        .map((resource) => resource as File)
-        .forEach((file) {
-      String packageName = basename(file.path);
-      workspace.getPackageSource(packageName);
-    });
-    return workspace;
-  }
-
-  Map<String, String> get packages => _packageCache;
+  GnWorkspace._(this.provider, this.root, this._packagesFilePath);
 
   @override
-  Map<String, List<Folder>> get packageMap {
-    Map<String, List<Folder>> result = new HashMap<String, List<Folder>>();
-    _packageCache.forEach((package, sourceDir) {
-      result[package] = [provider.getFolder(sourceDir)];
-    });
-    return result;
+  Map<String, List<Folder>> get packageMap =>
+      _packageMap ??= _convertPackagesToMap(packages);
+
+  Packages get packages => _packages ??= _createPackages();
+
+  /**
+   * Creates an alternate representation for available packages.
+   */
+  Map<String, List<Folder>> _convertPackagesToMap(Packages packages) {
+    Map<String, List<Folder>> folderMap = new HashMap<String, List<Folder>>();
+    if (packages != null && packages != Packages.noPackages) {
+      packages.asMap().forEach((String packageName, Uri uri) {
+        String path = provider.pathContext.fromUri(uri);
+        folderMap[packageName] = [provider.getFolder(path)];
+      });
+    }
+    return folderMap;
+  }
+
+  /**
+   * Loads the packages from the .packages file.
+   */
+  Packages _createPackages() {
+    File configFile = provider.getFile(_packagesFilePath);
+    List<int> bytes = configFile.readAsBytesSync();
+    Map<String, Uri> map = parse(bytes, configFile.toUri());
+    _resolveSymbolicLinks(map);
+    return new MapPackages(map);
+  }
+
+  /**
+   * Resolve any symbolic links encoded in the path to the given [folder].
+   */
+  String _resolveSymbolicLink(Folder folder) {
+    try {
+      return folder.resolveSymbolicLinksSync().path;
+    } on FileSystemException {
+      return folder.path;
+    }
+  }
+
+  /**
+   * Resolve any symbolic links encoded in the URI's in the given [map] by
+   * replacing the values in the map.
+   */
+  void _resolveSymbolicLinks(Map<String, Uri> map) {
+    Context pathContext = provider.pathContext;
+    for (String packageName in map.keys) {
+      Folder folder = provider.getFolder(pathContext.fromUri(map[packageName]));
+      String folderPath = _resolveSymbolicLink(folder);
+      // Add a '.' so that the URI is suitable for resolving relative URI's
+      // against it.
+      String uriPath = pathContext.join(folderPath, '.');
+      map[packageName] = pathContext.toUri(uriPath);
+    }
   }
 
   @override
-  UriResolver get packageUriResolver => new GnPackageUriResolver(this);
+  UriResolver get packageUriResolver =>
+      new PackageMapUriResolver(provider, packageMap);
 
   @override
   SourceFactory createSourceFactory(DartSdk sdk) {
@@ -212,20 +128,8 @@ class GnWorkspace extends Workspace {
       resolvers.add(new DartUriResolver(sdk));
     }
     resolvers.add(packageUriResolver);
-    resolvers.add(new GnFileUriResolver(this));
-    return new SourceFactory(resolvers, null, provider);
-  }
-
-  /**
-   * Return the source directory for the given package, or null if it could not
-   * be found.
-   */
-  String getPackageSource(String packageName) {
-    return _putIfNotNull(_packageCache, packageName, () {
-      String path =
-          provider.pathContext.join(_packagesDirectoryPath, packageName);
-      return findFile(path)?.readAsStringSync();
-    });
+    resolvers.add(new ResourceUriResolver(provider));
+    return new SourceFactory(resolvers, packages, provider);
   }
 
   /**
@@ -244,25 +148,65 @@ class GnWorkspace extends Workspace {
   }
 
   /**
-   * Locate the Dart sources directory.
+   * For a source at `$root/foo/bar`, the packages file is generated in
+   * `$root/out/<debug|release>-XYZ/[hostABC/]gen/foo/bar`.
    *
-   * Return `null` if it could not be found.
+   * Note that in some cases multiple .packages files can be found at that
+   * location, for example if the package contains both a library and a binary
+   * target. In that case, the .packages files are almost equivalent as the
+   * binary will depend on the library itself.
    */
-  static String _getPackagesDirectory(ResourceProvider provider, String root) {
+  static String _findPackagesFile(
+      ResourceProvider provider, String root, String path,
+      {forHost: false}) {
     Context pathContext = provider.pathContext;
-    String outDirectory = provider
-        .getFolder(pathContext.join(root, 'out'))
+    String sourceDirectory = pathContext.relative(path, from: root);
+    Folder outDirectory = provider.getFolder(pathContext.join(root, 'out'));
+    if (!outDirectory.exists) {
+      return null;
+    }
+    outDirectory = outDirectory
         .getChildren()
         .where((resource) => resource is Folder)
         .map((resource) => resource as Folder)
         .firstWhere((Folder folder) {
-      String baseName = basename(folder.path);
+      String baseName = pathContext.basename(folder.path);
       // TODO(pylaligand): find a better way to locate the proper directory.
       return baseName.startsWith('debug') || baseName.startsWith('release');
-    }, orElse: () => null)?.path;
-    return outDirectory == null
-        ? null
-        : provider.pathContext.join(outDirectory, 'gen', 'dart.sources');
+    }, orElse: () => null);
+    if (outDirectory == null) {
+      return null;
+    }
+    if (forHost) {
+      outDirectory = outDirectory
+          .getChildren()
+          .where((resource) => resource is Folder)
+          .map((resource) => resource as Folder)
+          .firstWhere(
+              (Folder folder) =>
+                  pathContext.basename(folder.path).startsWith('host'),
+              orElse: () => null);
+    }
+    if (outDirectory == null) {
+      return null;
+    }
+    Folder genDir = outDirectory
+        .getChildAssumingFolder(pathContext.join('gen', sourceDirectory));
+    if (!genDir.exists) {
+      return null;
+    }
+    return genDir
+        .getChildren()
+        .where((resource) => resource is File)
+        .map((resource) => resource as File)
+        .firstWhere(
+            // Note: there might be multiple .packages in that location, but
+            // they will have near identical contents, with the delta unlikely
+            // to affect analysis.
+            // TODO(pylaligand): consider using the union of these files.
+            (File file) => pathContext.extension(file.path) == '.packages',
+            orElse: () => null)
+        ?.path;
   }
 
   /**
@@ -276,7 +220,7 @@ class GnWorkspace extends Workspace {
 
     // Ensure that the path is absolute and normalized.
     if (!context.isAbsolute(path)) {
-      throw new ArgumentError('not absolute: $path');
+      throw new ArgumentError('Not an absolute path: $path');
     }
     path = context.normalize(path);
 
@@ -290,8 +234,13 @@ class GnWorkspace extends Workspace {
       // Found the .jiri_root file, must be a non-git workspace.
       if (folder.getChildAssumingFolder(_jiriRootName).exists) {
         String root = folder.path;
-        String packagesDirectory = _getPackagesDirectory(provider, root);
-        return new GnWorkspace._(provider, root, packagesDirectory);
+        String packagesFile =
+            _findPackagesFile(provider, root, path, forHost: false);
+        packagesFile ??= _findPackagesFile(provider, root, path, forHost: true);
+        if (packagesFile == null) {
+          return null;
+        }
+        return new GnWorkspace._(provider, path, packagesFile);
       }
 
       // Go up the folder.

--- a/pkg/analyzer/test/generated/gn_test.dart
+++ b/pkg/analyzer/test/generated/gn_test.dart
@@ -12,92 +12,8 @@ import 'package:test_reflective_loader/test_reflective_loader.dart';
 
 main() {
   defineReflectiveSuite(() {
-    defineReflectiveTests(GnPackageUriResolverTest);
     defineReflectiveTests(GnWorkspaceTest);
   });
-}
-
-@reflectiveTest
-class GnPackageUriResolverTest extends _BaseTest {
-  GnWorkspace workspace;
-  GnPackageUriResolver resolver;
-
-  void test_resolve() {
-    _addResources([
-      '/workspace/.jiri_root/',
-      '/workspace/out/debug-x87_128/gen/dart.sources/',
-      '/workspace/some/code/',
-      '/workspace/a/source/code.dart',
-    ]);
-    provider.newFile(
-        _p('/workspace/out/debug-x87_128/gen/dart.sources/flutter'),
-        _p('/workspace/a/source'));
-    _setUp();
-    _assertResolve(
-        'package:flutter/code.dart', _p('/workspace/a/source/code.dart'));
-  }
-
-  void test_resolveDoesNotExist() {
-    _addResources([
-      '/workspace/.jiri_root/',
-      '/workspace/out/debug-x87_128/gen/dart.sources/',
-      '/workspace/some/code/',
-      '/workspace/a/source/code.dart',
-    ]);
-    provider.newFile(
-        _p('/workspace/out/debug-x87_128/gen/dart.sources/flutter'),
-        _p('/workspace/a/source'));
-    _setUp();
-    expect(
-        resolver.resolveAbsolute(Uri.parse('package:bogus/code.dart')), null);
-  }
-
-  void test_resolveAddToCache() {
-    _addResources([
-      '/workspace/.jiri_root/',
-      '/workspace/out/debug-x87_128/gen/dart.sources/',
-      '/workspace/some/code/',
-      '/workspace/a/source/code.dart',
-    ]);
-    _setUp();
-    expect(
-        resolver.resolveAbsolute(Uri.parse('package:flutter/code.dart')), null);
-    provider.newFile(
-        _p('/workspace/out/debug-x87_128/gen/dart.sources/flutter'),
-        _p('/workspace/a/source'));
-    _assertResolve(
-        'package:flutter/code.dart', _p('/workspace/a/source/code.dart'));
-  }
-
-  void _addResources(List<String> paths) {
-    for (String path in paths) {
-      if (path.endsWith('/')) {
-        provider.newFolder(_p(path.substring(0, path.length - 1)));
-      } else {
-        provider.newFile(_p(path), '');
-      }
-    }
-  }
-
-  void _setUp() {
-    workspace = GnWorkspace.find(provider, _p('/workspace'));
-    resolver = new GnPackageUriResolver(workspace);
-  }
-
-  void _assertResolve(String uriStr, String posixPath,
-      {bool exists: true, bool restore: true}) {
-    Uri uri = Uri.parse(uriStr);
-    Source source = resolver.resolveAbsolute(uri);
-    expect(source, isNotNull);
-    expect(source.fullName, _p(posixPath));
-    expect(source.uri, uri);
-    expect(source.exists(), exists);
-    // If enabled, test also "restoreAbsolute".
-    if (restore) {
-      Uri uri = resolver.restoreAbsolute(source);
-      expect(uri.toString(), uriStr);
-    }
-  }
 }
 
 @reflectiveTest
@@ -115,27 +31,43 @@ class GnWorkspaceTest extends _BaseTest {
 
   void test_find_withRoot() {
     provider.newFolder(_p('/workspace/.jiri_root'));
-    provider.newFolder(_p('/workspace/out/debug-x87_128/gen/dart.sources'));
     provider.newFolder(_p('/workspace/some/code'));
+    provider.newFile(_p('/workspace/some/code/pubspec.yaml'), '');
+    provider.newFile(
+        _p('/workspace/out/debug-x87_128/gen/some/code/foo.packages'), '');
     GnWorkspace workspace =
         GnWorkspace.find(provider, _p('/workspace/some/code'));
     expect(workspace, isNotNull);
-    expect(workspace.root, _p('/workspace'));
+    expect(workspace.root, _p('/workspace/some/code'));
+  }
+
+  void test_find_inHost() {
+    provider.newFolder(_p('/workspace/.jiri_root'));
+    provider.newFolder(_p('/workspace/some/code'));
+    provider.newFile(_p('/workspace/some/code/pubspec.yaml'), '');
+    provider.newFile(
+        _p('/workspace/out/debug-x87_128/host_y32/gen/some/code/foo.packages'),
+        '');
+    GnWorkspace workspace =
+        GnWorkspace.find(provider, _p('/workspace/some/code'));
+    expect(workspace, isNotNull);
+    expect(workspace.root, _p('/workspace/some/code'));
   }
 
   void test_packages() {
     provider.newFolder(_p('/workspace/.jiri_root'));
-    provider.newFolder(_p('/workspace/out/debug-x87_128/gen/dart.sources'));
-    provider.newFile(
-        _p('/workspace/out/debug-x87_128/gen/dart.sources/flutter'),
-        _p('/path/to/source'));
     provider.newFolder(_p('/workspace/some/code'));
+    provider.newFile(_p('/workspace/some/code/pubspec.yaml'), '');
+    String packageLocation = _p('/workspace/this/is/the/package');
+    provider.newFile(
+        _p('/workspace/out/debug-x87_128/gen/some/code/foo.packages'),
+        'flutter:$packageLocation');
     GnWorkspace workspace =
         GnWorkspace.find(provider, _p('/workspace/some/code'));
     expect(workspace, isNotNull);
-    expect(workspace.root, _p('/workspace'));
+    expect(workspace.root, _p('/workspace/some/code'));
     expect(workspace.packageMap.length, 1);
-    expect(workspace.packageMap['flutter'][0].path, _p('/path/to/source'));
+    expect(workspace.packageMap['flutter'][0].path, packageLocation);
   }
 }
 


### PR DESCRIPTION
The previous version would use a global cache of package locations which would hide missing dependencies.
Also fixed an issue in file tracking with non-existing sources that resolvers such as PackageMapUriResolver sometimes return.