### PR TITLE
Make it super clear that dart2js lives on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,8 +93,9 @@ entirely to allow inference to fill in the type.
 
       In practice what that means is you can edit your Dart files, refresh in
       Chrome (or other supported browsers), and see your edits almost
-      immediately. This is because pub is only recompiling your package, not all
-      packages that you depend on.
+      immediately. This fast edit-refresh cycle was previously only possible
+      in Dartium — now it's available everywhere. This is because pub is
+      only recompiling your package, not all packages that you depend on.
 
       There is one caveat with the new compiler, which is that your package and
       your dependencies must all be strong mode clean. If you are getting an
@@ -122,6 +123,10 @@ entirely to allow inference to fill in the type.
       quickly than you can with dart2js. In order to do that, run
       `pub serve test --web-compiler=dartdevc`, and then run
       `pub run test -p chrome --pub-serve=8080`.
+      
+      Note that `dart2js` is still the compiler you will use for production:
+      it produces much smaller and more performant code. The Dart Development
+      Compiler is for development.
 
     * The `--no-dart2js` flag has been deprecated in favor of
       `--web-compiler=none`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,7 +124,7 @@ entirely to allow inference to fill in the type.
       `pub serve test --web-compiler=dartdevc`, and then run
       `pub run test -p chrome --pub-serve=8080`.
       
-      Note that `dart2js` is still the compiler you will use for production:
+      Note that `dart2js` is still the recommended compiler for production:
       it produces much smaller and more performant code. The Dart Development
       Compiler is for development.
 


### PR DESCRIPTION
Also, for the benefit of newcomers, include blurb that explains that fast edit-refresh was previously possible, but only in Dartium.