### PR TITLE
Copy compiler_annotations.dart into dart2js tests.

### DIFF
--- a/tests/compiler/dart2js/compiler_annotations.dart
+++ b/tests/compiler/dart2js/compiler_annotations.dart
@@ -1,0 +1,12 @@
+// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+library compiler_annotations;
+
+// This library contains annotations useful for testing.
+
+// TODO(ngeoffray): Implement in dart2js.
+class DontInline {
+  const DontInline();
+}


### PR DESCRIPTION
I moved abstract_exact_selector_test from language into dart2js since
it appears to be a dart2js regression test and not an interesting test
of the language proper. It uses this little utility library which I
forgot to copy over.