### PR TITLE
Fix Homebrew undent warning

### DIFF
--- a/tools/apps/update_homebrew/lib/update_homebrew.dart
+++ b/tools/apps/update_homebrew/lib/update_homebrew.dart
@@ -170,13 +170,13 @@ class Dart < Formula
   end
 
   def shim_script(target)
-    <<-EOS.undent
+    <<~EOS
       #!/usr/bin/env bash
       exec "#{prefix}/#{target}" "\$@"
     EOS
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     Please note the path to the Dart SDK:
       #{opt_libexec}
 
@@ -187,7 +187,7 @@ class Dart < Formula
   end
 
   test do
-    (testpath/"sample.dart").write <<-EOS.undent
+    (testpath/"sample.dart").write <<~EOS
       void main() {
         print(r"test message");
       }


### PR DESCRIPTION
Update the generated `dart.rb` formula file to fix:

```
Warning: Calling <<-EOS.undent is deprecated!
Use <<~EOS instead.
/usr/local/Homebrew/Library/Taps/dart-lang/homebrew-dart/dart.rb:72:in `caveats'
Please report this to the dart-lang/dart tap!
```

being reported by `brew`.

Fixes https://github.com/dart-lang/homebrew-dart/issues/48

Credit for original patch to @fsouza:

https://github.com/fsouza/homebrew-dart/commit/06b76e0935a0c74e8f10d32b81e1b72358a661b4