### PR TITLE
If a directory entry is invalid utf8, consider it a kListError.

### DIFF
--- a/runtime/bin/directory_linux.cc
+++ b/runtime/bin/directory_linux.cc
@@ -23,6 +23,7 @@
 #include "bin/namespace.h"
 #include "bin/platform.h"
 #include "platform/signal_blocker.h"
+#include "vm/unicode.h"
 
 namespace dart {
 namespace bin {
@@ -120,6 +121,11 @@ ListType DirectoryListingEntry::Next(DirectoryListing* listing) {
   // ports.
   errno = 0;
   dirent* entry = readdir(reinterpret_cast<DIR*>(lister_));
+  if (entry != NULL) {
+    const uint8_t* d_name = reinterpret_cast<uint8_t *>(entry->d_name);
+    if (!Utf8::IsValid(d_name, strlen(entry->d_name)))
+      return kListError;
+  }
   if (entry != NULL) {
     if (!listing->path_buffer().Add(entry->d_name)) {
       done_ = true;


### PR DESCRIPTION
Not to be merged as is - it's just an idea.

Following the "steps to reproduce" by @tvolkert in https://github.com/dart-lang/sdk/issues/29451 before this pr produces this error:
Dart_NewStringFromUTF8 expects argument 'str' to be valid UTF-8.

With this PR:
Unhandled exception:
FileSystemException: Directory listing failed, path = '/tmp/dartcrash/' (OS Error: Success, errno = 0)
#0      _Directory._fillWithDirectoryListing (dart:io-patch/directory_patch.dart:34)
#1      _Directory.listSync (dart:io/directory_impl.dart:214)
#2      main (file:///tmp/dartcrash/test.dart:5:21)
#3      _startIsolate.<anonymous closure> (dart:isolate-patch/dart:isolate/isolate_patch.dart:279)
#4      _RawReceivePortImpl._handleMessage (dart:isolate-patch/dart:isolate/isolate_patch.dart:165)

This is a sketch only (tried this on my Linux Mint machine at home), but if the approach is ok then it could be generalized enough so the error is easier to understand. E.g. "Directory listing failed due to invalid UTF8 in directory listing of '/tmp/dartcrash'" or similar.