### PR TITLE
New Lint quick-fix: prefer_collection_literals (#29378)

### DIFF
--- a/pkg/analysis_server/lib/src/services/correction/fix.dart
+++ b/pkg/analysis_server/lib/src/services/correction/fix.dart
@@ -109,8 +109,9 @@ bool hasFix(ErrorCode errorCode) =>
     errorCode == CompileTimeErrorCode.UNDEFINED_NAMED_PARAMETER ||
     (errorCode is LintCode &&
         (errorCode.name == LintNames.annotate_overrides ||
-            errorCode.name == LintNames.unnecessary_brace_in_string_interp ||
-            errorCode.name == LintNames.avoid_init_to_null));
+            errorCode.name == LintNames.avoid_init_to_null ||
+            errorCode.name == LintNames.prefer_collection_literals ||
+            errorCode.name == LintNames.unnecessary_brace_in_string_interp));
 
 /**
  * An enumeration of possible quick fix kinds.
@@ -222,6 +223,8 @@ class DartFixKind {
       'REPLACE_RETURN_TYPE_FUTURE',
       50,
       "Return 'Future' from 'async' function");
+  static const REPLACE_WITH_LITERAL =
+      const FixKind('REPLACE_WITH_LITERAL', 50, 'Replace with literal');
   static const REPLACE_WITH_NULL_AWARE = const FixKind(
       'REPLACE_WITH_NULL_AWARE',
       50,

--- a/pkg/analysis_server/lib/src/services/correction/fix_internal.dart
+++ b/pkg/analysis_server/lib/src/services/correction/fix_internal.dart
@@ -382,11 +382,14 @@ class FixProcessor {
       if (errorCode.name == LintNames.annotate_overrides) {
         _addLintFixAddOverrideAnnotation();
       }
-      if (errorCode.name == LintNames.unnecessary_brace_in_string_interp) {
-        _addLintRemoveInterpolationBraces();
-      }
       if (errorCode.name == LintNames.avoid_init_to_null) {
         _addFix_removeInitializer();
+      }
+      if (errorCode.name == LintNames.prefer_collection_literals) {
+        _addFix_replaceWithLiteral();
+      }
+      if (errorCode.name == LintNames.unnecessary_brace_in_string_interp) {
+        _addLintRemoveInterpolationBraces();
       }
     }
     // done
@@ -1903,6 +1906,24 @@ class FixProcessor {
     }
   }
 
+  void _addFix_replaceWithLiteral() {
+    final InstanceCreationExpression instanceCreation =
+        node.getAncestor((node) => node is InstanceCreationExpression);
+    final InterfaceType type = instanceCreation.staticType;
+    final buffer = new StringBuffer();
+    final generics = instanceCreation.constructorName.type.typeArguments;
+    if (generics != null) {
+      buffer.write(utils.getNodeText(generics));
+    }
+    if (type.name == 'List') {
+      buffer.write('[]');
+    } else {
+      buffer.write('{}');
+    }
+    _addReplaceEdit(rf.rangeNode(instanceCreation), buffer.toString());
+    _addFix(DartFixKind.REPLACE_WITH_LITERAL, []);
+  }
+
   void _addFix_undefinedClass_useSimilar() {
     AstNode node = this.node;
     // Prepare the optional import prefix name.
@@ -3050,6 +3071,7 @@ class FixProcessor {
 class LintNames {
   static const String annotate_overrides = 'annotate_overrides';
   static const String avoid_init_to_null = 'avoid_init_to_null';
+  static const String prefer_collection_literals = 'prefer_collection_literals';
   static const String unnecessary_brace_in_string_interp =
       'unnecessary_brace_in_string_interp';
 }

--- a/pkg/analysis_server/test/mock_sdk.dart
+++ b/pkg/analysis_server/test/mock_sdk.dart
@@ -200,6 +200,7 @@ abstract class StreamTransformer<S, T> {}
 library dart.collection;
 
 abstract class HashMap<K, V> implements Map<K, V> {}
+abstract class LinkedHashMap<K, V> implements Map<K, V> {}
 ''');
 
   static const MockSdkLibrary LIB_CONVERT = const MockSdkLibrary(

--- a/pkg/analysis_server/test/services/correction/fix_test.dart
+++ b/pkg/analysis_server/test/services/correction/fix_test.dart
@@ -5986,6 +5986,126 @@ var x;
 ''');
   }
 
+  test_replaceWithLiteral_linkedHashMap_withCommentsInGeneric() async {
+    String src = '''
+import 'dart:collection';
+
+final a = /*LINT*/new LinkedHashMap<int,/*comment*/int>();
+''';
+    await findLint(src, LintNames.prefer_collection_literals);
+
+    await applyFix(DartFixKind.REPLACE_WITH_LITERAL);
+
+    verifyResult('''
+import 'dart:collection';
+
+final a = <int,/*comment*/int>{};
+''');
+  }
+
+  test_replaceWithLiteral_linkedHashMap_withDynamicGenerics() async {
+    String src = '''
+import 'dart:collection';
+
+final a = /*LINT*/new LinkedHashMap<dynamic,dynamic>();
+''';
+    await findLint(src, LintNames.prefer_collection_literals);
+
+    await applyFix(DartFixKind.REPLACE_WITH_LITERAL);
+
+    verifyResult('''
+import 'dart:collection';
+
+final a = <dynamic,dynamic>{};
+''');
+  }
+
+  test_replaceWithLiteral_linkedHashMap_withGeneric() async {
+    String src = '''
+import 'dart:collection';
+
+final a = /*LINT*/new LinkedHashMap<int,int>();
+''';
+    await findLint(src, LintNames.prefer_collection_literals);
+
+    await applyFix(DartFixKind.REPLACE_WITH_LITERAL);
+
+    verifyResult('''
+import 'dart:collection';
+
+final a = <int,int>{};
+''');
+  }
+
+  test_replaceWithLiteral_linkedHashMap_withoutGeneric() async {
+    String src = '''
+import 'dart:collection';
+
+final a = /*LINT*/new LinkedHashMap();
+''';
+    await findLint(src, LintNames.prefer_collection_literals);
+
+    await applyFix(DartFixKind.REPLACE_WITH_LITERAL);
+
+    verifyResult('''
+import 'dart:collection';
+
+final a = {};
+''');
+  }
+
+  test_replaceWithLiteral_list_withGeneric() async {
+    String src = '''
+final a = /*LINT*/new List<int>();
+''';
+    await findLint(src, LintNames.prefer_collection_literals);
+
+    await applyFix(DartFixKind.REPLACE_WITH_LITERAL);
+
+    verifyResult('''
+final a = <int>[];
+''');
+  }
+
+  test_replaceWithLiteral_list_withoutGeneric() async {
+    String src = '''
+final a = /*LINT*/new List();
+''';
+    await findLint(src, LintNames.prefer_collection_literals);
+
+    await applyFix(DartFixKind.REPLACE_WITH_LITERAL);
+
+    verifyResult('''
+final a = [];
+''');
+  }
+
+  test_replaceWithLiteral_map_withGeneric() async {
+    String src = '''
+final a = /*LINT*/new Map<int,int>();
+''';
+    await findLint(src, LintNames.prefer_collection_literals);
+
+    await applyFix(DartFixKind.REPLACE_WITH_LITERAL);
+
+    verifyResult('''
+final a = <int,int>{};
+''');
+  }
+
+  test_replaceWithLiteral_map_withoutGeneric() async {
+    String src = '''
+final a = /*LINT*/new Map();
+''';
+    await findLint(src, LintNames.prefer_collection_literals);
+
+    await applyFix(DartFixKind.REPLACE_WITH_LITERAL);
+
+    verifyResult('''
+final a = {};
+''');
+  }
+
   void verifyResult(String expectedResult) {
     expect(resultCode, expectedResult);
   }


### PR DESCRIPTION
https://codereview.chromium.org/2827863003

I was using this command to run the tests:

`./tools/test.py -mrelease pkg/analysis_server/`

And did not failed when I removed the line `import 'dart:collection';` in the tests with `LinkedHashMap` so I thought they were unnecessary but what happened was that I ran the test incorrectly now I use:

`./tools/test.py -mrelease pkg/analysis_server/ --checked -t60`

And could detect that they were necessary and I added them.

Thanks @ErikCorryGoogle 
