### PR TITLE
`new Widget` not `new widget`

### DIFF
--- a/pkg/analysis_server/lib/src/services/correction/assist_internal.dart
+++ b/pkg/analysis_server/lib/src/services/correction/assist_internal.dart
@@ -1736,7 +1736,7 @@ class AssistProcessor {
     sb.append(indentArg);
     sb.append('new ');
     sb.startPosition('WIDGET');
-    sb.append('widget');
+    sb.append('Widget');
     sb.endPosition();
     sb.append('(');
     sb.append(eol);
@@ -1767,7 +1767,7 @@ class AssistProcessor {
     SourceBuilder sb = new SourceBuilder(file, newExpr.offset);
     sb.append('new ');
     sb.startPosition('WIDGET');
-    sb.append('widget');
+    sb.append('Widget');
     sb.endPosition();
     sb.append('(');
     if (newExprSrc.contains(eol)) {


### PR DESCRIPTION
It seems like these two assists have a lot of work to be done on them, but I can at least fix these typos.