### PR TITLE
Fix dart:collection library link in docs

### DIFF
--- a/sdk/lib/core/core.dart
+++ b/sdk/lib/core/core.dart
@@ -101,7 +101,8 @@
  * and used by Map for its keys and values.
  *
  * For other kinds of collections, check out the
- * [dart:collection](#dart-collection) library.
+ * [dart:collection](https://api.dartlang.org/stable/dart-collection/dart-collection-library.html)
+ * library.
  *
  * ## Date and time
  *

--- a/sdk/lib/core/iterable.dart
+++ b/sdk/lib/core/iterable.dart
@@ -38,7 +38,8 @@ part of dart.core;
  *     }
  *
  * The [List] and [Set] classes are both `Iterable`,
- * as are most classes in the [dart:collection](#dart-collection) library.
+ * as are most classes in the [dart:collection](https://api.dartlang.org/stable/dart-collection/dart-collection-library.html)
+ * library.
  *
  * Some [Iterable] collections can be modified.
  * Adding an element to a `List` or `Set` will change which elements it


### PR DESCRIPTION
Addresses #31246 by fixing the link to the `dart:library` in the docs of the `dart:core` library and `Iterable` class.