### PR TITLE
Fix typo's

### DIFF
--- a/docs/newsletter/20170915.md
+++ b/docs/newsletter/20170915.md
@@ -296,9 +296,9 @@ class A {
 
 In this example, some other function is testing for the value of the `isDoingRequest`. If that field is set to false, it invokes `doRequest`, which, in the first line, sets the value to `true`. However, because of the asynchronous start, the field is not set immediately, but only in the next microtask. This means that other calls to foo might still see the `isDoingRequest` as `false` and initiate more requests.
 
-This mistake can happen easily when switching from synchronous functions to `async` functions. The code is much easier to read, but the additional delay could introduce substle bugs.
+This mistake can happen easily when switching from synchronous functions to `async` functions. The code is much easier to read, but the additional delay could introduce subtle bugs.
 
-Running synchronously also brings Dart in line with other languages, like Ecmascript. `<footnote>`C# also executes the body of async functions synchronously. However, C# doesn't guarantee, that `await` always yields. If a `Task` (the equivalent class for `Future`) is already completed, C# code may immediately continue running at the `await` point.`</footnote>
+Running synchronously also brings Dart in line with other languages, like Ecmascript. `<footnote>`C# also executes the body of async functions synchronously. However, C# doesn't guarantee, that `await` always yields. If a `Task` (the equivalent class for `Future`) is already completed, C# code may immediately continue running at the `await` point.`</footnote>`
 
 ### Required Changes
 Switching to synchronous starts of `async` functions requires changes in the specification and in our tools.


### PR DESCRIPTION
substle => subtle, added missing backtick after </footnote>