### PR TITLE
Convert paths for mock SDK libraries to fix tests on Windows

### DIFF
--- a/pkg/analysis_server/test/analysis/get_errors_test.dart
+++ b/pkg/analysis_server/test/analysis/get_errors_test.dart
@@ -44,8 +44,8 @@ main() {
   }
 
   test_errorInPart() async {
-    String libPath = '$testFolder/main.dart';
-    String partPath = '$testFolder/main_part.dart';
+    String libPath = join(testFolder, 'main.dart');
+    String partPath = join(testFolder, 'main_part.dart');
     newFile(libPath, content: r'''
 library main;
 part 'main_part.dart';

--- a/pkg/analysis_server/test/analysis/notification_errors_test.dart
+++ b/pkg/analysis_server/test/analysis/notification_errors_test.dart
@@ -45,8 +45,8 @@ class NotificationErrorsTest extends AbstractAnalysisTest {
   }
 
   test_analysisOptionsFile() async {
-    String analysisOptionsFile =
-        newFile('$projectPath/analysis_options.yaml', content: '''
+    String filePath = join(projectPath, 'analysis_options.yaml');
+    String analysisOptionsFile = newFile(filePath, content: '''
 linter:
   rules:
     - invalid_lint_rule_name
@@ -63,7 +63,7 @@ linter:
     List<AnalysisError> errors = filesErrors[analysisOptionsFile];
     expect(errors, hasLength(1));
     AnalysisError error = errors[0];
-    expect(error.location.file, '/project/analysis_options.yaml');
+    expect(error.location.file, filePath);
     expect(error.severity, AnalysisErrorSeverity.WARNING);
     expect(error.type, AnalysisErrorType.STATIC_WARNING);
   }
@@ -89,7 +89,7 @@ import 'does_not_exist.dart';
   test_lintError() async {
     var camelCaseTypesLintName = 'camel_case_types';
 
-    newFile('$projectPath/.analysis_options', content: '''
+    newFile(join(projectPath, '.analysis_options'), content: '''
 linter:
   rules:
     - $camelCaseTypesLintName
@@ -115,7 +115,7 @@ linter:
     List<AnalysisError> errors = filesErrors[testFile];
     expect(errors, hasLength(1));
     AnalysisError error = errors[0];
-    expect(error.location.file, '/project/bin/test.dart');
+    expect(error.location.file, join(projectPath, 'bin', 'test.dart'));
     expect(error.severity, AnalysisErrorSeverity.INFO);
     expect(error.type, AnalysisErrorType.LINT);
     expect(error.message, lint.description);
@@ -142,7 +142,7 @@ main() {
     List<AnalysisError> errors = filesErrors[testFile];
     expect(errors, hasLength(1));
     AnalysisError error = errors[0];
-    expect(error.location.file, '/project/bin/test.dart');
+    expect(error.location.file, join(projectPath, 'bin', 'test.dart'));
     expect(error.location.offset, isPositive);
     expect(error.location.length, isNonNegative);
     expect(error.severity, AnalysisErrorSeverity.ERROR);
@@ -151,7 +151,8 @@ main() {
   }
 
   test_pubspecFile() async {
-    String pubspecFile = newFile('$projectPath/pubspec.yaml', content: '''
+    String filePath = join(projectPath, 'pubspec.yaml');
+    String pubspecFile = newFile(filePath, content: '''
 version: 1.3.2
 ''').path;
 
@@ -166,7 +167,7 @@ version: 1.3.2
     List<AnalysisError> errors = filesErrors[pubspecFile];
     expect(errors, hasLength(1));
     AnalysisError error = errors[0];
-    expect(error.location.file, '/project/pubspec.yaml');
+    expect(error.location.file, filePath);
     expect(error.severity, AnalysisErrorSeverity.WARNING);
     expect(error.type, AnalysisErrorType.STATIC_WARNING);
     //

--- a/pkg/analysis_server/test/analysis/notification_highlights_test.dart
+++ b/pkg/analysis_server/test/analysis/notification_highlights_test.dart
@@ -956,7 +956,7 @@ class A<T> {
   }
 
   void _addLibraryForTestPart() {
-    newFile('$testFolder/my_lib.dart', content: '''
+    newFile(join(testFolder, 'my_lib.dart'), content: '''
 library lib;
 part 'test.dart';
     ''');

--- a/pkg/analysis_server/test/analysis/notification_highlights_test2.dart
+++ b/pkg/analysis_server/test/analysis/notification_highlights_test2.dart
@@ -1107,7 +1107,7 @@ class A {
   }
 
   void _addLibraryForTestPart() {
-    newFile('$testFolder/my_lib.dart', content: '''
+    newFile(join(testFolder, 'my_lib.dart'), content: '''
 library lib;
 part 'test.dart';
     ''');

--- a/pkg/analysis_server/test/analysis/notification_implemented_test.dart
+++ b/pkg/analysis_server/test/analysis/notification_implemented_test.dart
@@ -271,7 +271,7 @@ class C extends A {
   }
 
   test_method_withMethod_private_differentLib() async {
-    newFile('$testFolder/lib.dart', content: r'''
+    newFile(join(testFolder, 'lib.dart'), content: r'''
 import 'test.dart';
 class B extends A {
   void _m() {}

--- a/pkg/analysis_server/test/analysis/notification_navigation_test.dart
+++ b/pkg/analysis_server/test/analysis/notification_navigation_test.dart
@@ -229,7 +229,7 @@ main() {
   }
 
   test_annotationConstructor_importPrefix() async {
-    newFile('$testFolder/my_annotation.dart', content: r'''
+    newFile(join(testFolder, 'my_annotation.dart'), content: r'''
 library an;
 class MyAnnotation {
   const MyAnnotation();
@@ -304,7 +304,7 @@ main() {
   }
 
   test_annotationField_importPrefix() async {
-    newFile('$testFolder/mayn.dart', content: r'''
+    newFile(join(testFolder, 'mayn.dart'), content: r'''
 library an;
 const myan = new Object();
 ''');

--- a/pkg/analysis_server/test/analysis/notification_overrides_test.dart
+++ b/pkg/analysis_server/test/analysis/notification_overrides_test.dart
@@ -232,7 +232,7 @@ class B extends A {
   }
 
   test_BAD_privateByPrivate_inDifferentLib() async {
-    newFile('$testFolder/lib.dart', content: r'''
+    newFile(join(testFolder, 'lib.dart'), content: r'''
 class A {
   void _m() {}
 }

--- a/pkg/analysis_server/test/analysis/update_content_test.dart
+++ b/pkg/analysis_server/test/analysis/update_content_test.dart
@@ -61,8 +61,8 @@ class UpdateContentTest extends AbstractAnalysisTest {
   }
 
   test_multiple_contexts() async {
-    String project1path = resourceProvider.convertPath('/project1');
-    String project2path = resourceProvider.convertPath('/project2');
+    String project1path = convertPath('/project1');
+    String project2path = convertPath('/project2');
     String fooPath = newFile('/project1/foo.dart', content: '''
 library foo;
 import '../project2/baz.dart';
@@ -128,7 +128,7 @@ f() {}
   }
 
   test_overlayOnly() async {
-    String filePath = resourceProvider.convertPath('/User/project1/test.dart');
+    String filePath = convertPath('/User/project1/test.dart');
     Folder folder1 = newFolder('/User/project1');
     Folder folder2 = newFolder('/User/project2');
     Request request =
@@ -256,7 +256,7 @@ f() {}
   List<String> _getUserSources(AnalysisDriver driver) {
     List<String> sources = <String>[];
     driver.addedFiles.forEach((path) {
-      if (path.startsWith(resourceProvider.convertPath('/User/'))) {
+      if (path.startsWith(convertPath('/User/'))) {
         sources.add(path);
       }
     });

--- a/pkg/analysis_server/test/analysis/update_content_test.dart
+++ b/pkg/analysis_server/test/analysis/update_content_test.dart
@@ -61,6 +61,8 @@ class UpdateContentTest extends AbstractAnalysisTest {
   }
 
   test_multiple_contexts() async {
+    String project1path = resourceProvider.convertPath('/project1');
+    String project2path = resourceProvider.convertPath('/project2');
     String fooPath = newFile('/project1/foo.dart', content: '''
 library foo;
 import '../project2/baz.dart';
@@ -74,7 +76,7 @@ library baz;
 f(int i) {}
 ''').path;
     Request request =
-        new AnalysisSetAnalysisRootsParams(['/project1', '/project2'], [])
+        new AnalysisSetAnalysisRootsParams([project1path, project2path], [])
             .toRequest('0');
     handleSuccessfulRequest(request);
     {
@@ -126,7 +128,7 @@ f() {}
   }
 
   test_overlayOnly() async {
-    String filePath = '/User/project1/test.dart';
+    String filePath = resourceProvider.convertPath('/User/project1/test.dart');
     Folder folder1 = newFolder('/User/project1');
     Folder folder2 = newFolder('/User/project2');
     Request request =
@@ -254,7 +256,7 @@ f() {}
   List<String> _getUserSources(AnalysisDriver driver) {
     List<String> sources = <String>[];
     driver.addedFiles.forEach((path) {
-      if (path.startsWith('/User/')) {
+      if (path.startsWith(resourceProvider.convertPath('/User/'))) {
         sources.add(path);
       }
     });

--- a/pkg/analysis_server/test/analysis_abstract.dart
+++ b/pkg/analysis_server/test/analysis_abstract.dart
@@ -101,6 +101,30 @@ class AbstractAnalysisTest extends Object with ResourceProviderMixin {
     return testFile;
   }
 
+  /// Joins the given path parts into a single path. Example:
+  ///
+  ///     context.join('path', 'to', 'foo'); // -> 'path/to/foo'
+  ///
+  /// If any part ends in a path separator, then a redundant separator will not
+  /// be added:
+  ///
+  ///     context.join('path/', 'to', 'foo'); // -> 'path/to/foo
+  ///
+  /// If a part is an absolute path, then anything before that will be ignored:
+  ///
+  ///     context.join('path', '/to', 'foo'); // -> '/to/foo'
+  ///
+  String join(String part1,
+          [String part2,
+          String part3,
+          String part4,
+          String part5,
+          String part6,
+          String part7,
+          String part8]) =>
+      resourceProvider.pathContext
+          .join(part1, part2, part3, part4, part5, part6, part7, part8);
+
   AnalysisServer createAnalysisServer() {
     //
     // Process plugins

--- a/pkg/analysis_server/test/analysis_abstract.dart
+++ b/pkg/analysis_server/test/analysis_abstract.dart
@@ -101,30 +101,6 @@ class AbstractAnalysisTest extends Object with ResourceProviderMixin {
     return testFile;
   }
 
-  /// Joins the given path parts into a single path. Example:
-  ///
-  ///     context.join('path', 'to', 'foo'); // -> 'path/to/foo'
-  ///
-  /// If any part ends in a path separator, then a redundant separator will not
-  /// be added:
-  ///
-  ///     context.join('path/', 'to', 'foo'); // -> 'path/to/foo
-  ///
-  /// If a part is an absolute path, then anything before that will be ignored:
-  ///
-  ///     context.join('path', '/to', 'foo'); // -> '/to/foo'
-  ///
-  String join(String part1,
-          [String part2,
-          String part3,
-          String part4,
-          String part5,
-          String part6,
-          String part7,
-          String part8]) =>
-      resourceProvider.pathContext
-          .join(part1, part2, part3, part4, part5, part6, part7, part8);
-
   AnalysisServer createAnalysisServer() {
     //
     // Process plugins

--- a/pkg/analysis_server/test/analysis_server_test.dart
+++ b/pkg/analysis_server/test/analysis_server_test.dart
@@ -99,7 +99,7 @@ class AnalysisServerTest extends Object with ResourceProviderMixin {
         resourceProvider,
         packageMapProvider,
         new AnalysisServerOptions(),
-        new DartSdkManager('/', false),
+        new DartSdkManager(resourceProvider.convertPath('/'), false),
         InstrumentationService.NULL_SERVICE);
   }
 

--- a/pkg/analysis_server/test/analysis_server_test.dart
+++ b/pkg/analysis_server/test/analysis_server_test.dart
@@ -115,7 +115,6 @@ class AnalysisServerTest extends Object with ResourceProviderMixin {
   Future test_serverStatusNotifications() {
     server.serverServices.add(ServerService.STATUS);
     var pkgFolder = resourceProvider.convertPath('/pkg');
-    print(pkgFolder);
     newFolder(pkgFolder);
     newFolder(resourceProvider.pathContext.join(pkgFolder, 'lib'));
     newFile(resourceProvider.pathContext.join(pkgFolder, 'lib', 'test.dart'),

--- a/pkg/analysis_server/test/analysis_server_test.dart
+++ b/pkg/analysis_server/test/analysis_server_test.dart
@@ -114,10 +114,13 @@ class AnalysisServerTest extends Object with ResourceProviderMixin {
 
   Future test_serverStatusNotifications() {
     server.serverServices.add(ServerService.STATUS);
-    newFolder('/pkg');
-    newFolder('/pkg/lib');
-    newFile('/pkg/lib/test.dart', content: 'class C {}');
-    server.setAnalysisRoots('0', ['/pkg'], [], {});
+    var pkgFolder = resourceProvider.convertPath('/pkg');
+    print(pkgFolder);
+    newFolder(pkgFolder);
+    newFolder(resourceProvider.pathContext.join(pkgFolder, 'lib'));
+    newFile(resourceProvider.pathContext.join(pkgFolder, 'lib', 'test.dart'),
+        content: 'class C {}');
+    server.setAnalysisRoots('0', [pkgFolder], [], {});
     // Pump the event queue to make sure the server has finished any
     // analysis.
     return pumpEventQueue(times: 5000).then((_) {

--- a/pkg/analysis_server/test/analysis_server_test.dart
+++ b/pkg/analysis_server/test/analysis_server_test.dart
@@ -99,7 +99,7 @@ class AnalysisServerTest extends Object with ResourceProviderMixin {
         resourceProvider,
         packageMapProvider,
         new AnalysisServerOptions(),
-        new DartSdkManager(resourceProvider.convertPath('/'), false),
+        new DartSdkManager(convertPath('/'), false),
         InstrumentationService.NULL_SERVICE);
   }
 
@@ -114,10 +114,10 @@ class AnalysisServerTest extends Object with ResourceProviderMixin {
 
   Future test_serverStatusNotifications() {
     server.serverServices.add(ServerService.STATUS);
-    var pkgFolder = resourceProvider.convertPath('/pkg');
+    var pkgFolder = convertPath('/pkg');
     newFolder(pkgFolder);
-    newFolder(resourceProvider.pathContext.join(pkgFolder, 'lib'));
-    newFile(resourceProvider.pathContext.join(pkgFolder, 'lib', 'test.dart'),
+    newFolder(join(pkgFolder, 'lib'));
+    newFile(join(pkgFolder, 'lib', 'test.dart'),
         content: 'class C {}');
     server.setAnalysisRoots('0', [pkgFolder], [], {});
     // Pump the event queue to make sure the server has finished any

--- a/pkg/analysis_server/test/context_manager_test.dart
+++ b/pkg/analysis_server/test/context_manager_test.dart
@@ -144,6 +144,7 @@ test_pack:lib/''');
   }
 
   test_embedder_packagespec() async {
+    final convertPath = resourceProvider.convertPath;
     // Create files.
     String libPath = '$projPath/${ContextManagerTest.LIB_NAME}';
     newFile('$libPath/main.dart');
@@ -171,7 +172,7 @@ test_pack:lib/''');
     expect(count, equals(1));
     var source = sourceFactory.forUri('dart:foobar');
     expect(source, isNotNull);
-    expect(source.fullName, '/my/proj/sdk_ext/entry.dart');
+    expect(source.fullName, convertPath('/my/proj/sdk_ext/entry.dart'));
     // We can't find dart:core because we didn't list it in our
     // embedded_libs map.
     expect(sourceFactory.forUri('dart:core'), isNull);
@@ -199,16 +200,18 @@ test_pack:lib/''');
   }
 
   void test_isInAnalysisRoot_excluded() {
+    final convertPath = resourceProvider.convertPath;
     // prepare paths
-    String project = '/project';
-    String excludedFolder = '$project/excluded';
+    String project = convertPath('/project');
+    String excludedFolder = convertPath('$project/excluded');
     // set roots
     resourceProvider.newFolder(project);
     resourceProvider.newFolder(excludedFolder);
     manager.setRoots(
         <String>[project], <String>[excludedFolder], <String, String>{});
     // verify
-    expect(manager.isInAnalysisRoot('$excludedFolder/test.dart'), isFalse);
+    expect(manager.isInAnalysisRoot(convertPath('$excludedFolder/test.dart')),
+        isFalse);
   }
 
   void test_isInAnalysisRoot_inNestedContext() {
@@ -260,7 +263,8 @@ test_pack:lib/''');
     // Verify that ignored files were ignored.
     Iterable<String> filePaths = callbacks.currentFilePaths;
     expect(filePaths, hasLength(1));
-    expect(filePaths, contains('/my/proj/lib/main.dart'));
+    expect(filePaths,
+        contains(resourceProvider.convertPath('/my/proj/lib/main.dart')));
   }
 
   test_refresh_folder_with_packagespec() {
@@ -283,12 +287,13 @@ test_pack:lib/''');
   // Once http://dartbug.com/23909 is fixed, add a test for sdk extensions
   // and PackageMapDisposition.
   test_refresh_folder_with_packagespec_subfolders() {
+    final join = resourceProvider.pathContext.join;
     // Create a folder with no .packages file, containing two subfolders with
     // .packages files.
-    String subdir1Path = path.posix.join(projPath, 'subdir1');
-    String subdir2Path = path.posix.join(projPath, 'subdir2');
-    String packagespec1Path = path.posix.join(subdir1Path, '.packages');
-    String packagespec2Path = path.posix.join(subdir2Path, '.packages');
+    String subdir1Path = join(projPath, 'subdir1');
+    String subdir2Path = join(projPath, 'subdir2');
+    String packagespec1Path = join(subdir1Path, '.packages');
+    String packagespec2Path = join(subdir2Path, '.packages');
     resourceProvider.newFile(packagespec1Path, '');
     resourceProvider.newFile(packagespec2Path, '');
     manager.setRoots(<String>[projPath], <String>[], <String, String>{});
@@ -324,12 +329,13 @@ test_pack:lib/''');
   }
 
   test_refresh_folder_with_pubspec_subfolders() {
+    final join = resourceProvider.pathContext.join;
     // Create a folder with no pubspec.yaml, containing two subfolders with
     // pubspec.yaml files.
-    String subdir1Path = path.posix.join(projPath, 'subdir1');
-    String subdir2Path = path.posix.join(projPath, 'subdir2');
-    String pubspec1Path = path.posix.join(subdir1Path, 'pubspec.yaml');
-    String pubspec2Path = path.posix.join(subdir2Path, 'pubspec.yaml');
+    String subdir1Path = join(projPath, 'subdir1');
+    String subdir2Path = join(projPath, 'subdir2');
+    String pubspec1Path = join(subdir1Path, 'pubspec.yaml');
+    String pubspec2Path = join(subdir2Path, 'pubspec.yaml');
     resourceProvider.newFile(pubspec1Path, 'pubspec');
     resourceProvider.newFile(pubspec2Path, 'pubspec');
     manager.setRoots(<String>[projPath], <String>[], <String, String>{});
@@ -349,13 +355,15 @@ test_pack:lib/''');
   }
 
   test_refresh_oneContext() {
+    final convertPath = resourceProvider.convertPath;
+    final join = resourceProvider.pathContext.join;
     // create two contexts with pubspec.yaml files
-    String pubspecPath = path.posix.join(projPath, 'pubspec.yaml');
+    String pubspecPath = join(projPath, 'pubspec.yaml');
     resourceProvider.newFile(pubspecPath, 'pubspec1');
 
-    String proj2Path = '/my/proj2';
+    String proj2Path = convertPath('/my/proj2');
     resourceProvider.newFolder(proj2Path);
-    String pubspec2Path = path.posix.join(proj2Path, 'pubspec.yaml');
+    String pubspec2Path = join(proj2Path, 'pubspec.yaml');
     resourceProvider.newFile(pubspec2Path, 'pubspec2');
 
     List<String> roots = <String>[projPath, proj2Path];
@@ -398,11 +406,12 @@ test_pack:lib/''');
         .numberOfContextsInAnalysisRoot(resourceProvider.newFolder(projPath));
     expect(count, equals(1));
     var source = sourceFactory.forUri('dart:foobar');
-    expect(source.fullName, equals('/my/proj/sdk_ext/entry.dart'));
+    expect(source.fullName,
+        equals(resourceProvider.convertPath('/my/proj/sdk_ext/entry.dart')));
   }
 
   void test_setRoots_addFolderWithDartFile() {
-    String filePath = path.posix.join(projPath, 'foo.dart');
+    String filePath = resourceProvider.pathContext.join(projPath, 'foo.dart');
     resourceProvider.newFile(filePath, 'contents');
     manager.setRoots(<String>[projPath], <String>[], <String, String>{});
     // verify
@@ -418,7 +427,8 @@ test_pack:lib/''');
   }
 
   void test_setRoots_addFolderWithDartFileInSubfolder() {
-    String filePath = path.posix.join(projPath, 'foo', 'bar.dart');
+    String filePath =
+        resourceProvider.pathContext.join(projPath, 'foo', 'bar.dart');
     resourceProvider.newFile(filePath, 'contents');
     manager.setRoots(<String>[projPath], <String>[], <String, String>{});
     // verify
@@ -428,7 +438,7 @@ test_pack:lib/''');
   }
 
   void test_setRoots_addFolderWithDummyLink() {
-    String filePath = path.posix.join(projPath, 'foo.dart');
+    String filePath = resourceProvider.pathContext.join(projPath, 'foo.dart');
     resourceProvider.newDummyLink(filePath);
     manager.setRoots(<String>[projPath], <String>[], <String, String>{});
     // verify
@@ -436,8 +446,11 @@ test_pack:lib/''');
   }
 
   void test_setRoots_addFolderWithNestedPackageSpec() {
-    String examplePath = '$projPath/${ContextManagerTest.EXAMPLE_NAME}';
-    String libPath = '$projPath/${ContextManagerTest.LIB_NAME}';
+    final join = resourceProvider.pathContext.join;
+    final convertPath = resourceProvider.convertPath;
+    String examplePath =
+        convertPath('$projPath/${ContextManagerTest.EXAMPLE_NAME}');
+    String libPath = convertPath('$projPath/${ContextManagerTest.LIB_NAME}');
 
     newFile('$projPath/${ContextManagerImpl.PACKAGE_SPEC_NAME}');
     newFile('$libPath/main.dart');
@@ -455,18 +468,21 @@ test_pack:lib/''');
     expect(callbacks.currentContextRoots, contains(projPath));
     Iterable<Source> projSources = callbacks.currentFileSources(projPath);
     expect(projSources, hasLength(1));
-    expect(projSources.first.uri.toString(), 'file:///my/proj/lib/main.dart');
+    expect(projSources.first.uri.toString(),
+        (new Uri.file(join(libPath, 'main.dart')).toString()));
 
     expect(callbacks.currentContextRoots, contains(examplePath));
     Iterable<Source> exampleSources = callbacks.currentFileSources(examplePath);
     expect(exampleSources, hasLength(1));
     expect(exampleSources.first.uri.toString(),
-        'file:///my/proj/example/example.dart');
+        (new Uri.file(join(examplePath, 'example.dart')).toString()));
   }
 
   void test_setRoots_addFolderWithNestedPubspec() {
-    String examplePath = '$projPath/${ContextManagerTest.EXAMPLE_NAME}';
-    String libPath = '$projPath/${ContextManagerTest.LIB_NAME}';
+    final convertPath = resourceProvider.convertPath;
+    String examplePath =
+        convertPath('$projPath/${ContextManagerTest.EXAMPLE_NAME}');
+    String libPath = convertPath('$projPath/${ContextManagerTest.LIB_NAME}');
 
     newFile('$projPath/${ContextManagerImpl.PUBSPEC_NAME}');
     newFile('$projPath/${ContextManagerImpl.PACKAGE_SPEC_NAME}',
@@ -488,7 +504,7 @@ test_pack:lib/''');
     Iterable<Source> exampleSources = callbacks.currentFileSources(examplePath);
     expect(exampleSources, hasLength(1));
     expect(exampleSources.first.uri.toString(),
-        'file:///my/proj/example/example.dart');
+        (new Uri.file('$examplePath/example.dart').toString()));
   }
 
   void test_setRoots_addFolderWithoutPubspec() {
@@ -500,12 +516,13 @@ test_pack:lib/''');
   }
 
   void test_setRoots_addFolderWithPackagespec() {
-    String packagespecPath = path.posix.join(projPath, '.packages');
+    final join = resourceProvider.pathContext.join;
+    final convertPath = resourceProvider.convertPath;
+    String packagespecPath = join(projPath, '.packages');
     resourceProvider.newFile(packagespecPath,
         'unittest:file:///home/somebody/.pub/cache/unittest-0.9.9/lib/');
     String libPath = '$projPath/${ContextManagerTest.LIB_NAME}';
-    File mainFile =
-        resourceProvider.newFile(path.posix.join(libPath, 'main.dart'), '');
+    File mainFile = resourceProvider.newFile(join(libPath, 'main.dart'), '');
     Source source = mainFile.createSource();
 
     manager.setRoots(<String>[projPath], <String>[], <String, String>{});
@@ -518,8 +535,10 @@ test_pack:lib/''');
     Source resolvedSource =
         sourceFactory.resolveUri(source, 'package:unittest/unittest.dart');
     expect(resolvedSource, isNotNull);
-    expect(resolvedSource.fullName,
-        equals('/home/somebody/.pub/cache/unittest-0.9.9/lib/unittest.dart'));
+    expect(
+        resolvedSource.fullName,
+        equals(convertPath(
+            '/home/somebody/.pub/cache/unittest-0.9.9/lib/unittest.dart')));
   }
 
   void test_setRoots_addFolderWithPackagespecAndPackageRoot() {
@@ -574,20 +593,21 @@ test_pack:lib/''');
     expect(sources, hasLength(4));
     List<String> uris =
         sources.map((Source source) => source.uri.toString()).toList();
-    expect(uris, contains('file://$appPath'));
+    expect(uris, contains((new Uri.file(appPath)).toString()));
     expect(uris, contains('package:proj/main.dart'));
     expect(uris, contains('package:proj/src/internal.dart'));
-    expect(uris, contains('file://$testFilePath'));
+    expect(uris, contains((new Uri.file(testFilePath)).toString()));
   }
 
   void test_setRoots_addFolderWithPubspecAndPackagespecFolders() {
+    final convertPath = resourceProvider.convertPath;
     // prepare paths
-    String root = '/root';
-    String rootFile = '$root/root.dart';
-    String subProjectA = '$root/sub/aaa';
-    String subProjectB = '$root/sub/sub2/bbb';
-    String subProjectA_file = '$subProjectA/bin/a.dart';
-    String subProjectB_file = '$subProjectB/bin/b.dart';
+    String root = convertPath('/root');
+    String rootFile = convertPath('$root/root.dart');
+    String subProjectA = convertPath('$root/sub/aaa');
+    String subProjectB = convertPath('$root/sub/sub2/bbb');
+    String subProjectA_file = convertPath('$subProjectA/bin/a.dart');
+    String subProjectB_file = convertPath('$subProjectB/bin/b.dart');
     // create files
     resourceProvider.newFile('$subProjectA/pubspec.yaml', 'pubspec');
     resourceProvider.newFile('$subProjectB/pubspec.yaml', 'pubspec');
@@ -608,15 +628,16 @@ test_pack:lib/''');
   }
 
   void test_setRoots_addFolderWithPubspecFolders() {
+    final convertPath = resourceProvider.convertPath;
     // prepare paths
-    String root = '/root';
-    String rootFile = '$root/root.dart';
-    String projectA = '$root/sub/aaa';
-    String projectALib = '$root/sub/aaa/lib';
-    String subProjectA_file = '$projectA/bin/a.dart';
-    String projectB = '$root/sub/sub2/bbb';
-    String projectBLib = '$root/sub/sub2/bbb/lib';
-    String subProjectB_file = '$projectB/bin/b.dart';
+    String root = convertPath('/root');
+    String rootFile = convertPath('$root/root.dart');
+    String projectA = convertPath('$root/sub/aaa');
+    String projectALib = convertPath('$root/sub/aaa/lib');
+    String subProjectA_file = convertPath('$projectA/bin/a.dart');
+    String projectB = convertPath('$root/sub/sub2/bbb');
+    String projectBLib = convertPath('$root/sub/sub2/bbb/lib');
+    String subProjectB_file = convertPath('$projectB/bin/b.dart');
     // create files
     newFile('$projectA/${ContextManagerImpl.PUBSPEC_NAME}');
     newFile('$projectA/${ContextManagerImpl.PACKAGE_SPEC_NAME}',
@@ -649,8 +670,8 @@ test_pack:lib/''');
   }
 
   void test_setRoots_addPackageRoot() {
-    String packagePathFoo = '/package1/foo';
-    String packageRootPath = '/package2/foo';
+    String packagePathFoo = resourceProvider.convertPath('/package1/foo');
+    String packageRootPath = resourceProvider.convertPath('/package2/foo');
     newFile('$projPath/${ContextManagerImpl.PACKAGE_SPEC_NAME}',
         content: 'foo:file:///package1/foo');
     Folder packageFolder = resourceProvider.newFolder(packagePathFoo);
@@ -681,10 +702,11 @@ test_pack:lib/''');
   }
 
   void test_setRoots_exclude_newRoot_withExcludedFile() {
+    final convertPath = resourceProvider.convertPath;
     // prepare paths
-    String project = '/project';
-    String file1 = '$project/file1.dart';
-    String file2 = '$project/file2.dart';
+    String project = convertPath('/project');
+    String file1 = convertPath('$project/file1.dart');
+    String file2 = convertPath('$project/file2.dart');
     // create files
     resourceProvider.newFile(file1, '// 1');
     resourceProvider.newFile(file2, '// 2');
@@ -695,12 +717,13 @@ test_pack:lib/''');
   }
 
   void test_setRoots_exclude_newRoot_withExcludedFolder() {
+    final convertPath = resourceProvider.convertPath;
     // prepare paths
-    String project = '/project';
-    String folderA = '$project/aaa';
-    String folderB = '$project/bbb';
-    String fileA = '$folderA/a.dart';
-    String fileB = '$folderB/b.dart';
+    String project = convertPath('/project');
+    String folderA = convertPath('$project/aaa');
+    String folderB = convertPath('$project/bbb');
+    String fileA = convertPath('$folderA/a.dart');
+    String fileB = convertPath('$folderB/b.dart');
     // create files
     resourceProvider.newFile(fileA, 'library a;');
     resourceProvider.newFile(fileB, 'library b;');
@@ -711,10 +734,11 @@ test_pack:lib/''');
   }
 
   void test_setRoots_exclude_sameRoot_addExcludedFile() {
+    final convertPath = resourceProvider.convertPath;
     // prepare paths
-    String project = '/project';
-    String file1 = '$project/file1.dart';
-    String file2 = '$project/file2.dart';
+    String project = convertPath('/project');
+    String file1 = convertPath('$project/file1.dart');
+    String file2 = convertPath('$project/file2.dart');
     // create files
     resourceProvider.newFile(file1, '// 1');
     resourceProvider.newFile(file2, '// 2');
@@ -729,12 +753,13 @@ test_pack:lib/''');
   }
 
   void test_setRoots_exclude_sameRoot_addExcludedFolder() {
+    final convertPath = resourceProvider.convertPath;
     // prepare paths
-    String project = '/project';
-    String folderA = '$project/aaa';
-    String folderB = '$project/bbb';
-    String fileA = '$folderA/a.dart';
-    String fileB = '$folderB/b.dart';
+    String project = convertPath('/project');
+    String folderA = convertPath('$project/aaa');
+    String folderB = convertPath('$project/bbb');
+    String fileA = convertPath('$folderA/a.dart');
+    String fileB = convertPath('$folderB/b.dart');
     // create files
     resourceProvider.newFile(fileA, 'library a;');
     resourceProvider.newFile(fileB, 'library b;');
@@ -749,10 +774,11 @@ test_pack:lib/''');
   }
 
   void test_setRoots_exclude_sameRoot_removeExcludedFile() {
+    final convertPath = resourceProvider.convertPath;
     // prepare paths
-    String project = '/project';
-    String file1 = '$project/file1.dart';
-    String file2 = '$project/file2.dart';
+    String project = convertPath('/project');
+    String file1 = convertPath('$project/file1.dart');
+    String file2 = convertPath('$project/file2.dart');
     // create files
     resourceProvider.newFile(file1, '// 1');
     resourceProvider.newFile(file2, '// 2');
@@ -767,10 +793,11 @@ test_pack:lib/''');
   }
 
   void test_setRoots_exclude_sameRoot_removeExcludedFile_inFolder() {
+    final convertPath = resourceProvider.convertPath;
     // prepare paths
-    String project = '/project';
-    String file1 = '$project/bin/file1.dart';
-    String file2 = '$project/bin/file2.dart';
+    String project = convertPath('/project');
+    String file1 = convertPath('$project/bin/file1.dart');
+    String file2 = convertPath('$project/bin/file2.dart');
     // create files
     resourceProvider.newFile(file1, '// 1');
     resourceProvider.newFile(file2, '// 2');
@@ -785,12 +812,13 @@ test_pack:lib/''');
   }
 
   void test_setRoots_exclude_sameRoot_removeExcludedFolder() {
+    final convertPath = resourceProvider.convertPath;
     // prepare paths
-    String project = '/project';
-    String folderA = '$project/aaa';
-    String folderB = '$project/bbb';
-    String fileA = '$folderA/a.dart';
-    String fileB = '$folderB/b.dart';
+    String project = convertPath('/project');
+    String folderA = convertPath('$project/aaa');
+    String folderB = convertPath('$project/bbb');
+    String fileA = convertPath('$folderA/a.dart');
+    String fileB = convertPath('$folderB/b.dart');
     // create files
     resourceProvider.newFile(fileA, 'library a;');
     resourceProvider.newFile(fileB, 'library b;');
@@ -805,10 +833,11 @@ test_pack:lib/''');
   }
 
   void test_setRoots_ignoreDocFolder() {
-    String project = '/project';
-    String fileA = '$project/foo.dart';
-    String fileB = '$project/lib/doc/bar.dart';
-    String fileC = '$project/doc/bar.dart';
+    final convertPath = resourceProvider.convertPath;
+    String project = convertPath('/project');
+    String fileA = convertPath('$project/foo.dart');
+    String fileB = convertPath('$project/lib/doc/bar.dart');
+    String fileC = convertPath('$project/doc/bar.dart');
     resourceProvider.newFile(fileA, '');
     resourceProvider.newFile(fileB, '');
     resourceProvider.newFile(fileC, '');
@@ -818,10 +847,11 @@ test_pack:lib/''');
   }
 
   void test_setRoots_nested_includedByOuter_innerFirst() {
-    String project = '/project';
-    String projectPubspec = '$project/pubspec.yaml';
-    String example = '$project/example';
-    String examplePubspec = '$example/pubspec.yaml';
+    final convertPath = resourceProvider.convertPath;
+    String project = convertPath('/project');
+    String projectPubspec = convertPath('$project/pubspec.yaml');
+    String example = convertPath('$project/example');
+    String examplePubspec = convertPath('$example/pubspec.yaml');
     // create files
     resourceProvider.newFile(projectPubspec, 'name: project');
     resourceProvider.newFile(examplePubspec, 'name: example');
@@ -846,9 +876,10 @@ test_pack:lib/''');
   }
 
   void test_setRoots_nested_includedByOuter_outerPubspec() {
-    String project = '/project';
-    String projectPubspec = '$project/pubspec.yaml';
-    String example = '$project/example';
+    final convertPath = resourceProvider.convertPath;
+    String project = convertPath('/project');
+    String projectPubspec = convertPath('$project/pubspec.yaml');
+    String example = convertPath('$project/example');
     // create files
     resourceProvider.newFile(projectPubspec, 'name: project');
     resourceProvider.newFolder(example);
@@ -868,10 +899,11 @@ test_pack:lib/''');
   }
 
   void test_setRoots_nested_includedByOuter_twoPubspecs() {
-    String project = '/project';
-    String projectPubspec = '$project/pubspec.yaml';
-    String example = '$project/example';
-    String examplePubspec = '$example/pubspec.yaml';
+    final convertPath = resourceProvider.convertPath;
+    String project = convertPath('/project');
+    String projectPubspec = convertPath('$project/pubspec.yaml');
+    String example = convertPath('$project/example');
+    String examplePubspec = convertPath('$example/pubspec.yaml');
     // create files
     resourceProvider.newFile(projectPubspec, 'name: project');
     resourceProvider.newFile(examplePubspec, 'name: example');
@@ -903,7 +935,7 @@ test_pack:lib/''');
   }
 
   void test_setRoots_newlyAddedFoldersGetProperPackageMap() {
-    String packagePath = '/package/foo';
+    String packagePath = resourceProvider.convertPath('/package/foo');
     newFile('$projPath/${ContextManagerImpl.PACKAGE_SPEC_NAME}',
         content: 'foo:file:///package/foo');
     Folder packageFolder = resourceProvider.newFolder(packagePath);
@@ -916,10 +948,11 @@ test_pack:lib/''');
   }
 
   void test_setRoots_noContext_excludedFolder() {
+    final convertPath = resourceProvider.convertPath;
     // prepare paths
-    String project = '/project';
-    String excludedFolder = '$project/excluded';
-    String excludedPubspec = '$excludedFolder/pubspec.yaml';
+    String project = convertPath('/project');
+    String excludedFolder = convertPath('$project/excluded');
+    String excludedPubspec = convertPath('$excludedFolder/pubspec.yaml');
     // create files
     resourceProvider.newFile(excludedPubspec, 'name: ignore-me');
     // set "/project", and exclude "/project/excluded"
@@ -949,7 +982,8 @@ test_pack:lib/''');
   }
 
   void test_setRoots_packageResolver() {
-    String filePath = path.posix.join(projPath, 'lib', 'foo.dart');
+    String filePath =
+        resourceProvider.pathContext.join(projPath, 'lib', 'foo.dart');
     newFile('$projPath/${ContextManagerImpl.PACKAGE_SPEC_NAME}',
         content: 'foo:lib/');
     resourceProvider.newFile(filePath, 'contents');
@@ -964,11 +998,12 @@ test_pack:lib/''');
   }
 
   void test_setRoots_pathContainsDotFile() {
+    final convertPath = resourceProvider.convertPath;
     // If the path to a file (relative to the context root) contains a folder
     // whose name begins with '.', then the file is ignored.
-    String project = '/project';
-    String fileA = '$project/foo.dart';
-    String fileB = '$project/.pub/bar.dart';
+    String project = convertPath('/project');
+    String fileA = convertPath('$project/foo.dart');
+    String fileB = convertPath('$project/.pub/bar.dart');
     resourceProvider.newFile(fileA, '');
     resourceProvider.newFile(fileB, '');
     manager.setRoots(<String>[project], <String>[], <String, String>{});
@@ -1003,17 +1038,18 @@ test_pack:lib/''');
   }
 
   void test_setRoots_removeFolderWithPackagespecFolder() {
+    final convertPath = resourceProvider.convertPath;
     // prepare paths
-    String projectA = '/projectA';
-    String projectB = '/projectB';
-    String subProjectA = '$projectA/sub';
-    String subProjectB = '$projectB/sub';
-    String projectA_file = '$projectA/a.dart';
-    String projectB_file = '$projectB/a.dart';
-    String subProjectA_pubspec = '$subProjectA/.packages';
-    String subProjectB_pubspec = '$subProjectB/.packages';
-    String subProjectA_file = '$subProjectA/bin/sub_a.dart';
-    String subProjectB_file = '$subProjectB/bin/sub_b.dart';
+    String projectA = convertPath('/projectA');
+    String projectB = convertPath('/projectB');
+    String subProjectA = convertPath('$projectA/sub');
+    String subProjectB = convertPath('$projectB/sub');
+    String projectA_file = convertPath('$projectA/a.dart');
+    String projectB_file = convertPath('$projectB/a.dart');
+    String subProjectA_pubspec = convertPath('$subProjectA/.packages');
+    String subProjectB_pubspec = convertPath('$subProjectB/.packages');
+    String subProjectA_file = convertPath('$subProjectA/bin/sub_a.dart');
+    String subProjectB_file = convertPath('$subProjectB/bin/sub_b.dart');
     // create files
     resourceProvider.newFile(projectA_file, '// a');
     resourceProvider.newFile(projectB_file, '// b');
@@ -1051,17 +1087,18 @@ test_pack:lib/''');
   }
 
   void test_setRoots_removeFolderWithPubspecFolder() {
+    final convertPath = resourceProvider.convertPath;
     // prepare paths
-    String projectA = '/projectA';
-    String projectB = '/projectB';
-    String subProjectA = '$projectA/sub';
-    String subProjectB = '$projectB/sub';
-    String projectA_file = '$projectA/a.dart';
-    String projectB_file = '$projectB/a.dart';
-    String subProjectA_pubspec = '$subProjectA/pubspec.yaml';
-    String subProjectB_pubspec = '$subProjectB/pubspec.yaml';
-    String subProjectA_file = '$subProjectA/bin/sub_a.dart';
-    String subProjectB_file = '$subProjectB/bin/sub_b.dart';
+    String projectA = convertPath('/projectA');
+    String projectB = convertPath('/projectB');
+    String subProjectA = convertPath('$projectA/sub');
+    String subProjectB = convertPath('$projectB/sub');
+    String projectA_file = convertPath('$projectA/a.dart');
+    String projectB_file = convertPath('$projectB/a.dart');
+    String subProjectA_pubspec = convertPath('$subProjectA/pubspec.yaml');
+    String subProjectB_pubspec = convertPath('$subProjectB/pubspec.yaml');
+    String subProjectA_file = convertPath('$subProjectA/bin/sub_a.dart');
+    String subProjectB_file = convertPath('$subProjectB/bin/sub_b.dart');
     // create files
     resourceProvider.newFile(projectA_file, '// a');
     resourceProvider.newFile(projectB_file, '// b');
@@ -1086,8 +1123,9 @@ test_pack:lib/''');
   }
 
   void test_setRoots_removePackageRoot() {
-    String packagePathFoo = '/package1/foo';
-    String packageRootPath = '/package2/foo';
+    final convertPath = resourceProvider.convertPath;
+    String packagePathFoo = convertPath('/package1/foo');
+    String packageRootPath = convertPath('/package2/foo');
     Folder packageFolder = resourceProvider.newFolder(packagePathFoo);
     newFile('$projPath/${ContextManagerImpl.PACKAGE_SPEC_NAME}',
         content: 'foo:file:///package1/foo');
@@ -1108,8 +1146,9 @@ test_pack:lib/''');
     // If the path to the context root itself contains a folder whose name
     // begins with '.', then that is not sufficient to cause any files in the
     // context to be ignored.
-    String project = '/.pub/project';
-    String fileA = '$project/foo.dart';
+    final convertPath = resourceProvider.convertPath;
+    String project = convertPath('/.pub/project');
+    String fileA = convertPath('$project/foo.dart');
     resourceProvider.newFile(fileA, '');
     manager.setRoots(<String>[project], <String>[], <String, String>{});
     callbacks.assertContextPaths([project]);
@@ -1130,11 +1169,12 @@ test_pack:lib/''');
   }
 
   test_watch_addFile() {
+    final join = resourceProvider.pathContext.join;
     manager.setRoots(<String>[projPath], <String>[], <String, String>{});
     // empty folder initially
     expect(callbacks.currentFilePaths, hasLength(0));
     // add file
-    String filePath = path.posix.join(projPath, 'foo.dart');
+    String filePath = join(projPath, 'foo.dart');
     resourceProvider.newFile(filePath, 'contents');
     // the file was added
     return pumpEventQueue().then((_) {
@@ -1145,12 +1185,13 @@ test_pack:lib/''');
   }
 
   test_watch_addFile_excluded() {
+    final convertPath = resourceProvider.convertPath;
     // prepare paths
-    String project = '/project';
-    String folderA = '$project/aaa';
-    String folderB = '$project/bbb';
-    String fileA = '$folderA/a.dart';
-    String fileB = '$folderB/b.dart';
+    String project = convertPath('/project');
+    String folderA = convertPath('$project/aaa');
+    String folderB = convertPath('$project/bbb');
+    String fileA = convertPath('$folderA/a.dart');
+    String fileB = convertPath('$folderB/b.dart');
     // create files
     resourceProvider.newFile(fileA, 'library a;');
     // set roots
@@ -1166,10 +1207,11 @@ test_pack:lib/''');
   }
 
   test_watch_addFile_inDocFolder_inner() {
+    final convertPath = resourceProvider.convertPath;
     // prepare paths
-    String project = '/project';
-    String fileA = '$project/a.dart';
-    String fileB = '$project/lib/doc/b.dart';
+    String project = convertPath('/project');
+    String fileA = convertPath('$project/a.dart');
+    String fileB = convertPath('$project/lib/doc/b.dart');
     // create files
     resourceProvider.newFile(fileA, '');
     // set roots
@@ -1185,10 +1227,11 @@ test_pack:lib/''');
   }
 
   test_watch_addFile_inDocFolder_topLevel() {
+    final convertPath = resourceProvider.convertPath;
     // prepare paths
-    String project = '/project';
-    String fileA = '$project/a.dart';
-    String fileB = '$project/doc/b.dart';
+    String project = convertPath('/project');
+    String fileA = convertPath('$project/a.dart');
+    String fileB = convertPath('$project/doc/b.dart');
     // create files
     resourceProvider.newFile(fileA, '');
     // set roots
@@ -1204,11 +1247,12 @@ test_pack:lib/''');
   }
 
   test_watch_addFile_pathContainsDotFile() async {
+    final convertPath = resourceProvider.convertPath;
     // If a file is added and the path to it (relative to the context root)
     // contains a folder whose name begins with '.', then the file is ignored.
-    String project = '/project';
-    String fileA = '$project/foo.dart';
-    String fileB = '$project/.pub/bar.dart';
+    String project = convertPath('/project');
+    String fileA = convertPath('$project/foo.dart');
+    String fileB = convertPath('$project/.pub/bar.dart');
     resourceProvider.newFile(fileA, '');
     manager.setRoots(<String>[project], <String>[], <String, String>{});
     callbacks.assertContextPaths([project]);
@@ -1220,11 +1264,12 @@ test_pack:lib/''');
   }
 
   test_watch_addFile_rootPathContainsDotFile() async {
+    final convertPath = resourceProvider.convertPath;
     // If a file is added and the path to the context contains a folder whose
     // name begins with '.', then the file is not ignored.
-    String project = '/.pub/project';
-    String fileA = '$project/foo.dart';
-    String fileB = '$project/bar/baz.dart';
+    String project = convertPath('/.pub/project');
+    String fileA = convertPath('$project/foo.dart');
+    String fileB = convertPath('$project/bar/baz.dart');
     resourceProvider.newFile(fileA, '');
     manager.setRoots(<String>[project], <String>[], <String, String>{});
     callbacks.assertContextPaths([project]);
@@ -1240,7 +1285,8 @@ test_pack:lib/''');
     // empty folder initially
     expect(callbacks.currentFilePaths, hasLength(0));
     // add file in subfolder
-    String filePath = path.posix.join(projPath, 'foo', 'bar.dart');
+    String filePath =
+        resourceProvider.pathContext.join(projPath, 'foo', 'bar.dart');
     resourceProvider.newFile(filePath, 'contents');
     // the file was added
     return pumpEventQueue().then((_) {
@@ -1251,10 +1297,11 @@ test_pack:lib/''');
   }
 
   test_watch_addPackagespec_toRoot() {
+    final convertPath = resourceProvider.convertPath;
     // prepare paths
-    String root = '/root';
-    String rootFile = '$root/root.dart';
-    String rootPackagespec = '$root/.packages';
+    String root = convertPath('/root');
+    String rootFile = convertPath('$root/root.dart');
+    String rootPackagespec = convertPath('$root/.packages');
     // create files
     resourceProvider.newFile(rootFile, 'library root;');
     // set roots
@@ -1273,12 +1320,13 @@ test_pack:lib/''');
   }
 
   test_watch_addPackagespec_toSubFolder() {
+    final convertPath = resourceProvider.convertPath;
     // prepare paths
-    String root = '/root';
-    String rootFile = '$root/root.dart';
-    String subProject = '$root/sub/aaa';
-    String subPubspec = '$subProject/.packages';
-    String subFile = '$subProject/bin/a.dart';
+    String root = convertPath('/root');
+    String rootFile = convertPath('$root/root.dart');
+    String subProject = convertPath('$root/sub/aaa');
+    String subPubspec = convertPath('$subProject/.packages');
+    String subFile = convertPath('$subProject/bin/a.dart');
     // create files
     resourceProvider.newFile(rootFile, 'library root;');
     resourceProvider.newFile(subFile, 'library a;');
@@ -1297,13 +1345,14 @@ test_pack:lib/''');
   }
 
   test_watch_addPackagespec_toSubFolder_ofSubFolder() {
+    final convertPath = resourceProvider.convertPath;
     // prepare paths
-    String root = '/root';
-    String rootFile = '$root/root.dart';
-    String subProject = '$root/sub';
-    String subPubspec = '$subProject/.packages';
-    String subFile = '$subProject/bin/sub.dart';
-    String subSubPubspec = '$subProject/subsub/.packages';
+    String root = convertPath('/root');
+    String rootFile = convertPath('$root/root.dart');
+    String subProject = convertPath('$root/sub');
+    String subPubspec = convertPath('$subProject/.packages');
+    String subFile = convertPath('$subProject/bin/sub.dart');
+    String subSubPubspec = convertPath('$subProject/subsub/.packages');
     // create files
     resourceProvider.newFile(rootFile, 'library root;');
     resourceProvider.newFile(subPubspec, '');
@@ -1323,13 +1372,14 @@ test_pack:lib/''');
   }
 
   test_watch_addPackagespec_toSubFolder_withPubspec() {
+    final convertPath = resourceProvider.convertPath;
     // prepare paths
-    String root = '/root';
-    String rootFile = '$root/root.dart';
-    String subProject = '$root/sub/aaa';
-    String subPackagespec = '$subProject/.packages';
-    String subPubspec = '$subProject/pubspec.yaml';
-    String subFile = '$subProject/bin/a.dart';
+    String root = convertPath('/root');
+    String rootFile = convertPath('$root/root.dart');
+    String subProject = convertPath('$root/sub/aaa');
+    String subPackagespec = convertPath('$subProject/.packages');
+    String subPubspec = convertPath('$subProject/pubspec.yaml');
+    String subFile = convertPath('$subProject/bin/a.dart');
     // create files
     resourceProvider.newFile(subPubspec, 'pubspec');
     resourceProvider.newFile(rootFile, 'library root;');
@@ -1352,10 +1402,11 @@ test_pack:lib/''');
   }
 
   test_watch_addPubspec_toRoot() {
+    final convertPath = resourceProvider.convertPath;
     // prepare paths
-    String root = '/root';
-    String rootFile = '$root/root.dart';
-    String rootPubspec = '$root/pubspec.yaml';
+    String root = convertPath('/root');
+    String rootFile = convertPath('$root/root.dart');
+    String rootPubspec = convertPath('$root/pubspec.yaml');
     // create files
     resourceProvider.newFile(rootFile, 'library root;');
     // set roots
@@ -1372,12 +1423,13 @@ test_pack:lib/''');
   }
 
   test_watch_addPubspec_toSubFolder() {
+    final convertPath = resourceProvider.convertPath;
     // prepare paths
-    String root = '/root';
-    String rootFile = '$root/root.dart';
-    String subProject = '$root/sub/aaa';
-    String subPubspec = '$subProject/pubspec.yaml';
-    String subFile = '$subProject/bin/a.dart';
+    String root = convertPath('/root');
+    String rootFile = convertPath('$root/root.dart');
+    String subProject = convertPath('$root/sub/aaa');
+    String subPubspec = convertPath('$subProject/pubspec.yaml');
+    String subFile = convertPath('$subProject/bin/a.dart');
     // create files
     resourceProvider.newFile(rootFile, 'library root;');
     resourceProvider.newFile(subFile, 'library a;');
@@ -1396,13 +1448,14 @@ test_pack:lib/''');
   }
 
   test_watch_addPubspec_toSubFolder_ofSubFolder() {
+    final convertPath = resourceProvider.convertPath;
     // prepare paths
-    String root = '/root';
-    String rootFile = '$root/root.dart';
-    String subProject = '$root/sub';
-    String subPubspec = '$subProject/pubspec.yaml';
-    String subFile = '$subProject/bin/sub.dart';
-    String subSubPubspec = '$subProject/subsub/pubspec.yaml';
+    String root = convertPath('/root');
+    String rootFile = convertPath('$root/root.dart');
+    String subProject = convertPath('$root/sub');
+    String subPubspec = convertPath('$subProject/pubspec.yaml');
+    String subFile = convertPath('$subProject/bin/sub.dart');
+    String subSubPubspec = convertPath('$subProject/subsub/pubspec.yaml');
     // create files
     resourceProvider.newFile(rootFile, 'library root;');
     resourceProvider.newFile(subPubspec, 'pubspec');
@@ -1422,7 +1475,7 @@ test_pack:lib/''');
   }
 
   test_watch_deleteFile() {
-    String filePath = path.posix.join(projPath, 'foo.dart');
+    String filePath = resourceProvider.pathContext.join(projPath, 'foo.dart');
     // add root with a file
     File file = resourceProvider.newFile(filePath, 'contents');
     Folder projFolder = file.parent;
@@ -1443,7 +1496,7 @@ test_pack:lib/''');
   }
 
   test_watch_deleteFolder() {
-    String filePath = path.posix.join(projPath, 'foo.dart');
+    String filePath = resourceProvider.pathContext.join(projPath, 'foo.dart');
     // add root with a file
     File file = resourceProvider.newFile(filePath, 'contents');
     Folder projFolder = file.parent;
@@ -1464,10 +1517,11 @@ test_pack:lib/''');
   }
 
   test_watch_deletePackagespec_fromRoot() {
+    final convertPath = resourceProvider.convertPath;
     // prepare paths
-    String root = '/root';
-    String rootPubspec = '$root/.packages';
-    String rootFile = '$root/root.dart';
+    String root = convertPath('/root');
+    String rootPubspec = convertPath('$root/.packages');
+    String rootFile = convertPath('$root/root.dart');
     // create files
     resourceProvider.newFile(rootPubspec, '');
     resourceProvider.newFile(rootFile, 'library root;');
@@ -1484,12 +1538,13 @@ test_pack:lib/''');
   }
 
   test_watch_deletePackagespec_fromSubFolder() {
+    final convertPath = resourceProvider.convertPath;
     // prepare paths
-    String root = '/root';
-    String rootFile = '$root/root.dart';
-    String subProject = '$root/sub/aaa';
-    String subPubspec = '$subProject/.packages';
-    String subFile = '$subProject/bin/a.dart';
+    String root = convertPath('/root');
+    String rootFile = convertPath('$root/root.dart');
+    String subProject = convertPath('$root/sub/aaa');
+    String subPubspec = convertPath('$subProject/.packages');
+    String subFile = convertPath('$subProject/bin/a.dart');
     // create files
     resourceProvider.newFile(subPubspec, '');
     resourceProvider.newFile(rootFile, 'library root;');
@@ -1509,6 +1564,7 @@ test_pack:lib/''');
   }
 
   test_watch_deletePackagespec_fromSubFolder_withPubspec() {
+    final convertPath = resourceProvider.convertPath;
     // prepare paths:
     //
     // root
@@ -1520,12 +1576,12 @@ test_pack:lib/''');
     //       bin
     //         a.dart
     //
-    String root = '/root';
-    String rootFile = '$root/root.dart';
-    String subProject = '$root/sub/aaa';
-    String subPackagespec = '$subProject/.packages';
-    String subPubspec = '$subProject/pubspec.yaml';
-    String subFile = '$subProject/bin/a.dart';
+    String root = convertPath('/root');
+    String rootFile = convertPath('$root/root.dart');
+    String subProject = convertPath('$root/sub/aaa');
+    String subPackagespec = convertPath('$subProject/.packages');
+    String subPubspec = convertPath('$subProject/pubspec.yaml');
+    String subFile = convertPath('$subProject/bin/a.dart');
     // create files
     resourceProvider.newFile(subPackagespec, '');
     resourceProvider.newFile(subPubspec, 'pubspec');
@@ -1547,10 +1603,11 @@ test_pack:lib/''');
   }
 
   test_watch_deletePubspec_fromRoot() {
+    final convertPath = resourceProvider.convertPath;
     // prepare paths
-    String root = '/root';
-    String rootPubspec = '$root/pubspec.yaml';
-    String rootFile = '$root/root.dart';
+    String root = convertPath('/root');
+    String rootPubspec = convertPath('$root/pubspec.yaml');
+    String rootFile = convertPath('$root/root.dart');
     // create files
     resourceProvider.newFile(rootPubspec, 'pubspec');
     resourceProvider.newFile(rootFile, 'library root;');
@@ -1567,12 +1624,13 @@ test_pack:lib/''');
   }
 
   test_watch_deletePubspec_fromSubFolder() {
+    final convertPath = resourceProvider.convertPath;
     // prepare paths
-    String root = '/root';
-    String rootFile = '$root/root.dart';
-    String subProject = '$root/sub/aaa';
-    String subPubspec = '$subProject/pubspec.yaml';
-    String subFile = '$subProject/bin/a.dart';
+    String root = convertPath('/root');
+    String rootFile = convertPath('$root/root.dart');
+    String subProject = convertPath('$root/sub/aaa');
+    String subPubspec = convertPath('$subProject/pubspec.yaml');
+    String subFile = convertPath('$subProject/bin/a.dart');
     // create files
     resourceProvider.newFile(subPubspec, 'pubspec');
     resourceProvider.newFile(rootFile, 'library root;');
@@ -1592,7 +1650,7 @@ test_pack:lib/''');
   }
 
   test_watch_modifyFile() {
-    String filePath = path.posix.join(projPath, 'foo.dart');
+    String filePath = resourceProvider.pathContext.join(projPath, 'foo.dart');
     // add root with a file
     resourceProvider.newFile(filePath, 'contents');
     manager.setRoots(<String>[projPath], <String>[], <String, String>{});
@@ -1610,12 +1668,13 @@ test_pack:lib/''');
   }
 
   test_watch_modifyPackageMapDependency_fail() async {
+    final join = resourceProvider.pathContext.join;
     // create a dependency file
-    String dependencyPath = path.posix.join(projPath, 'dep');
+    String dependencyPath = join(projPath, 'dep');
     resourceProvider.newFile(dependencyPath, 'contents');
     packageMapProvider.dependencies.add(dependencyPath);
     // create a Dart file
-    String dartFilePath = path.posix.join(projPath, 'main.dart');
+    String dartFilePath = join(projPath, 'main.dart');
     resourceProvider.newFile(dartFilePath, 'contents');
     // the created context has the expected empty package map
     manager.setRoots(<String>[projPath], <String>[], <String, String>{});
@@ -1630,8 +1689,9 @@ test_pack:lib/''');
   }
 
   test_watch_modifyPackagespec() {
-    String packagesPath = '$projPath/.packages';
-    String filePath = '$projPath/bin/main.dart';
+    final convertPath = resourceProvider.convertPath;
+    String packagesPath = convertPath('$projPath/.packages');
+    String filePath = convertPath('$projPath/bin/main.dart');
 
     resourceProvider.newFile(packagesPath, '');
     resourceProvider.newFile(filePath, 'library main;');
@@ -1701,7 +1761,7 @@ abstract class ContextManagerTest extends Object with ResourceProviderMixin {
 
   UriResolver packageResolver = null;
 
-  String projPath = '/my/proj';
+  String projPath = null;
 
   AnalysisError missing_required_param = new AnalysisError(
       new TestSource(), 0, 1, HintCode.MISSING_REQUIRED_PARAM, [
@@ -1765,11 +1825,13 @@ abstract class ContextManagerTest extends Object with ResourceProviderMixin {
 
   void setUp() {
     processRequiredPlugins();
+    projPath = resourceProvider.convertPath('/my/proj');
     resourceProvider.newFolder(projPath);
     packageMapProvider = new MockPackageMapProvider();
     // Create an SDK in the mock file system.
     new MockSdk(generateSummaryFiles: true, resourceProvider: resourceProvider);
-    DartSdkManager sdkManager = new DartSdkManager('/', true);
+    DartSdkManager sdkManager =
+        new DartSdkManager(resourceProvider.convertPath('/'), true);
     manager = new ContextManagerImpl(
         resourceProvider,
         new FileContentOverlay(),
@@ -2274,8 +2336,9 @@ analyzer:
     Folder projectFolder = resourceProvider.newFolder(projPath);
     var drivers = manager.getDriversInAnalysisRoot(projectFolder);
     expect(drivers, hasLength(2));
-    expect(drivers[0].name, equals('/my/proj'));
-    expect(drivers[1].name, equals('/my/proj/lib'));
+    final convertPath = resourceProvider.convertPath;
+    expect(drivers[0].name, equals(convertPath('/my/proj')));
+    expect(drivers[1].name, equals(convertPath('/my/proj/lib')));
   }
 
   test_path_filter_recursive_wildcard_child_contexts_option() async {
@@ -2305,8 +2368,9 @@ analyzer:
     Folder projectFolder = resourceProvider.newFolder(projPath);
     var drivers = manager.getDriversInAnalysisRoot(projectFolder);
     expect(drivers, hasLength(2));
-    expect(drivers[0].name, equals('/my/proj'));
-    expect(drivers[1].name, equals('/my/proj/lib'));
+    final convertPath = resourceProvider.convertPath;
+    expect(drivers[0].name, equals(convertPath('/my/proj')));
+    expect(drivers[1].name, equals(convertPath('/my/proj/lib')));
   }
 
   test_path_filter_wildcard_child_contexts_option() async {
@@ -2334,15 +2398,17 @@ analyzer:
     Folder projectFolder = resourceProvider.newFolder(projPath);
     var drivers = manager.getDriversInAnalysisRoot(projectFolder);
     expect(drivers, hasLength(2));
-    expect(drivers[0].name, equals('/my/proj'));
-    expect(drivers[1].name, equals('/my/proj/lib'));
+    final convertPath = resourceProvider.convertPath;
+    expect(drivers[0].name, equals(convertPath('/my/proj')));
+    expect(drivers[1].name, equals(convertPath('/my/proj/lib')));
   }
 
   void test_setRoots_nested_excludedByOuter() {
-    String project = '/project';
-    String projectPubspec = '$project/pubspec.yaml';
-    String example = '$project/example';
-    String examplePubspec = '$example/pubspec.yaml';
+    final convertPath = resourceProvider.convertPath;
+    String project = convertPath('/project');
+    String projectPubspec = convertPath('$project/pubspec.yaml');
+    String example = convertPath('$project/example');
+    String examplePubspec = convertPath('$example/pubspec.yaml');
     // create files
     resourceProvider.newFile(projectPubspec, 'name: project');
     resourceProvider.newFile(examplePubspec, 'name: example');
@@ -2373,10 +2439,11 @@ analyzer:
   }
 
   void test_setRoots_nested_excludedByOuter_deep() {
-    String a = '/a';
-    String c = '$a/b/c';
-    String aPubspec = '$a/pubspec.yaml';
-    String cPubspec = '$c/pubspec.yaml';
+    final convertPath = resourceProvider.convertPath;
+    String a = convertPath('/a');
+    String c = convertPath('$a/b/c');
+    String aPubspec = convertPath('$a/pubspec.yaml');
+    String cPubspec = convertPath('$c/pubspec.yaml');
     // create files
     resourceProvider.newFile(aPubspec, 'name: aaa');
     resourceProvider.newFile(cPubspec, 'name: ccc');

--- a/pkg/analysis_server/test/context_manager_test.dart
+++ b/pkg/analysis_server/test/context_manager_test.dart
@@ -144,7 +144,6 @@ test_pack:lib/''');
   }
 
   test_embedder_packagespec() async {
-    final convertPath = resourceProvider.convertPath;
     // Create files.
     String libPath = '$projPath/${ContextManagerTest.LIB_NAME}';
     newFile('$libPath/main.dart');
@@ -200,7 +199,6 @@ test_pack:lib/''');
   }
 
   void test_isInAnalysisRoot_excluded() {
-    final convertPath = resourceProvider.convertPath;
     // prepare paths
     String project = convertPath('/project');
     String excludedFolder = convertPath('$project/excluded');
@@ -263,8 +261,7 @@ test_pack:lib/''');
     // Verify that ignored files were ignored.
     Iterable<String> filePaths = callbacks.currentFilePaths;
     expect(filePaths, hasLength(1));
-    expect(filePaths,
-        contains(resourceProvider.convertPath('/my/proj/lib/main.dart')));
+    expect(filePaths, contains(convertPath('/my/proj/lib/main.dart')));
   }
 
   test_refresh_folder_with_packagespec() {
@@ -287,7 +284,6 @@ test_pack:lib/''');
   // Once http://dartbug.com/23909 is fixed, add a test for sdk extensions
   // and PackageMapDisposition.
   test_refresh_folder_with_packagespec_subfolders() {
-    final join = resourceProvider.pathContext.join;
     // Create a folder with no .packages file, containing two subfolders with
     // .packages files.
     String subdir1Path = join(projPath, 'subdir1');
@@ -329,7 +325,6 @@ test_pack:lib/''');
   }
 
   test_refresh_folder_with_pubspec_subfolders() {
-    final join = resourceProvider.pathContext.join;
     // Create a folder with no pubspec.yaml, containing two subfolders with
     // pubspec.yaml files.
     String subdir1Path = join(projPath, 'subdir1');
@@ -355,8 +350,6 @@ test_pack:lib/''');
   }
 
   test_refresh_oneContext() {
-    final convertPath = resourceProvider.convertPath;
-    final join = resourceProvider.pathContext.join;
     // create two contexts with pubspec.yaml files
     String pubspecPath = join(projPath, 'pubspec.yaml');
     resourceProvider.newFile(pubspecPath, 'pubspec1');
@@ -406,8 +399,7 @@ test_pack:lib/''');
         .numberOfContextsInAnalysisRoot(resourceProvider.newFolder(projPath));
     expect(count, equals(1));
     var source = sourceFactory.forUri('dart:foobar');
-    expect(source.fullName,
-        equals(resourceProvider.convertPath('/my/proj/sdk_ext/entry.dart')));
+    expect(source.fullName, equals(convertPath('/my/proj/sdk_ext/entry.dart')));
   }
 
   void test_setRoots_addFolderWithDartFile() {
@@ -427,8 +419,7 @@ test_pack:lib/''');
   }
 
   void test_setRoots_addFolderWithDartFileInSubfolder() {
-    String filePath =
-        resourceProvider.pathContext.join(projPath, 'foo', 'bar.dart');
+    String filePath = join(projPath, 'foo', 'bar.dart');
     resourceProvider.newFile(filePath, 'contents');
     manager.setRoots(<String>[projPath], <String>[], <String, String>{});
     // verify
@@ -438,7 +429,7 @@ test_pack:lib/''');
   }
 
   void test_setRoots_addFolderWithDummyLink() {
-    String filePath = resourceProvider.pathContext.join(projPath, 'foo.dart');
+    String filePath = join(projPath, 'foo.dart');
     resourceProvider.newDummyLink(filePath);
     manager.setRoots(<String>[projPath], <String>[], <String, String>{});
     // verify
@@ -446,8 +437,6 @@ test_pack:lib/''');
   }
 
   void test_setRoots_addFolderWithNestedPackageSpec() {
-    final join = resourceProvider.pathContext.join;
-    final convertPath = resourceProvider.convertPath;
     String examplePath =
         convertPath('$projPath/${ContextManagerTest.EXAMPLE_NAME}');
     String libPath = convertPath('$projPath/${ContextManagerTest.LIB_NAME}');
@@ -479,7 +468,6 @@ test_pack:lib/''');
   }
 
   void test_setRoots_addFolderWithNestedPubspec() {
-    final convertPath = resourceProvider.convertPath;
     String examplePath =
         convertPath('$projPath/${ContextManagerTest.EXAMPLE_NAME}');
     String libPath = convertPath('$projPath/${ContextManagerTest.LIB_NAME}');
@@ -516,8 +504,6 @@ test_pack:lib/''');
   }
 
   void test_setRoots_addFolderWithPackagespec() {
-    final join = resourceProvider.pathContext.join;
-    final convertPath = resourceProvider.convertPath;
     String packagespecPath = join(projPath, '.packages');
     resourceProvider.newFile(packagespecPath,
         'unittest:file:///home/somebody/.pub/cache/unittest-0.9.9/lib/');
@@ -600,7 +586,6 @@ test_pack:lib/''');
   }
 
   void test_setRoots_addFolderWithPubspecAndPackagespecFolders() {
-    final convertPath = resourceProvider.convertPath;
     // prepare paths
     String root = convertPath('/root');
     String rootFile = convertPath('$root/root.dart');
@@ -628,7 +613,6 @@ test_pack:lib/''');
   }
 
   void test_setRoots_addFolderWithPubspecFolders() {
-    final convertPath = resourceProvider.convertPath;
     // prepare paths
     String root = convertPath('/root');
     String rootFile = convertPath('$root/root.dart');
@@ -670,8 +654,8 @@ test_pack:lib/''');
   }
 
   void test_setRoots_addPackageRoot() {
-    String packagePathFoo = resourceProvider.convertPath('/package1/foo');
-    String packageRootPath = resourceProvider.convertPath('/package2/foo');
+    String packagePathFoo = convertPath('/package1/foo');
+    String packageRootPath = convertPath('/package2/foo');
     newFile('$projPath/${ContextManagerImpl.PACKAGE_SPEC_NAME}',
         content: 'foo:file:///package1/foo');
     Folder packageFolder = resourceProvider.newFolder(packagePathFoo);
@@ -702,7 +686,6 @@ test_pack:lib/''');
   }
 
   void test_setRoots_exclude_newRoot_withExcludedFile() {
-    final convertPath = resourceProvider.convertPath;
     // prepare paths
     String project = convertPath('/project');
     String file1 = convertPath('$project/file1.dart');
@@ -717,7 +700,6 @@ test_pack:lib/''');
   }
 
   void test_setRoots_exclude_newRoot_withExcludedFolder() {
-    final convertPath = resourceProvider.convertPath;
     // prepare paths
     String project = convertPath('/project');
     String folderA = convertPath('$project/aaa');
@@ -734,7 +716,6 @@ test_pack:lib/''');
   }
 
   void test_setRoots_exclude_sameRoot_addExcludedFile() {
-    final convertPath = resourceProvider.convertPath;
     // prepare paths
     String project = convertPath('/project');
     String file1 = convertPath('$project/file1.dart');
@@ -753,7 +734,6 @@ test_pack:lib/''');
   }
 
   void test_setRoots_exclude_sameRoot_addExcludedFolder() {
-    final convertPath = resourceProvider.convertPath;
     // prepare paths
     String project = convertPath('/project');
     String folderA = convertPath('$project/aaa');
@@ -774,7 +754,6 @@ test_pack:lib/''');
   }
 
   void test_setRoots_exclude_sameRoot_removeExcludedFile() {
-    final convertPath = resourceProvider.convertPath;
     // prepare paths
     String project = convertPath('/project');
     String file1 = convertPath('$project/file1.dart');
@@ -793,7 +772,6 @@ test_pack:lib/''');
   }
 
   void test_setRoots_exclude_sameRoot_removeExcludedFile_inFolder() {
-    final convertPath = resourceProvider.convertPath;
     // prepare paths
     String project = convertPath('/project');
     String file1 = convertPath('$project/bin/file1.dart');
@@ -812,7 +790,6 @@ test_pack:lib/''');
   }
 
   void test_setRoots_exclude_sameRoot_removeExcludedFolder() {
-    final convertPath = resourceProvider.convertPath;
     // prepare paths
     String project = convertPath('/project');
     String folderA = convertPath('$project/aaa');
@@ -833,7 +810,6 @@ test_pack:lib/''');
   }
 
   void test_setRoots_ignoreDocFolder() {
-    final convertPath = resourceProvider.convertPath;
     String project = convertPath('/project');
     String fileA = convertPath('$project/foo.dart');
     String fileB = convertPath('$project/lib/doc/bar.dart');
@@ -847,7 +823,6 @@ test_pack:lib/''');
   }
 
   void test_setRoots_nested_includedByOuter_innerFirst() {
-    final convertPath = resourceProvider.convertPath;
     String project = convertPath('/project');
     String projectPubspec = convertPath('$project/pubspec.yaml');
     String example = convertPath('$project/example');
@@ -876,7 +851,6 @@ test_pack:lib/''');
   }
 
   void test_setRoots_nested_includedByOuter_outerPubspec() {
-    final convertPath = resourceProvider.convertPath;
     String project = convertPath('/project');
     String projectPubspec = convertPath('$project/pubspec.yaml');
     String example = convertPath('$project/example');
@@ -899,7 +873,6 @@ test_pack:lib/''');
   }
 
   void test_setRoots_nested_includedByOuter_twoPubspecs() {
-    final convertPath = resourceProvider.convertPath;
     String project = convertPath('/project');
     String projectPubspec = convertPath('$project/pubspec.yaml');
     String example = convertPath('$project/example');
@@ -935,7 +908,7 @@ test_pack:lib/''');
   }
 
   void test_setRoots_newlyAddedFoldersGetProperPackageMap() {
-    String packagePath = resourceProvider.convertPath('/package/foo');
+    String packagePath = convertPath('/package/foo');
     newFile('$projPath/${ContextManagerImpl.PACKAGE_SPEC_NAME}',
         content: 'foo:file:///package/foo');
     Folder packageFolder = resourceProvider.newFolder(packagePath);
@@ -948,7 +921,6 @@ test_pack:lib/''');
   }
 
   void test_setRoots_noContext_excludedFolder() {
-    final convertPath = resourceProvider.convertPath;
     // prepare paths
     String project = convertPath('/project');
     String excludedFolder = convertPath('$project/excluded');
@@ -982,8 +954,7 @@ test_pack:lib/''');
   }
 
   void test_setRoots_packageResolver() {
-    String filePath =
-        resourceProvider.pathContext.join(projPath, 'lib', 'foo.dart');
+    String filePath = join(projPath, 'lib', 'foo.dart');
     newFile('$projPath/${ContextManagerImpl.PACKAGE_SPEC_NAME}',
         content: 'foo:lib/');
     resourceProvider.newFile(filePath, 'contents');
@@ -998,7 +969,6 @@ test_pack:lib/''');
   }
 
   void test_setRoots_pathContainsDotFile() {
-    final convertPath = resourceProvider.convertPath;
     // If the path to a file (relative to the context root) contains a folder
     // whose name begins with '.', then the file is ignored.
     String project = convertPath('/project');
@@ -1038,7 +1008,6 @@ test_pack:lib/''');
   }
 
   void test_setRoots_removeFolderWithPackagespecFolder() {
-    final convertPath = resourceProvider.convertPath;
     // prepare paths
     String projectA = convertPath('/projectA');
     String projectB = convertPath('/projectB');
@@ -1087,7 +1056,6 @@ test_pack:lib/''');
   }
 
   void test_setRoots_removeFolderWithPubspecFolder() {
-    final convertPath = resourceProvider.convertPath;
     // prepare paths
     String projectA = convertPath('/projectA');
     String projectB = convertPath('/projectB');
@@ -1123,7 +1091,6 @@ test_pack:lib/''');
   }
 
   void test_setRoots_removePackageRoot() {
-    final convertPath = resourceProvider.convertPath;
     String packagePathFoo = convertPath('/package1/foo');
     String packageRootPath = convertPath('/package2/foo');
     Folder packageFolder = resourceProvider.newFolder(packagePathFoo);
@@ -1146,7 +1113,6 @@ test_pack:lib/''');
     // If the path to the context root itself contains a folder whose name
     // begins with '.', then that is not sufficient to cause any files in the
     // context to be ignored.
