### PR TITLE
Fix documentation of Uint32List and Uint64List

### DIFF
--- a/sdk/lib/typed_data/typed_data.dart
+++ b/sdk/lib/typed_data/typed_data.dart
@@ -913,7 +913,7 @@ abstract class Int16List implements List<int>, TypedData {
  *
  * Integers stored in the list are truncated to their low 16 bits,
  * interpreted as an unsigned 16-bit integer with values in the
- * range 0 to 65536.
+ * range 0 to 65535.
  */
 abstract class Uint16List implements List<int>, TypedData {
   /**
@@ -1123,7 +1123,7 @@ abstract class Int64List implements List<int>, TypedData {
  *
  * Integers stored in the list are truncated to their low 64 bits,
  * interpreted as an unsigned 64-bit integer with values in the
- * range 0 to 18446744073709551616.
+ * range 0 to 18446744073709551615.
  */
 abstract class Uint64List implements List<int>, TypedData {
   /**


### PR DESCRIPTION
The currently documented max value is 2^n, but since 0 should be counted too the actual max value is only 2^n - 1.