### PR TITLE
Re-triage the DDC test statuses.

### DIFF
--- a/tests/corelib_strong/corelib_strong.status
+++ b/tests/corelib_strong/corelib_strong.status
@@ -52,7 +52,6 @@ symbol_test: Skip
 [ $compiler == dartdevc ]
 double_parse_test/01: RuntimeError # Issue 29921
 hash_set_test/01: RuntimeError # Issue 29921
-int_from_environment_test: RuntimeError # Issue 29921
 int_modulo_arith_test/bignum: RuntimeError # Issue 29921
 int_modulo_arith_test/modPow: RuntimeError # Issue 29921
 int_modulo_arith_test/none: RuntimeError # Issue 29921
@@ -111,8 +110,6 @@ regexp/stack-overflow_test: RuntimeError # Issue 29921
 regexp/unicode-handling_test: RuntimeError # Issue 29921
 regexp/zero-length-alternatives_test: RuntimeError # Issue 29921
 regress_r21715_test: RuntimeError # Issue 29921
-string_from_environment2_test: RuntimeError # Issue 29921
-string_from_environment_test: RuntimeError # Issue 29921
 string_operations_with_null_test: RuntimeError # Issue 29921
 string_trimlr_test/01: RuntimeError # Issue 29921
 string_trimlr_test/none: RuntimeError # Issue 29921

--- a/tests/language_strong/enum_duplicate_test.dart
+++ b/tests/language_strong/enum_duplicate_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// SharedOptions=--enable-enum
-
 // Test for duplicate enums.
 
 library enum_duplicate_test;

--- a/tests/language_strong/enum_index_test.dart
+++ b/tests/language_strong/enum_index_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// SharedOptions=--enable-enum
-
 // Test index access for enums.
 
 library enum_index_test;

--- a/tests/language_strong/enum_mirror_test.dart
+++ b/tests/language_strong/enum_mirror_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// SharedOptions=--enable-enum
-
 import 'dart:mirrors';
 
 import 'package:expect/expect.dart';

--- a/tests/language_strong/enum_private_test.dart
+++ b/tests/language_strong/enum_private_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// SharedOptions=--enable-enum
-
 // Test privacy issue for enums.
 
 library enum_private_test;

--- a/tests/language_strong/enum_syntax_test.dart
+++ b/tests/language_strong/enum_syntax_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// SharedOptions=--enable-enum
-
 // Basic syntax test for enumeration types
 
 import 'package:expect/expect.dart';

--- a/tests/language_strong/enum_test.dart
+++ b/tests/language_strong/enum_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// SharedOptions=--enable-enum
-
 import 'package:expect/expect.dart';
 
 enum Enum1 { _ }

--- a/tests/language_strong/enum_value_name_test.dart
+++ b/tests/language_strong/enum_value_name_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// SharedOptions=--enable-enum
-
 import 'package:expect/expect.dart';
 
 enum ErrorContext { general, name, description, targets }

--- a/tests/language_strong/language_strong.status
+++ b/tests/language_strong/language_strong.status
@@ -720,7 +720,6 @@ async_star_test/05: RuntimeError # Issue 28969
 async_star_test/none: RuntimeError # Issue 28969
 asyncstar_throw_in_catch_test: Timeout # Issue 29920
 await_future_test: Pass, Timeout # Issue 29920
-bad_raw_string_test/03: MissingCompileTimeError # Issue 29920
 bit_operations_test/01: RuntimeError # No bigints on web.
 bit_operations_test/02: RuntimeError # No bigints on web.
 bit_operations_test/03: RuntimeError # No bigints on web.
@@ -728,7 +727,6 @@ bit_operations_test/04: RuntimeError # No bigints on web.
 bit_operations_test/none: RuntimeError # No bigints on web.
 branch_canonicalization_test: RuntimeError # Issue 29920
 call_closurization_test: RuntimeError # Issue 29920
-call_with_no_such_method_test: RuntimeError # Function.apply not really implemented.
 canonical_const2_test: RuntimeError # Ints and doubles are unified.
 canonical_const_test: RuntimeError # Ints and doubles are unified.
 compile_time_constant_a_test: RuntimeError # Allows mutating const map.


### PR DESCRIPTION
- The other fromEnvironment() tests are passing now. (I must have
  missed those earlier.)
- Couple of other tests are compiling.
- Remove "--enable-enum" from the SharedOptions since those are being
  passed to DDC now and it doesn't know what that means. Also, uh,
  enums have been enabled for years...