### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,7 +159,7 @@
   assuming the declaration `int x;`, it is now type correct to have
   `void f() => ++x;`.
 
-* A new function-type syntax has been added to the language.
+* (**warning: not stable in Analyzer**) A new function-type syntax has been added to the language.
   Intuitively, the type of a function can be constructed by textually replacing
   the function's name with `Function` in its declaration. For instance, the
   type of `void foo() {}` would be `void Function()`. The new syntax may be used


### PR DESCRIPTION
Include a warning about the unstable status of the new function-type syntax mentioned in 1.24.0