### PR TITLE
tools/addlatexhash.dart: Remove unused import

### DIFF
--- a/tools/addlatexhash.dart
+++ b/tools/addlatexhash.dart
@@ -25,7 +25,6 @@
 // source file receieved as input; it will not work with other styles.
 
 import 'dart:io';
-import 'dart:convert';
 
 import 'package:crypto/crypto.dart';
 import 'package:convert/convert.dart';


### PR DESCRIPTION
... as reported by the 2-dev.19 analyzer:

```nocode
info: Unused import. (unused_import at [tools] addlatexhash.dart:28)
```

cc @kwalrath 