### PR TITLE
New Lint quick-fix: await_only_futures

### DIFF
--- a/pkg/analysis_server/lib/src/services/correction/fix.dart
+++ b/pkg/analysis_server/lib/src/services/correction/fix.dart
@@ -200,6 +200,7 @@ class DartFixKind {
       const FixKind('REMOVE_DEAD_CODE', 50, "Remove dead code");
   static const MAKE_FIELD_NOT_FINAL =
       const FixKind('MAKE_FIELD_NOT_FINAL', 50, "Make field '{0}' not final");
+  static const REMOVE_AWAIT = const FixKind('REMOVE_AWAIT', 50, "Remove await");
   static const REMOVE_EMPTY_STATEMENT =
       const FixKind('REMOVE_EMPTY_STATEMENT', 50, "Remove empty statement");
   static const REMOVE_INITIALIZER =

--- a/pkg/analysis_server/lib/src/services/correction/fix_internal.dart
+++ b/pkg/analysis_server/lib/src/services/correction/fix_internal.dart
@@ -393,6 +393,9 @@ class FixProcessor {
       if (errorCode.name == LintNames.avoid_types_on_closure_parameters) {
         _addFix_replaceWithIdentifier();
       }
+      if (errorCode.name == LintNames.await_only_futures) {
+        _addFix_removeAwait();
+      }
       if (errorCode.name == LintNames.empty_statements) {
         _addFix_removeEmptyStatement();
       }
@@ -1794,6 +1797,16 @@ class FixProcessor {
   void _addFix_nonBoolCondition_addNotNull() {
     _addInsertEdit(error.offset + error.length, ' != null');
     _addFix(DartFixKind.ADD_NE_NULL, []);
+  }
+
+  void _addFix_removeAwait() {
+    final awaitExpression = node;
+    if (awaitExpression is AwaitExpression) {
+      final awaitToken = awaitExpression.awaitKeyword;
+      _addRemoveEdit(
+          rf.rangeStartEnd(awaitToken.offset, awaitToken.next.offset));
+      _addFix(DartFixKind.REMOVE_AWAIT, []);
+    }
   }
 
   void _addFix_removeDeadCode() {
@@ -3217,6 +3230,7 @@ class LintNames {
       'avoid_return_types_on_setters';
   static const String avoid_types_on_closure_parameters =
       'avoid_types_on_closure_parameters';
+  static const String await_only_futures = 'await_only_futures';
   static const String empty_statements = 'empty_statements';
   static const String prefer_collection_literals = 'prefer_collection_literals';
   static const String prefer_conditional_assignment =

--- a/pkg/analysis_server/test/services/correction/fix_test.dart
+++ b/pkg/analysis_server/test/services/correction/fix_test.dart
@@ -5941,6 +5941,40 @@ main() {
 ''');
   }
 
+  test_removeAwait_intLiteral() async {
+    String src = '''
+bad() async {
+  print(/*LINT*/await 23);
+}
+''';
+    await findLint(src, LintNames.await_only_futures);
+
+    await applyFix(DartFixKind.REMOVE_AWAIT);
+
+    verifyResult('''
+bad() async {
+  print(23);
+}
+''');
+  }
+
+  test_removeAwait_StringLiteral() async {
+    String src = '''
+bad() async {
+  print(/*LINT*/await 'hola');
+}
+''';
+    await findLint(src, LintNames.await_only_futures);
+
+    await applyFix(DartFixKind.REMOVE_AWAIT);
+
+    verifyResult('''
+bad() async {
+  print('hola');
+}
+''');
+  }
+
   test_removeEmptyStatement_insideBlock() async {
     String src = '''
 void foo() {


### PR DESCRIPTION
From [Linter](http://dart-lang.github.io/linter/lints/await_only_futures.html)