### PR TITLE
New Lint quick-fixes: REMOVE_TYPE - 3 different lints

### DIFF
--- a/pkg/analysis_server/lib/src/services/correction/fix.dart
+++ b/pkg/analysis_server/lib/src/services/correction/fix.dart
@@ -216,6 +216,8 @@ class DartFixKind {
       "Remove parentheses in getter invocation");
   static const REMOVE_THIS_EXPRESSION =
       const FixKind('REMOVE_THIS_EXPRESSION', 50, "Remove this expression");
+  static const REMOVE_TYPE_NAME =
+      const FixKind('REMOVE_TYPE_NAME', 50, "Remove type name");
   static const REMOVE_UNNECESSARY_CAST =
       const FixKind('REMOVE_UNNECESSARY_CAST', 50, "Remove unnecessary cast");
   static const REMOVE_UNUSED_CATCH_CLAUSE =
@@ -236,6 +238,8 @@ class DartFixKind {
       const FixKind('REPLACE_WITH_BRACKETS', 50, "Replace with { }");
   static const REPLACE_WITH_CONDITIONAL_ASSIGNMENT = const FixKind(
       'REPLACE_WITH_CONDITIONAL_ASSIGNMENT', 50, 'Replace with ??=');
+  static const REPLACE_WITH_IDENTIFIER =
+      const FixKind('REPLACE_WITH_IDENTIFIER', 50, "Replace with identifier");
   static const REPLACE_WITH_LITERAL =
       const FixKind('REPLACE_WITH_LITERAL', 50, 'Replace with literal');
   static const REPLACE_WITH_NULL_AWARE = const FixKind(

--- a/pkg/analysis_server/test/services/correction/fix_test.dart
+++ b/pkg/analysis_server/test/services/correction/fix_test.dart
@@ -6196,6 +6196,151 @@ class A {
 ''');
   }
 
+  test_removeTypeName_avoidAnnotatingWithDynamic_InsideFunctionTypedFormalParameter() async {
+    String src = '''
+bad(void foo(/*LINT*/dynamic x)) {
+  return null;
+}
+''';
+    await findLint(src, LintNames.avoid_annotating_with_dynamic);
+
+    await applyFix(DartFixKind.REMOVE_TYPE_NAME);
+
+    verifyResult('''
+bad(void foo(x)) {
+  return null;
+}
+''');
+  }
+
+  test_removeTypeName_avoidAnnotatingWithDynamic_NamedParameter() async {
+    String src = '''
+bad({/*LINT*/dynamic defaultValue}) {
+  return null;
+}
+''';
+    await findLint(src, LintNames.avoid_annotating_with_dynamic);
+
+    await applyFix(DartFixKind.REMOVE_TYPE_NAME);
+
+    verifyResult('''
+bad({defaultValue}) {
+  return null;
+}
+''');
+  }
+
+  test_removeTypeName_avoidAnnotatingWithDynamic_NormalParameter() async {
+    String src = '''
+bad(/*LINT*/dynamic defaultValue) {
+  return null;
+}
+''';
+    await findLint(src, LintNames.avoid_annotating_with_dynamic);
+
+    await applyFix(DartFixKind.REMOVE_TYPE_NAME);
+
+    verifyResult('''
+bad(defaultValue) {
+  return null;
+}
+''');
+  }
+
+  test_removeTypeName_avoidAnnotatingWithDynamic_OptionalParameter() async {
+    String src = '''
+bad([/*LINT*/dynamic defaultValue]) {
+  return null;
+}
+''';
+    await findLint(src, LintNames.avoid_annotating_with_dynamic);
+
+    await applyFix(DartFixKind.REMOVE_TYPE_NAME);
+
+    verifyResult('''
+bad([defaultValue]) {
+  return null;
+}
+''');
+  }
+
+  test_removeTypeName_avoidReturnTypesOnSetters_void() async {
+    String src = '''
+/*LINT*/void set speed2(int ms) {}
+''';
+    await findLint(src, LintNames.avoid_return_types_on_setters);
+
+    await applyFix(DartFixKind.REMOVE_TYPE_NAME);
+
+    verifyResult('''
+set speed2(int ms) {}
+''');
+  }
+
+  test_removeTypeName_avoidTypesOnClosureParameters_FunctionTypedFormalParameter() async {
+    String src = '''
+var functionWithFunction = (/*LINT*/int f(int x)) => f(0);
+''';
+    await findLint(src, LintNames.avoid_types_on_closure_parameters);
+
+    await applyFix(DartFixKind.REPLACE_WITH_IDENTIFIER);
+
+    verifyResult('''
+var functionWithFunction = (f) => f(0);
+''');
+  }
+
+  test_removeTypeName_avoidTypesOnClosureParameters_NamedParameter() async {
+    String src = '''
+var x = ({/*LINT*/Future<int> defaultValue}) {
+  return null;
+};
+''';
+    await findLint(src, LintNames.avoid_types_on_closure_parameters);
+
+    await applyFix(DartFixKind.REMOVE_TYPE_NAME);
+
+    verifyResult('''
+var x = ({defaultValue}) {
+  return null;
+};
+''');
+  }
+
+  test_removeTypeName_avoidTypesOnClosureParameters_NormalParameter() async {
+    String src = '''
+var x = (/*LINT*/Future<int> defaultValue) {
+  return null;
+};
+''';
+    await findLint(src, LintNames.avoid_types_on_closure_parameters);
+
+    await applyFix(DartFixKind.REMOVE_TYPE_NAME);
+
+    verifyResult('''
+var x = (defaultValue) {
+  return null;
+};
+''');
+  }
+
+  test_removeTypeName_avoidTypesOnClosureParameters_OptionalParameter() async {
+    String src = '''
+var x = ([/*LINT*/Future<int> defaultValue]) {
+  return null;
+};
+''';
+    await findLint(src, LintNames.avoid_types_on_closure_parameters);
+
+    await applyFix(DartFixKind.REMOVE_TYPE_NAME);
+
+    verifyResult('''
+var x = ([defaultValue]) {
+  return null;
+};
+''');
+  }
+
   test_replaceWithConditionalAssignment_withCodeBeforeAndAfter() async {
     String src = '''
 class Person {


### PR DESCRIPTION
This quick-fix just remove a type, it is useful to 3 lints by now, they are:

From [Linter] (http://dart-lang.github.io/linter/lints/avoid_return_types_on_setters.html)
From [Linter] (https://github.com/dart-lang/linter/pull/545)
From [Linter] (https://github.com/dart-lang/linter/pull/551)