### PR TITLE
Add noImplement annotation

### DIFF
--- a/pkg/meta/lib/meta.dart
+++ b/pkg/meta/lib/meta.dart
@@ -130,6 +130,22 @@ const _Literal literal = const _Literal();
 ///   without invoking the overridden method.
 const _MustCallSuper mustCallSuper = const _MustCallSuper();
 
+/// Used to annotate a class that may not be no consumed as an interface.
+///
+/// This is useful because changes that would result in minor version
+/// increments require major version increments when applied to interfaces
+/// so packages may want to prevent consumers from implementing certain
+/// classes in order to protect semantic version guarantees.
+///
+/// Tools, such as the analyzer, can provide feedback if
+///
+/// * the annotation is associated with anything other than a class declaration
+/// * a class that has this annotation is used, either directly or
+///   transitively, as an interface (using `implements`)
+///
+/// At this time the analyzer does not enforce this annotation.
+const _NoImplement noImplement = const _NoImplement();
+
 /// Used to annotate a class declaration `C`. Indicates that any type arguments
 /// declared on `C` are to be treated as optional.  Tools such as the analyzer
 /// and linter can use this information to suppress warnings that would
@@ -247,6 +263,10 @@ class _Literal {
 
 class _MustCallSuper {
   const _MustCallSuper();
+}
+
+class _NoImplement {
+  const _NoImplement();
 }
 
 class _OptionalTypeArgs {

--- a/pkg/meta/lib/meta.dart
+++ b/pkg/meta/lib/meta.dart
@@ -130,7 +130,7 @@ const _Literal literal = const _Literal();
 ///   without invoking the overridden method.
 const _MustCallSuper mustCallSuper = const _MustCallSuper();
 
-/// Used to annotate a class that may not be no consumed as an interface.
+/// Used to annotate a class that may not be consumed as an interface.
 ///
 /// This is useful because changes that would result in minor version
 /// increments require major version increments when applied to interfaces

--- a/pkg/meta/lib/meta.dart
+++ b/pkg/meta/lib/meta.dart
@@ -142,8 +142,6 @@ const _MustCallSuper mustCallSuper = const _MustCallSuper();
 /// * the annotation is associated with anything other than a class declaration
 /// * a class that has this annotation is used, either directly or
 ///   transitively, as an interface (using `implements`)
-///
-/// At this time the analyzer does not enforce this annotation.
 const _NoImplement noImplement = const _NoImplement();
 
 /// Used to annotate a class declaration `C`. Indicates that any type arguments


### PR DESCRIPTION
We use this with an internal tool to guard against accidental API mis-use which can occur due to the fact that Dart permits any class to be used as an interface. If a class that is consumed as an interface then adding an additional method to that class causes a breaking change but may look like a minor version increment from the standpoint of the package author.

We thought it might be nice to have in a more central location (right now it lives with the tool, which is awkward) and figured we'd try here first.