-    final convertPath = resourceProvider.convertPath;
     String project = convertPath('/.pub/project');
     String fileA = convertPath('$project/foo.dart');
     resourceProvider.newFile(fileA, '');
@@ -1169,7 +1135,6 @@ test_pack:lib/''');
   }
 
   test_watch_addFile() {
-    final join = resourceProvider.pathContext.join;
     manager.setRoots(<String>[projPath], <String>[], <String, String>{});
     // empty folder initially
     expect(callbacks.currentFilePaths, hasLength(0));
@@ -1185,7 +1150,6 @@ test_pack:lib/''');
   }
 
   test_watch_addFile_excluded() {
-    final convertPath = resourceProvider.convertPath;
     // prepare paths
     String project = convertPath('/project');
     String folderA = convertPath('$project/aaa');
@@ -1207,7 +1171,6 @@ test_pack:lib/''');
   }
 
   test_watch_addFile_inDocFolder_inner() {
-    final convertPath = resourceProvider.convertPath;
     // prepare paths
     String project = convertPath('/project');
     String fileA = convertPath('$project/a.dart');
@@ -1227,7 +1190,6 @@ test_pack:lib/''');
   }
 
   test_watch_addFile_inDocFolder_topLevel() {
-    final convertPath = resourceProvider.convertPath;
     // prepare paths
     String project = convertPath('/project');
     String fileA = convertPath('$project/a.dart');
@@ -1247,7 +1209,6 @@ test_pack:lib/''');
   }
 
   test_watch_addFile_pathContainsDotFile() async {
-    final convertPath = resourceProvider.convertPath;
     // If a file is added and the path to it (relative to the context root)
     // contains a folder whose name begins with '.', then the file is ignored.
     String project = convertPath('/project');
@@ -1264,7 +1225,6 @@ test_pack:lib/''');
   }
 
   test_watch_addFile_rootPathContainsDotFile() async {
-    final convertPath = resourceProvider.convertPath;
     // If a file is added and the path to the context contains a folder whose
     // name begins with '.', then the file is not ignored.
     String project = convertPath('/.pub/project');
@@ -1285,8 +1245,7 @@ test_pack:lib/''');
     // empty folder initially
     expect(callbacks.currentFilePaths, hasLength(0));
     // add file in subfolder
-    String filePath =
-        resourceProvider.pathContext.join(projPath, 'foo', 'bar.dart');
+    String filePath = join(projPath, 'foo', 'bar.dart');
     resourceProvider.newFile(filePath, 'contents');
     // the file was added
     return pumpEventQueue().then((_) {
@@ -1297,7 +1256,6 @@ test_pack:lib/''');
   }
 
   test_watch_addPackagespec_toRoot() {
-    final convertPath = resourceProvider.convertPath;
     // prepare paths
     String root = convertPath('/root');
     String rootFile = convertPath('$root/root.dart');
@@ -1320,7 +1278,6 @@ test_pack:lib/''');
   }
 
   test_watch_addPackagespec_toSubFolder() {
-    final convertPath = resourceProvider.convertPath;
     // prepare paths
     String root = convertPath('/root');
     String rootFile = convertPath('$root/root.dart');
@@ -1345,7 +1302,6 @@ test_pack:lib/''');
   }
 
   test_watch_addPackagespec_toSubFolder_ofSubFolder() {
-    final convertPath = resourceProvider.convertPath;
     // prepare paths
     String root = convertPath('/root');
     String rootFile = convertPath('$root/root.dart');
@@ -1372,7 +1328,6 @@ test_pack:lib/''');
   }
 
   test_watch_addPackagespec_toSubFolder_withPubspec() {
-    final convertPath = resourceProvider.convertPath;
     // prepare paths
     String root = convertPath('/root');
     String rootFile = convertPath('$root/root.dart');
@@ -1402,7 +1357,6 @@ test_pack:lib/''');
   }
 
   test_watch_addPubspec_toRoot() {
-    final convertPath = resourceProvider.convertPath;
     // prepare paths
     String root = convertPath('/root');
     String rootFile = convertPath('$root/root.dart');
@@ -1423,7 +1377,6 @@ test_pack:lib/''');
   }
 
   test_watch_addPubspec_toSubFolder() {
-    final convertPath = resourceProvider.convertPath;
     // prepare paths
     String root = convertPath('/root');
     String rootFile = convertPath('$root/root.dart');
@@ -1448,7 +1401,6 @@ test_pack:lib/''');
   }
 
   test_watch_addPubspec_toSubFolder_ofSubFolder() {
-    final convertPath = resourceProvider.convertPath;
     // prepare paths
     String root = convertPath('/root');
     String rootFile = convertPath('$root/root.dart');
@@ -1475,7 +1427,7 @@ test_pack:lib/''');
   }
 
   test_watch_deleteFile() {
-    String filePath = resourceProvider.pathContext.join(projPath, 'foo.dart');
+    String filePath = join(projPath, 'foo.dart');
     // add root with a file
     File file = resourceProvider.newFile(filePath, 'contents');
     Folder projFolder = file.parent;
@@ -1496,7 +1448,7 @@ test_pack:lib/''');
   }
 
   test_watch_deleteFolder() {
-    String filePath = resourceProvider.pathContext.join(projPath, 'foo.dart');
+    String filePath = join(projPath, 'foo.dart');
     // add root with a file
     File file = resourceProvider.newFile(filePath, 'contents');
     Folder projFolder = file.parent;
@@ -1517,7 +1469,6 @@ test_pack:lib/''');
   }
 
   test_watch_deletePackagespec_fromRoot() {
-    final convertPath = resourceProvider.convertPath;
     // prepare paths
     String root = convertPath('/root');
     String rootPubspec = convertPath('$root/.packages');
@@ -1538,7 +1489,6 @@ test_pack:lib/''');
   }
 
   test_watch_deletePackagespec_fromSubFolder() {
-    final convertPath = resourceProvider.convertPath;
     // prepare paths
     String root = convertPath('/root');
     String rootFile = convertPath('$root/root.dart');
@@ -1564,7 +1514,6 @@ test_pack:lib/''');
   }
 
   test_watch_deletePackagespec_fromSubFolder_withPubspec() {
-    final convertPath = resourceProvider.convertPath;
     // prepare paths:
     //
     // root
@@ -1603,7 +1552,6 @@ test_pack:lib/''');
   }
 
   test_watch_deletePubspec_fromRoot() {
-    final convertPath = resourceProvider.convertPath;
     // prepare paths
     String root = convertPath('/root');
     String rootPubspec = convertPath('$root/pubspec.yaml');
@@ -1624,7 +1572,6 @@ test_pack:lib/''');
   }
 
   test_watch_deletePubspec_fromSubFolder() {
-    final convertPath = resourceProvider.convertPath;
     // prepare paths
     String root = convertPath('/root');
     String rootFile = convertPath('$root/root.dart');
@@ -1650,7 +1597,7 @@ test_pack:lib/''');
   }
 
   test_watch_modifyFile() {
-    String filePath = resourceProvider.pathContext.join(projPath, 'foo.dart');
+    String filePath = join(projPath, 'foo.dart');
     // add root with a file
     resourceProvider.newFile(filePath, 'contents');
     manager.setRoots(<String>[projPath], <String>[], <String, String>{});
@@ -1668,7 +1615,6 @@ test_pack:lib/''');
   }
 
   test_watch_modifyPackageMapDependency_fail() async {
-    final join = resourceProvider.pathContext.join;
     // create a dependency file
     String dependencyPath = join(projPath, 'dep');
     resourceProvider.newFile(dependencyPath, 'contents');
@@ -1689,7 +1635,6 @@ test_pack:lib/''');
   }
 
   test_watch_modifyPackagespec() {
-    final convertPath = resourceProvider.convertPath;
     String packagesPath = convertPath('$projPath/.packages');
     String filePath = convertPath('$projPath/bin/main.dart');
 
@@ -1825,13 +1770,12 @@ abstract class ContextManagerTest extends Object with ResourceProviderMixin {
 
   void setUp() {
     processRequiredPlugins();
-    projPath = resourceProvider.convertPath('/my/proj');
+    projPath = convertPath('/my/proj');
     resourceProvider.newFolder(projPath);
     packageMapProvider = new MockPackageMapProvider();
     // Create an SDK in the mock file system.
     new MockSdk(generateSummaryFiles: true, resourceProvider: resourceProvider);
-    DartSdkManager sdkManager =
-        new DartSdkManager(resourceProvider.convertPath('/'), true);
+    DartSdkManager sdkManager = new DartSdkManager(convertPath('/'), true);
     manager = new ContextManagerImpl(
         resourceProvider,
         new FileContentOverlay(),
@@ -2336,7 +2280,6 @@ analyzer:
     Folder projectFolder = resourceProvider.newFolder(projPath);
     var drivers = manager.getDriversInAnalysisRoot(projectFolder);
     expect(drivers, hasLength(2));
-    final convertPath = resourceProvider.convertPath;
     expect(drivers[0].name, equals(convertPath('/my/proj')));
     expect(drivers[1].name, equals(convertPath('/my/proj/lib')));
   }
@@ -2368,7 +2311,6 @@ analyzer:
     Folder projectFolder = resourceProvider.newFolder(projPath);
     var drivers = manager.getDriversInAnalysisRoot(projectFolder);
     expect(drivers, hasLength(2));
-    final convertPath = resourceProvider.convertPath;
     expect(drivers[0].name, equals(convertPath('/my/proj')));
     expect(drivers[1].name, equals(convertPath('/my/proj/lib')));
   }
@@ -2398,13 +2340,11 @@ analyzer:
     Folder projectFolder = resourceProvider.newFolder(projPath);
     var drivers = manager.getDriversInAnalysisRoot(projectFolder);
     expect(drivers, hasLength(2));
-    final convertPath = resourceProvider.convertPath;
     expect(drivers[0].name, equals(convertPath('/my/proj')));
     expect(drivers[1].name, equals(convertPath('/my/proj/lib')));
   }
 
   void test_setRoots_nested_excludedByOuter() {
-    final convertPath = resourceProvider.convertPath;
     String project = convertPath('/project');
     String projectPubspec = convertPath('$project/pubspec.yaml');
     String example = convertPath('$project/example');
@@ -2439,7 +2379,6 @@ analyzer:
   }
 
   void test_setRoots_nested_excludedByOuter_deep() {
-    final convertPath = resourceProvider.convertPath;
     String a = convertPath('/a');
     String c = convertPath('$a/b/c');
     String aPubspec = convertPath('$a/pubspec.yaml');

--- a/pkg/analysis_server/test/domain_analysis_test.dart
+++ b/pkg/analysis_server/test/domain_analysis_test.dart
@@ -69,8 +69,8 @@ class AnalysisDomainHandlerTest extends AbstractAnalysisTest {
   }
 
   test_setAnalysisRoots_included_nonexistentFolder() async {
-    String projectA = resourceProvider.convertPath('/project_a');
-    String projectB = resourceProvider.convertPath('/project_b');
+    String projectA = convertPath('/project_a');
+    String projectB = convertPath('/project_b');
     String fileB = newFile('/project_b/b.dart', content: '// b').path;
     var response = testSetAnalysisRoots([projectA, projectB], []);
     var serverRef = server;
@@ -114,11 +114,11 @@ class AnalysisDomainHandlerTest extends AbstractAnalysisTest {
   }
 
   test_setPriorityFiles_valid() {
-    var p1 = resourceProvider.convertPath('/p1');
-    var p2 = resourceProvider.convertPath('/p2');
-    var aPath = resourceProvider.convertPath('/p1/a.dart');
-    var bPath = resourceProvider.convertPath('/p2/b.dart');
-    var cPath = resourceProvider.convertPath('/p2/c.dart');
+    var p1 = convertPath('/p1');
+    var p2 = convertPath('/p2');
+    var aPath = convertPath('/p1/a.dart');
+    var bPath = convertPath('/p2/b.dart');
+    var cPath = convertPath('/p2/c.dart');
     newFile(aPath, content: 'library a;');
     newFile(bPath, content: 'library b;');
     newFile(cPath, content: 'library c;');
@@ -354,8 +354,8 @@ class AnalysisTestHelper extends Object with ResourceProviderMixin {
   String testCode;
 
   AnalysisTestHelper() {
-    projectPath = resourceProvider.convertPath('/project');
-    testFile = resourceProvider.convertPath('/project/bin/test.dart');
+    projectPath = convertPath('/project');
+    testFile = convertPath('/project/bin/test.dart');
     processRequiredPlugins();
     serverChannel = new MockServerChannel();
     // Create an SDK in the mock file system.
@@ -365,7 +365,7 @@ class AnalysisTestHelper extends Object with ResourceProviderMixin {
         resourceProvider,
         new MockPackageMapProvider(),
         new AnalysisServerOptions()..previewDart2 = true,
-        new DartSdkManager(resourceProvider.convertPath('/'), false),
+        new DartSdkManager(convertPath('/'), false),
         InstrumentationService.NULL_SERVICE);
     handler = new AnalysisDomainHandler(server);
     // listen for notifications
@@ -614,7 +614,6 @@ main() {
   }
 
   test_afterAnalysis_packageFile_inRoot() async {
-    final convertPath = resourceProvider.convertPath;
     String pkgA = convertPath('/pkgA');
     String pkgB = convertPath('/pkgA');
     String pkgFileA = newFile('$pkgA/lib/libA.dart', content: '''
@@ -666,7 +665,7 @@ class A {}
   }
 
   test_afterAnalysis_sdkFile() async {
-    String file = resourceProvider.convertPath('/lib/core/core.dart');
+    String file = convertPath('/lib/core/core.dart');
     addTestFile('// no matter');
     createProject();
     // wait for analysis, no results initially

--- a/pkg/analysis_server/test/domain_analysis_test.dart
+++ b/pkg/analysis_server/test/domain_analysis_test.dart
@@ -365,7 +365,7 @@ class AnalysisTestHelper extends Object with ResourceProviderMixin {
         resourceProvider,
         new MockPackageMapProvider(),
         new AnalysisServerOptions()..previewDart2 = true,
-        new DartSdkManager('/', false),
+        new DartSdkManager(resourceProvider.convertPath('/'), false),
         InstrumentationService.NULL_SERVICE);
     handler = new AnalysisDomainHandler(server);
     // listen for notifications
@@ -614,8 +614,9 @@ main() {
   }
 
   test_afterAnalysis_packageFile_inRoot() async {
-    String pkgA = '/pkgA';
-    String pkgB = '/pkgA';
+    final convertPath = resourceProvider.convertPath;
+    String pkgA = convertPath('/pkgA');
+    String pkgB = convertPath('/pkgA');
     String pkgFileA = newFile('$pkgA/lib/libA.dart', content: '''
 library lib_a;
 class A {}
@@ -665,7 +666,7 @@ class A {}
   }
 
   test_afterAnalysis_sdkFile() async {
-    String file = '/lib/core/core.dart';
+    String file = resourceProvider.convertPath('/lib/core/core.dart');
     addTestFile('// no matter');
     createProject();
     // wait for analysis, no results initially

--- a/pkg/analysis_server/test/edit/organize_directives_test.dart
+++ b/pkg/analysis_server/test/edit/organize_directives_test.dart
@@ -84,8 +84,8 @@ main() {
   }
 
   Future test_OK_remove_unresolvedDirectives() {
-    newFile('$testFolder/existing_part1.dart', content: 'part of lib;');
-    newFile('$testFolder/existing_part2.dart', content: 'part of lib;');
+    newFile(join(testFolder, 'existing_part1.dart'), content: 'part of lib;');
+    newFile(join(testFolder, 'existing_part2.dart'), content: 'part of lib;');
     addTestFile('''
 library lib;
 

--- a/pkg/analysis_server/test/edit/refactoring_test.dart
+++ b/pkg/analysis_server/test/edit/refactoring_test.dart
@@ -280,7 +280,7 @@ class ExtractLocalVariableTest extends _AbstractGetRefactoring_Test {
 
   test_analysis_onlyOneFile() async {
     shouldWaitForFullAnalysis = false;
-    newFile('$testFolder/other.dart', content: r'''
+    newFile(join(testFolder, 'other.dart'), content: r'''
 foo(int myName) {}
 ''');
     addTestFile('''
@@ -452,7 +452,7 @@ main() {
   }
 
   test_resetOnAnalysisSetChanged_watch_otherFile() async {
-    String otherFile = '$testFolder/other.dart';
+    String otherFile = join(testFolder, 'other.dart');
     newFile(otherFile, content: '// other 1');
     addTestFile('''
 main() {
@@ -987,7 +987,7 @@ main() {
 class InlineLocalTest extends _AbstractGetRefactoring_Test {
   test_analysis_onlyOneFile() async {
     shouldWaitForFullAnalysis = false;
-    String otherFile = '$testFolder/other.dart';
+    String otherFile = join(testFolder, 'other.dart');
     newFile(otherFile, content: r'''
 foo(int p) {}
 ''');
@@ -1056,7 +1056,7 @@ main() {
   }
 
   test_resetOnAnalysisSetChanged() async {
-    newFile('$testFolder/other.dart', content: '// other 1');
+    newFile(join(testFolder, 'other.dart'), content: '// other 1');
     addTestFile('''
 main() {
   int res = 1 + 2;
@@ -1761,7 +1761,7 @@ library my.new_name;
   }
 
   test_library_partOfDirective() {
-    newFile('$testFolder/my_lib.dart', content: '''
+    newFile(join(testFolder, 'my_lib.dart'), content: '''
 library aaa.bbb.ccc;
 part 'test.dart';
 ''');

--- a/pkg/analysis_server/test/mock_sdk.dart
+++ b/pkg/analysis_server/test/mock_sdk.dart
@@ -387,7 +387,7 @@ const Map<String, LibraryInfo> libraries = const {
 
     String path = uriToPath[dartUri];
     if (path != null) {
-      resource.File file = provider.getResource(path);
+      resource.File file = provider.getResource(provider.convertPath(path));
       Uri uri = new Uri(scheme: 'dart', path: dartUri.substring(5));
       return file.createSource(uri);
     }

--- a/pkg/analysis_server/test/mock_sdk.dart
+++ b/pkg/analysis_server/test/mock_sdk.dart
@@ -275,7 +275,8 @@ const Map<String, LibraryInfo> libraries = const {
       resource.ResourceProvider resourceProvider})
       : provider = resourceProvider ?? new resource.MemoryResourceProvider() {
     LIBRARIES.forEach((SdkLibrary library) {
-      provider.newFile(library.path, (library as MockSdkLibrary).content);
+      provider.newFile(provider.convertPath(library.path),
+          (library as MockSdkLibrary).content);
     });
     provider.newFile(
         provider.convertPath(

--- a/pkg/analysis_server/test/search/type_hierarchy_test.dart
+++ b/pkg/analysis_server/test/search/type_hierarchy_test.dart
@@ -695,7 +695,7 @@ class D extends C {
   }
 
   test_member_method_private_differentLib() async {
-    newFile('$testFolder/lib.dart', content: r'''
+    newFile(join(testFolder, 'lib.dart'), content: r'''
 import 'test.dart';
 class A {
   void _m() {}

--- a/pkg/analysis_server/test/services/refactoring/rename_unit_member_test.dart
+++ b/pkg/analysis_server/test/services/refactoring/rename_unit_member_test.dart
@@ -69,7 +69,7 @@ class B extends A {
     await indexTestUnit('''
 class Test {}
 ''');
-    await indexUnit('/lib.dart', '''
+    await indexUnit(convertPath('/lib.dart'), '''
 library my.lib;
 import 'test.dart';
 
@@ -109,7 +109,7 @@ class A {
     await indexTestUnit('''
 class Test {}
 ''');
-    await indexUnit('/lib.dart', '''
+    await indexUnit(convertPath('/lib.dart'), '''
 library my.lib;
 import 'test.dart';
 class A {
@@ -627,5 +627,9 @@ main() {
   newName += 2;
 }
 ''');
+  }
+
+  String convertPath(String path) {
+    return resourceProvider.convertPath(path);
   }
 }

--- a/pkg/analysis_server/test/services/refactoring/rename_unit_member_test.dart
+++ b/pkg/analysis_server/test/services/refactoring/rename_unit_member_test.dart
@@ -628,8 +628,4 @@ main() {
 }
 ''');
   }
-
-  String convertPath(String path) {
-    return resourceProvider.convertPath(path);
-  }
 }

--- a/pkg/analysis_server/test/src/computer/imported_elements_computer_test.dart
+++ b/pkg/analysis_server/test/src/computer/imported_elements_computer_test.dart
@@ -27,10 +27,6 @@ class ImportElementsComputerTest extends AbstractContextTest {
     sourcePath = resourceProvider.convertPath('/p/lib/source.dart');
   }
 
-  String convertPath(String path) {
-    return resourceProvider.convertPath(path);
-  }
-
   test_dartAsync_noPrefix() async {
     String selection = "Future<String> f = null;";
     String content = """
@@ -260,8 +256,7 @@ blankLine() {
     expect(elementsList, hasLength(1));
     ImportedElements elements = elementsList[0];
     expect(elements, isNotNull);
-    expect(elements.path,
-        resourceProvider.convertPath('/pubcache/foo/lib/foo.dart'));
+    expect(elements.path, convertPath('/pubcache/foo/lib/foo.dart'));
     expect(elements.prefix, '');
     expect(elements.elements, unorderedEquals(['A', 'B']));
   }

--- a/pkg/analysis_server/test/src/computer/imported_elements_computer_test.dart
+++ b/pkg/analysis_server/test/src/computer/imported_elements_computer_test.dart
@@ -27,6 +27,10 @@ class ImportElementsComputerTest extends AbstractContextTest {
     sourcePath = resourceProvider.convertPath('/p/lib/source.dart');
   }
 
+  String convertPath(String path) {
+    return resourceProvider.convertPath(path);
+  }
+
   test_dartAsync_noPrefix() async {
     String selection = "Future<String> f = null;";
     String content = """
@@ -43,7 +47,7 @@ printer() {
     ImportedElements elements2 = elementsList[1];
     ImportedElements asyncElements;
     ImportedElements coreElements;
-    if (elements1.path == '/lib/core/core.dart') {
+    if (elements1.path == convertPath('/lib/core/core.dart')) {
       coreElements = elements1;
       asyncElements = elements2;
     } else {
@@ -51,12 +55,12 @@ printer() {
       asyncElements = elements1;
     }
     expect(coreElements, isNotNull);
-    expect(coreElements.path, '/lib/core/core.dart');
+    expect(coreElements.path, convertPath('/lib/core/core.dart'));
     expect(coreElements.prefix, '');
     expect(coreElements.elements, unorderedEquals(['String']));
 
     expect(asyncElements, isNotNull);
-    expect(asyncElements.path, '/lib/async/async.dart');
+    expect(asyncElements.path, convertPath('/lib/async/async.dart'));
     expect(asyncElements.prefix, '');
     expect(asyncElements.elements, unorderedEquals(['Future']));
   }
@@ -77,7 +81,7 @@ printer() {
     ImportedElements elements2 = elementsList[1];
     ImportedElements asyncElements;
     ImportedElements coreElements;
-    if (elements1.path == '/lib/core/core.dart') {
+    if (elements1.path == convertPath('/lib/core/core.dart')) {
       coreElements = elements1;
       asyncElements = elements2;
     } else {
@@ -85,12 +89,12 @@ printer() {
       asyncElements = elements1;
     }
     expect(coreElements, isNotNull);
-    expect(coreElements.path, '/lib/core/core.dart');
+    expect(coreElements.path, convertPath('/lib/core/core.dart'));
     expect(coreElements.prefix, '');
     expect(coreElements.elements, unorderedEquals(['String']));
 
     expect(asyncElements, isNotNull);
-    expect(asyncElements.path, '/lib/async/async.dart');
+    expect(asyncElements.path, convertPath('/lib/async/async.dart'));
     expect(asyncElements.prefix, 'a');
     expect(asyncElements.elements, unorderedEquals(['Future']));
   }
@@ -108,7 +112,7 @@ blankLine() {
     expect(elementsList, hasLength(1));
     ImportedElements elements = elementsList[0];
     expect(elements, isNotNull);
-    expect(elements.path, '/lib/core/core.dart');
+    expect(elements.path, convertPath('/lib/core/core.dart'));
     expect(elements.prefix, '');
     expect(elements.elements, unorderedEquals(['String']));
   }
@@ -127,7 +131,7 @@ blankLine() {
     expect(elementsList, hasLength(1));
     ImportedElements elements = elementsList[0];
     expect(elements, isNotNull);
-    expect(elements.path, '/lib/core/core.dart');
+    expect(elements.path, convertPath('/lib/core/core.dart'));
     expect(elements.prefix, 'core');
     expect(elements.elements, unorderedEquals(['String']));
   }
@@ -146,7 +150,7 @@ bool randomBool() {
     expect(elementsList, hasLength(1));
     ImportedElements elements = elementsList[0];
     expect(elements, isNotNull);
-    expect(elements.path, '/lib/math/math.dart');
+    expect(elements.path, convertPath('/lib/math/math.dart'));
     expect(elements.prefix, '');
     expect(elements.elements, unorderedEquals(['Random']));
   }
@@ -170,13 +174,13 @@ $selection
 
     ImportedElements mathElements = elementsList[0];
     expect(mathElements, isNotNull);
-    expect(mathElements.path, '/lib/math/math.dart');
+    expect(mathElements.path, convertPath('/lib/math/math.dart'));
     expect(mathElements.prefix, '');
     expect(mathElements.elements, unorderedEquals(['Random']));
 
     ImportedElements coreElements = elementsList[1];
     expect(coreElements, isNotNull);
-    expect(coreElements.path, '/lib/core/core.dart');
+    expect(coreElements.path, convertPath('/lib/core/core.dart'));
     expect(coreElements.prefix, '');
     expect(coreElements.elements, unorderedEquals(['String', 'print']));
   }
@@ -256,7 +260,8 @@ blankLine() {
     expect(elementsList, hasLength(1));
     ImportedElements elements = elementsList[0];
     expect(elements, isNotNull);
-    expect(elements.path, '/pubcache/foo/lib/foo.dart');
+    expect(elements.path,
+        resourceProvider.convertPath('/pubcache/foo/lib/foo.dart'));
     expect(elements.prefix, '');
     expect(elements.elements, unorderedEquals(['A', 'B']));
   }
@@ -279,7 +284,7 @@ blankLine() {
     expect(elementsList, hasLength(1));
     ImportedElements elements = elementsList[0];
     expect(elements, isNotNull);
-    expect(elements.path, '/pubcache/foo/lib/foo.dart');
+    expect(elements.path, convertPath('/pubcache/foo/lib/foo.dart'));
     expect(elements.prefix, '');
     expect(elements.elements, unorderedEquals(['Foo']));
   }
@@ -302,7 +307,7 @@ blankLine() {
     expect(elementsList, hasLength(1));
     ImportedElements elements = elementsList[0];
     expect(elements, isNotNull);
-    expect(elements.path, '/pubcache/foo/lib/foo.dart');
+    expect(elements.path, convertPath('/pubcache/foo/lib/foo.dart'));
     expect(elements.prefix, 'f');
     expect(elements.elements, unorderedEquals(['Foo']));
   }
@@ -325,7 +330,7 @@ blankLine() {
     expect(elementsList, hasLength(1));
     ImportedElements elements = elementsList[0];
     expect(elements, isNotNull);
-    expect(elements.path, '/pubcache/foo/lib/foo.dart');
+    expect(elements.path, convertPath('/pubcache/foo/lib/foo.dart'));
     expect(elements.prefix, '');
     expect(elements.elements, unorderedEquals(['Foo']));
   }
@@ -362,12 +367,12 @@ blankLine() {
     }
 
     expect(notPrefixedElements, isNotNull);
-    expect(notPrefixedElements.path, '/pubcache/foo/lib/foo.dart');
+    expect(notPrefixedElements.path, convertPath('/pubcache/foo/lib/foo.dart'));
     expect(notPrefixedElements.prefix, '');
     expect(notPrefixedElements.elements, unorderedEquals(['Foo']));
 
     expect(prefixedElements, isNotNull);
-    expect(prefixedElements.path, '/pubcache/foo/lib/foo.dart');
+    expect(prefixedElements.path, convertPath('/pubcache/foo/lib/foo.dart'));
     expect(prefixedElements.prefix, 'f');
     expect(prefixedElements.elements, unorderedEquals(['Foo']));
   }

--- a/pkg/analyzer/lib/src/test_utilities/resource_provider_mixin.dart
+++ b/pkg/analyzer/lib/src/test_utilities/resource_provider_mixin.dart
@@ -52,4 +52,17 @@ class ResourceProviderMixin {
     String convertedPath = resourceProvider.convertPath(path);
     return resourceProvider.newFolder(convertedPath);
   }
+
+  String join(String part1,
+          [String part2,
+          String part3,
+          String part4,
+          String part5,
+          String part6,
+          String part7,
+          String part8]) =>
+      resourceProvider.pathContext
+          .join(part1, part2, part3, part4, part5, part6, part7, part8);
+
+  String convertPath(String path) => resourceProvider.convertPath(path);
 }


### PR DESCRIPTION
The other lines on this method are calling `provider.convertPath` around their paths but these ones do not, which is causing almost all analysis server tests to fail on Windows (for me - I can't explain them not
failing builds). This causes the hard-coded paths like `/lib/core/core.dart` to be fixed up to `C:\lib\core\core.dart` which is what the server is looking for (because at the other end the paths *have* been fixed up).

See #32226.