### PR TITLE
Fix inifinite loop in analysis server.

### DIFF
--- a/pkg/analysis_server/lib/src/plugin/plugin_watcher.dart
+++ b/pkg/analysis_server/lib/src/plugin/plugin_watcher.dart
@@ -132,8 +132,12 @@ class PluginWatcher implements DriverWatcher {
   String _getSdkPath(AnalysisDriver driver) {
     AbsolutePathContext context = resourceProvider.absolutePathContext;
     String sdkRoot = driver.sourceFactory.forUri('dart:core').fullName;
-    while (sdkRoot.isNotEmpty && context.basename(sdkRoot) != 'lib') {
-      sdkRoot = context.dirname(sdkRoot);
+    while (context.basename(sdkRoot) != 'lib') {
+      String parent = context.dirname(sdkRoot);
+      if (parent == sdkRoot) {
+        break;
+      }
+      sdkRoot = parent;
     }
     return sdkRoot;
   }


### PR DESCRIPTION
It was walking up a directory heirarchy looking for a directory named
"lib" but didn't terminate when it reached "/" without finding "lib".