### PR TITLE
Autocompletion for angular

### DIFF
--- a/pkg/analysis_server/lib/src/analysis_server.dart
+++ b/pkg/analysis_server/lib/src/analysis_server.dart
@@ -374,6 +374,12 @@ class AnalysisServer {
   Function onNoAnalysisResult;
 
   /**
+   * This exists as a temporary stopgap for plugins, until the official plugin
+   * API is complete.
+   */
+  Function onNoAnalysisCompletion;
+
+  /**
    * The set of the files that are currently priority.
    */
   final Set<String> priorityFiles = new Set<String>();


### PR DESCRIPTION
Adding stopgap to allow for angular2-analyzer-plugin to add to completion in .html files.
Also moved some critical code segments into a public facing wrapper function since I need to call them from angular-analyzer-plugin.

Temporarily not dealing with .dart files because of request object returning incorrect offset. Need to look into it; probably from intelliJ side. 

