### PR TITLE
Mark analyzer_cli/test/driver_test as slow.

### DIFF
--- a/pkg/pkg.status
+++ b/pkg/pkg.status
@@ -209,6 +209,8 @@ analyzer/test/src/task/strong/inferred_type_test: Pass, Slow
 [ $compiler == none ]
 kernel/test/closures_test: Fail
 
-[ $runtime == vm && $system == windows ]
+[ $runtime == vm ]
 analyzer_cli/test/driver_test: Pass, Slow
+
+[ $runtime == vm && $system == windows ]
 analyzer/test/src/task/strong/checker_test: Pass, Slow


### PR DESCRIPTION
This was already marked slow on Windows, but I saw a timeout on Linux as
well so it seems best to just mark it slow for all platforms.