### PR TITLE
Fix typo in exponent representation example

### DIFF
--- a/docs/newsletter/20171013.md
+++ b/docs/newsletter/20171013.md
@@ -34,7 +34,7 @@ In this section I will focus on Dart's `toString` methods of `double`. There are
 - `toStringAsFixed`
 - `toStringAsPrecision`
 
-The `double.toString` method is the most commonly used way of converting a double to a string. It uses a mixture of `toStringAsExponential` and `toStringAsFixed` to provide the most visibly appealing output. For large numbers (more than 20 digits) it emits an exponential representation as in `1.3e+21`. The same is true for very small floating-point numbers, strictly smaller than the one represented by `0.000001`. For example  `0.000000998` is printed as `0.98e-7`. All other numbers are printed in the "normal" decimal representation: `5.0`, `1.23`, or `0.001`.
+The `double.toString` method is the most commonly used way of converting a double to a string. It uses a mixture of `toStringAsExponential` and `toStringAsFixed` to provide the most visibly appealing output. For large numbers (more than 20 digits) it emits an exponential representation as in `1.3e+21`. The same is true for very small floating-point numbers, strictly smaller than the one represented by `0.000001`. For example  `0.000000998` is printed as `9.98e-7`. All other numbers are printed in the "normal" decimal representation: `5.0`, `1.23`, or `0.001`.
 
 The other methods just force a specific representation. I encourage readers to experiment with them, but I won't explain them in this section.
 


### PR DESCRIPTION
> `0.000000998` is printed as `0.98e-7`

I believe, that there is a typo and `0` should read as `9` as `0.000000998` would be typically represented as `9.98e-7`.

/cc @bkonyi 