### PR TITLE
double::toString perf improvement for integer case

### DIFF
--- a/runtime/lib/double.dart
+++ b/runtime/lib/double.dart
@@ -169,16 +169,34 @@ class _Double implements double {
   String _toString() native "Double_toString";
 
   String toString() {
+    if (identical(0.0, this)) {
+      return "0.0";
+    } else if (identical(-0.0, this)) {
+      return "-0.0";
+    } else if (isNaN) {
+      return "NaN";
+    } else if (this == double.INFINITY) {
+      return "Infinity";
+    } else if (this == -double.INFINITY) {
+      return "-Infinity";
+    }
+
+    // This will not throw because we have already tested
+    // for special values. Furthermore, we only take this
+    // path if we are between a range to mimic inaccuracies
+    // in certain floating point calculations.
+    int rounded = floor();
+    if (rounded == this && rounded is _Smi &&
+        rounded < 16777217 && rounded > -16777217) {
+      return _smiToString(rounded);
+    }
+
     // TODO(koda): Consider starting at most recently inserted.
     for (int i = 0; i < CACHE_LENGTH; i += 2) {
       // Need 'identical' to handle negative zero, etc.
       if (identical(_cache[i], this)) {
         return _cache[i + 1];
       }
-    }
-    // TODO(koda): Consider optimizing all small integral values.
-    if (identical(0.0, this)) {
-      return "0.0";
     }
     String result = _toString();
     // Replace the least recently inserted entry.
@@ -299,5 +317,61 @@ class _Double implements double {
       // Other is NaN.
       return LESS;
     }
+  }
+
+  /**
+   * Result of double.toString for -99.0, -98.0, ..., 98.0, 99.0.
+   */
+  static const _smallLookupTable = const [
+    "-99.0", "-98.0","-97.0","-96.0","-95.0","-94.0","-93.0","-92.0","-91.0",
+    "-90.0","-89.0","-88.0","-87.0","-86.0","-85.0","-84.0","-83.0","-82.0",
+    "-81.0","-80.0", "-79.0", "-78.0","-77.0","-76.0","-75.0","-74.0","-73.0",
+    "-72.0","-71.0","-70.0","-69.0","-68.0","-67.0","-66.0","-65.0","-64.0",
+    "-63.0","-62.0","-61.0","-60.0","-59.0","-58.0","-57.0","-56.0","-55.0",
+    "-54.0","-53.0","-52.0","-51.0","-50.0","-49.0","-48.0","-47.0","-46.0",
+    "-45.0","-44.0","-43.0","-42.0","-41.0","-40.0","-39.0","-38.0","-37.0",
+    "-36.0","-35.0","-34.0","-33.0","-32.0","-31.0","-30.0","-29.0","-28.0",
+    "-27.0","-26.0","-25.0","-24.0","-23.0","-22.0","-21.0","-20.0","-19.0",
+    "-18.0","-17.0","-16.0","-15.0","-14.0","-13.0","-12.0","-11.0","-10.0",
+    "-9.0","-8.0","-7.0","-6.0","-5.0","-4.0","-3.0","-2.0","-1.0","0.0",
+    "1.0","2.0","3.0","4.0","5.0","6.0","7.0","8.0","9.0","10.0","11.0",
+    "12.0","13.0","14.0","15.0","16.0","17.0","18.0","19.0","20.0","21.0",
+    "22.0","23.0","24.0","25.0","26.0","27.0","28.0","29.0","30.0","31.0",
+    "32.0","33.0","34.0","35.0","36.0","37.0","38.0","39.0","40.0","41.0",
+    "42.0","43.0","44.0","45.0","46.0","47.0","48.0","49.0","50.0","51.0",
+    "52.0","53.0","54.0","55.0","56.0","57.0","58.0","59.0","60.0","61.0",
+    "62.0","63.0","64.0","65.0","66.0","67.0","68.0","69.0","70.0","71.0",
+    "72.0","73.0","74.0","75.0","76.0","77.0","78.0","79.0","80.0","81.0",
+    "82.0","83.0","84.0","85.0","86.0","87.0","88.0","89.0","90.0","91.0",
+    "92.0","93.0","94.0","95.0","96.0","97.0","98.0","99.0",
+  ];
+
+  static String _smiToString(int smi) {
+    if (smi < 100 && smi > -100) return _smallLookupTable[smi + 99];
+    if (smi < 0) return _negativeSmiToString(smi);
+
+    const int DECIMAL = 0x2E;
+    const int DIGIT_ZERO = 0x30;
+    int digitCount = _Smi._positiveBase10Length(smi);
+
+    // Add bytes for trailing '.0'
+    _OneByteString result = _OneByteString._allocate(digitCount + 2);
+    result._setAt(digitCount + 1, DIGIT_ZERO);
+    result._setAt(digitCount, DECIMAL);
+    return _Smi._positiveToDigitString(result, smi, digitCount - 1);
+  }
+
+  static String _negativeSmiToString(int negSmi) {
+    // This should be handled by the lookup table
+    assert(negSmi <= -100);
+    const int DIGIT_ZERO = 0x30;
+    const int DECIMAL = 0x2E;
+    int digitCount = _Smi._negativeBase10Length(negSmi);
+
+    // Add bytes for minus sign and trailing '.0'
+    _OneByteString result = _OneByteString._allocate(digitCount + 3);
+    result._setAt(digitCount + 2, DIGIT_ZERO);
+    result._setAt(digitCount + 1, DECIMAL);
+    return _Smi._negativeToDigitString(result, negSmi, digitCount);
   }
 }

