### PR TITLE
Update dart_style to 1.0.6.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -61,7 +61,7 @@ vars = {
   "csslib_tag" : "@0.13.3+1",
   "dart2js_info_tag" : "@0.5.4+2",
   "dart_services_rev" : "@7aea2574e6f3924bf409a80afb8ad52aa2be4f97",
-  "dart_style_tag": "@1.0.5",
+  "dart_style_tag": "@1.0.6",
   "dartdoc_tag" : "@v0.9.14-dev",
   "fixnum_tag": "@0.10.5",
   "func_tag": "@1.0.0",


### PR DESCRIPTION
This brings in support for URIs in "part of" directives.