### PR TITLE
New Lint quick-fix: avoid_init_to_null

### DIFF
--- a/pkg/analysis_server/lib/src/services/correction/fix.dart
+++ b/pkg/analysis_server/lib/src/services/correction/fix.dart
@@ -109,7 +109,8 @@ bool hasFix(ErrorCode errorCode) =>
     errorCode == CompileTimeErrorCode.UNDEFINED_NAMED_PARAMETER ||
     (errorCode is LintCode &&
         (errorCode.name == LintNames.annotate_overrides ||
-            errorCode.name == LintNames.unnecessary_brace_in_string_interp));
+            errorCode.name == LintNames.unnecessary_brace_in_string_interp ||
+            errorCode.name == LintNames.avoid_init_to_null));
 
 /**
  * An enumeration of possible quick fix kinds.
@@ -195,6 +196,8 @@ class DartFixKind {
       const FixKind('REMOVE_DEAD_CODE', 50, "Remove dead code");
   static const MAKE_FIELD_NOT_FINAL =
       const FixKind('MAKE_FIELD_NOT_FINAL', 50, "Make field '{0}' not final");
+  static const REMOVE_INITIALIZER =
+      const FixKind('REMOVE_INITIALIZER', 50, "Remove initializer");
   static const REMOVE_PARAMETERS_IN_GETTER_DECLARATION = const FixKind(
       'REMOVE_PARAMETERS_IN_GETTER_DECLARATION',
       50,

--- a/pkg/analysis_server/lib/src/services/correction/fix_internal.dart
+++ b/pkg/analysis_server/lib/src/services/correction/fix_internal.dart
@@ -384,6 +384,9 @@ class FixProcessor {
       if (errorCode.name == LintNames.unnecessary_brace_in_string_interp) {
         _addLintRemoveInterpolationBraces();
       }
+      if (errorCode.name == LintNames.avoid_init_to_null) {
+        _addFix_removeInitializer();
+      }
     }
     // done
     return fixes;
@@ -1795,6 +1798,20 @@ class FixProcessor {
     }
   }
 
+  void _addFix_removeInitializer() {
+    // Retrieve the linted node.
+    VariableDeclaration ancestor =
+        node.getAncestor((a) => a is VariableDeclaration);
+    if (ancestor == null) {
+      return;
+    }
+
+    final start = ancestor.name.end;
+    final end = ancestor.initializer.end;
+    _addRemoveEdit(rf.rangeStartLength(start, end - start));
+    _addFix(DartFixKind.REMOVE_INITIALIZER, []);
+  }
+
   void _addFix_removeParameters_inGetterDeclaration() {
     if (node is MethodDeclaration) {
       MethodDeclaration method = node as MethodDeclaration;
@@ -2998,6 +3015,7 @@ class FixProcessor {
  */
 class LintNames {
   static const String annotate_overrides = 'annotate_overrides';
+  static const String avoid_init_to_null = 'avoid_init_to_null';
   static const String unnecessary_brace_in_string_interp =
       'unnecessary_brace_in_string_interp';
 }

--- a/pkg/analysis_server/test/services/correction/fix_test.dart
+++ b/pkg/analysis_server/test/services/correction/fix_test.dart
@@ -5915,6 +5915,49 @@ main() {
 ''');
   }
 
+  test_removeInitializer_field() async {
+    String src = '''
+class Test {
+  int /*LINT*/x = null;
+}
+''';
+    await findLint(src, LintNames.avoid_init_to_null);
+
+    await applyFix(DartFixKind.REMOVE_INITIALIZER);
+
+    verifyResult('''
+class Test {
+  int x;
+}
+''');
+  }
+
+  test_removeInitializer_listOfVariableDeclarations() async {
+    String src = '''
+String a = 'a', /*LINT*/b = null, c = 'c';
+''';
+    await findLint(src, LintNames.avoid_init_to_null);
+
+    await applyFix(DartFixKind.REMOVE_INITIALIZER);
+
+    verifyResult('''
+String a = 'a', b, c = 'c';
+''');
+  }
+
+  test_removeInitializer_topLevel() async {
+    String src = '''
+var /*LINT*/x = null;
+''';
+    await findLint(src, LintNames.avoid_init_to_null);
+
+    await applyFix(DartFixKind.REMOVE_INITIALIZER);
+
+    verifyResult('''
+var x;
+''');
+  }
+
   void verifyResult(String expectedResult) {
     expect(resultCode, expectedResult);
   }


### PR DESCRIPTION
From [Linter](http://dart-lang.github.io/linter/lints/avoid_init_to_null.html)