### PR TITLE
Load exception

### DIFF
--- a/pkg/dev_compiler/lib/js/legacy/dart_library.js
+++ b/pkg/dev_compiler/lib/js/legacy/dart_library.js
@@ -14,6 +14,10 @@ dart_library =
 
   /** Note that we cannot use dart_utils.throwInternalError from here. */
   function throwLibraryError(message) {
+    // Dispatch event to allow others to react to the load error without
+    // capturing the exception.
+    var errorEvent = new CustomEvent('dartLoadException', { detail: message });
+    window.dispatchEvent(errorEvent);
     throw Error(message);
   }
 


### PR DESCRIPTION
Dispatch load exception so that others can react without capturing the corresponding error. Will be used in conjunction with https://github.com/dart-lang/test/pull/682