### PR TITLE
Use "|" as the separator between module path and name.

### DIFF
--- a/pkg/dev_compiler/lib/src/analyzer/context.dart
+++ b/pkg/dev_compiler/lib/src/analyzer/context.dart
@@ -113,7 +113,7 @@ class AnalyzerOptions {
     return mappings;
   }
 
-  /// A summary path can contain ":" followed by an explicit module name to
+  /// A summary path can contain "|" followed by an explicit module name to
   /// allow working with summaries whose physical location is outside of the
   /// module root directory.
   ///
@@ -122,11 +122,11 @@ class AnalyzerOptions {
   void _parseCustomSummaryModules() {
     for (var i = 0; i < summaryPaths.length; i++) {
       var summaryPath = summaryPaths[i];
-      var comma = summaryPath.indexOf(":");
-      if (comma != -1) {
-        summaryPaths[i] = summaryPath.substring(0, comma);
+      var pipe = summaryPath.indexOf("|");
+      if (pipe != -1) {
+        summaryPaths[i] = summaryPath.substring(0, pipe);
         customSummaryModules[summaryPaths[i]] =
-            summaryPath.substring(comma + 1);
+            summaryPath.substring(pipe + 1);
       }
     }
   }

--- a/pkg/dev_compiler/lib/src/analyzer/context.dart
+++ b/pkg/dev_compiler/lib/src/analyzer/context.dart
@@ -113,7 +113,7 @@ class AnalyzerOptions {
     return mappings;
   }
 
-  /// A summary path can contain "|" followed by an explicit module name to
+  /// A summary path can contain "=" followed by an explicit module name to
   /// allow working with summaries whose physical location is outside of the
   /// module root directory.
   ///
@@ -122,7 +122,7 @@ class AnalyzerOptions {
   void _parseCustomSummaryModules() {
     for (var i = 0; i < summaryPaths.length; i++) {
       var summaryPath = summaryPaths[i];
-      var pipe = summaryPath.indexOf("|");
+      var pipe = summaryPath.indexOf("=");
       if (pipe != -1) {
         summaryPaths[i] = summaryPath.substring(0, pipe);
         customSummaryModules[summaryPaths[i]] =

--- a/pkg/dev_compiler/test/options/options_test.dart
+++ b/pkg/dev_compiler/test/options/options_test.dart
@@ -83,9 +83,9 @@ main() {
   test('custom module name for summary', () {
     var args = <String>[
       '-snormal',
-      '-scustom/path:module',
+      '-scustom/path|module',
       '-sanother',
-      '-scustom/path2:module2'
+      '-scustom/path2|module2'
     ];
 
     var argResults = ddcArgParser().parse(args);

--- a/pkg/dev_compiler/test/options/options_test.dart
+++ b/pkg/dev_compiler/test/options/options_test.dart
@@ -83,9 +83,9 @@ main() {
   test('custom module name for summary', () {
     var args = <String>[
       '-snormal',
-      '-scustom/path|module',
+      '-scustom/path=module',
       '-sanother',
-      '-scustom/path2|module2'
+      '--summary=custom/path2=module2'
     ];
 
     var argResults = ddcArgParser().parse(args);

--- a/tools/testing/dart/compiler_configuration.dart
+++ b/tools/testing/dart/compiler_configuration.dart
@@ -393,7 +393,7 @@ class DartdevcCompilerConfiguration extends CompilerConfiguration {
       // will tell require.js where to find each package's compiled JS.
       var summary = _configuration.buildDirectory +
           "/gen/utils/dartdevc/pkg/$package.sum";
-      args.add("$summary:$package");
+      args.add("$summary|$package");
     }
 
     return Command.compilation(Compiler.dartdevc.name, outputFile,

--- a/tools/testing/dart/compiler_configuration.dart
+++ b/tools/testing/dart/compiler_configuration.dart
@@ -393,7 +393,7 @@ class DartdevcCompilerConfiguration extends CompilerConfiguration {
       // will tell require.js where to find each package's compiled JS.
       var summary = _configuration.buildDirectory +
           "/gen/utils/dartdevc/pkg/$package.sum";
-      args.add("$summary|$package");
+      args.add("$summary=$package");
     }
 
     return Command.compilation(Compiler.dartdevc.name, outputFile,


### PR DESCRIPTION
":" is already a path character in Windows. This is why the
dartdevc tests aren't working on Windows. Because they try to do:

-sC:/some/path/blah.dart:blah

And it splits at the first ":". Oops.