### PR TITLE
Increase analysis server version to 1.18.5.

### DIFF
--- a/pkg/analysis_server/doc/api.html
+++ b/pkg/analysis_server/doc/api.html
@@ -109,7 +109,7 @@ a:focus, a:hover {
 <body>
 <h1>Analysis Server API Specification</h1>
 <h1 style="color:#999999">Version
-  1.18.4
+  1.18.5
 </h1>
 <p>
   This document contains a specification of the API provided by the

--- a/pkg/analysis_server/lib/src/analysis_server.dart
+++ b/pkg/analysis_server/lib/src/analysis_server.dart
@@ -108,7 +108,7 @@ class AnalysisServer {
    * The version of the analysis server. The value should be replaced
    * automatically during the build.
    */
-  static final String VERSION = '1.18.4';
+  static final String VERSION = '1.18.5';
 
   /**
    * The options of this server instance.

--- a/pkg/analysis_server/tool/spec/spec_input.html
+++ b/pkg/analysis_server/tool/spec/spec_input.html
@@ -7,7 +7,7 @@
 <body>
 <h1>Analysis Server API Specification</h1>
 <h1 style="color:#999999">Version
-  <version>1.18.4</version>
+  <version>1.18.5</version>
 </h1>
 <p>
   This document contains a specification of the API provided by the


### PR DESCRIPTION
The version hasn't been increased since the server started accepting overlays for HTML files (for angular plugin) so this is to allow editors to know for sure that the server supports them.