--- a/runtime/lib/integers.dart
+++ b/runtime/lib/integers.dart
@@ -565,11 +565,17 @@ class _Smi extends _IntegerImplementation implements int, _int64 {
     // Inspired by Andrei Alexandrescu: "Three Optimization Tips for C++"
     // Avoid expensive remainder operation by doing it on more than
     // one digit at a time.
-    const int DIGIT_ZERO = 0x30;
     int length = _positiveBase10Length(this);
     _OneByteString result = _OneByteString._allocate(length);
-    int index = length - 1;
-    var smi = this;
+    return _positiveToDigitString(result, this, length - 1);
+  }
+
+  // Converts an smi >= 100 to a String. Result must be large enough for all
+  // of the digits. Index is the index for the smallest magnitude digit.
+  static String _positiveToDigitString(_OneByteString result, int smi,
+      int index) {
+    assert(smi >= 100);
+    const int DIGIT_ZERO = 0x30;
     do {
       // Two digits at a time.
       var twoDigits = smi.remainder(100);
@@ -616,9 +622,7 @@ class _Smi extends _IntegerImplementation implements int, _int64 {
   // Doesn't negate the smi to avoid negating the most negative smi, which
   // would become a non-smi.
   static String _negativeToString(int negSmi) {
-    // Character code for '-'
     const int MINUS_SIGN = 0x2d;
-    // Character code for '0'.
     const int DIGIT_ZERO = 0x30;
     if (negSmi > -10) {
       return _OneByteString._allocate(2)
@@ -635,8 +639,18 @@ class _Smi extends _IntegerImplementation implements int, _int64 {
     // Number of digits, not including minus.
     int digitCount = _negativeBase10Length(negSmi);
     _OneByteString result = _OneByteString._allocate(digitCount + 1);
-    result._setAt(0, MINUS_SIGN); // '-'.
-    int index = digitCount;
+    return _negativeToDigitString(result, negSmi, digitCount);
+   }
+
+  // Converts an smi <= -100 to a String. Result must be large enough for all
+  // of the digits plus the '-' sign. Index is the index for the smallest
+  // magnitude digit.
+  static String _negativeToDigitString(_OneByteString result, int negSmi,
+      int index) {
+    assert(negSmi <= -100);
+    const int MINUS_SIGN = 0x2d;
+    const int DIGIT_ZERO = 0x30;
+    result._setAt(0, MINUS_SIGN);
     do {
       var twoDigits = negSmi.remainder(100);
       negSmi = negSmi ~/ 100;


### PR DESCRIPTION
fixes #17622

This change is experimental, but I wanted to get some feedback before continuing. I haven't tested on mobile but on desktop its a pretty clear win in the integer case without a significant penalty in the non integer case.

Open question - if we want to go through with this, should we cache integer values?