### PR TITLE
Proof of concept for listing directories with file names that have invalid utf8 bytes in them.

### DIFF
--- a/runtime/bin/directory.cc
+++ b/runtime/bin/directory.cc
@@ -5,6 +5,7 @@
 #include "bin/directory.h"
 
 #include "bin/dartutils.h"
+#include "bin/io_buffer.h"
 #include "bin/log.h"
 #include "bin/namespace.h"
 #include "include/dart_api.h"
@@ -432,8 +433,24 @@ bool SyncDirectoryListing::HandleLink(const char* link_name) {
 }
 
 bool SyncDirectoryListing::HandleFile(const char* file_name) {
-  Dart_Handle file_name_dart = DartUtils::NewString(file_name);
-  Dart_Handle file = Dart_New(file_type_, Dart_Null(), 1, &file_name_dart);
+  // Allocates a Uint8List for file_name, and invokes the File.fromRawPath
+  // constructor. This avoids/delays interpreting the utf8 bytes in file_name.
+  // Later, client code may either choose to access FileSystemEntity.path
+  // or FileSystemEntity.rawPath. FileSystemEntity.path will trigger
+  // UTF8 decoding and throw an exception if invalid bytes are found,
+  // whereas FileSystemEntity.rawPath returns the bytes exactly as they
+  // came from the OS (same as what's in file_name here).
+
+  size_t file_name_length = strlen(file_name);
+  uint8_t* buffer = NULL;
+  Dart_Handle file_name_dart = IOBuffer::Allocate(file_name_length, &buffer);
+  if (Dart_IsNull(file_name_dart)) {
+    dart_error_ = DartUtils::NewDartOSError();
+    return false;
+  }
+  memmove(buffer, file_name, file_name_length);
+  Dart_Handle constructor_name = DartUtils::NewString("fromRawPath");
+  Dart_Handle file = Dart_New(file_type_, constructor_name, 1, &file_name_dart);
   Dart_Handle result = Dart_Invoke(results_, add_string_, 1, &file);
   if (Dart_IsError(result)) {
     dart_error_ = result;

--- a/runtime/bin/directory.cc
+++ b/runtime/bin/directory.cc
@@ -449,7 +449,7 @@ bool SyncDirectoryListing::HandleFile(const char* file_name) {
     return false;
   }
   memmove(buffer, file_name, file_name_length);
-  Dart_Handle constructor_name = DartUtils::NewString("fromRawPath");
+  Dart_Handle constructor_name = from_raw_path_string_;
   Dart_Handle file = Dart_New(file_type_, constructor_name, 1, &file_name_dart);
   Dart_Handle result = Dart_Invoke(results_, add_string_, 1, &file);
   if (Dart_IsError(result)) {

--- a/runtime/bin/directory.h
+++ b/runtime/bin/directory.h
@@ -211,6 +211,7 @@ class SyncDirectoryListing : public DirectoryListing {
         results_(results),
         dart_error_(Dart_Null()) {
     add_string_ = DartUtils::NewString("add");
+    from_raw_path_string_ = DartUtils::NewString("fromRawPath");
     directory_type_ = DartUtils::GetDartType(DartUtils::kIOLibURL, "Directory");
     file_type_ = DartUtils::GetDartType(DartUtils::kIOLibURL, "File");
     link_type_ = DartUtils::GetDartType(DartUtils::kIOLibURL, "Link");
@@ -226,6 +227,7 @@ class SyncDirectoryListing : public DirectoryListing {
  private:
   Dart_Handle results_;
   Dart_Handle add_string_;
+  Dart_Handle from_raw_path_string_;
   Dart_Handle directory_type_;
   Dart_Handle file_type_;
   Dart_Handle link_type_;

--- a/sdk/lib/io/directory_impl.dart
+++ b/sdk/lib/io/directory_impl.dart
@@ -5,13 +5,14 @@
 part of dart.io;
 
 class _Directory extends FileSystemEntity implements Directory {
-  final String path;
+  Uint8List rawPath;
 
-  _Directory(this.path) {
+  _Directory(String path) {
     if (path is! String) {
-      throw new ArgumentError('${Error.safeToString(path)} '
-          'is not a String');
+      throw new ArgumentError(
+          '${Error.safeToString(path)} is not a String');
     }
+    this.rawPath = new Uint8List.fromList(utf8.encode(path));
   }
 
   external static _current(_Namespace namespace);

--- a/sdk/lib/io/directory_impl.dart
+++ b/sdk/lib/io/directory_impl.dart
@@ -5,15 +5,19 @@
 part of dart.io;
 
 class _Directory extends FileSystemEntity implements Directory {
-  Uint8List rawPath;
+  Uint8List _rawPath;
 
   _Directory(String path) {
     if (path is! String) {
       throw new ArgumentError(
           '${Error.safeToString(path)} is not a String');
     }
-    this.rawPath = new Uint8List.fromList(utf8.encode(path));
+    this._rawPath = new Uint8List.fromList(utf8.encode(path));
   }
+
+  _Directory.fromRawPath(this._rawPath);
+
+  Uint8List get rawPath => _rawPath;
 
   external static _current(_Namespace namespace);
   external static _setCurrent(_Namespace namespace, path);

--- a/sdk/lib/io/file.dart
+++ b/sdk/lib/io/file.dart
@@ -235,6 +235,15 @@ abstract class File implements FileSystemEntity {
   factory File.fromUri(Uri uri) => new File(uri.toFilePath());
 
   /**
+   * Creates a File object from a raw path, that is, a sequence of bytes
+   * as represented by the OS.
+   */
+  factory File.fromRawPath(Uint8List rawPath) {
+    // TODO(powdercloud): Handle overrides (see File constructor for example).
+    return new _File.fromRawPath(rawPath);
+  }
+
+  /**
    * Create the file. Returns a `Future<File>` that completes with
    * the file when it has been created.
    *

--- a/sdk/lib/io/file_impl.dart
+++ b/sdk/lib/io/file_impl.dart
@@ -203,15 +203,17 @@ class _FileStreamConsumer extends StreamConsumer<List<int>> {
 
 // Class for encapsulating the native implementation of files.
 class _File extends FileSystemEntity implements File {
-  final String path;
+  Uint8List rawPath;
 
-  // Constructor for file.
-  _File(this.path) {
+  _File(String path) {
     if (path is! String) {
-      throw new ArgumentError('${Error.safeToString(path)} '
-          'is not a String');
+      throw new ArgumentError(
+          '${Error.safeToString(path)} is not a String');
     }
+    this.rawPath = new Uint8List.fromList(utf8.encode(path));
   }
+
+  _File.fromRawPath(this.rawPath) {}
 
   // WARNING:
   // Calling this function will increase the reference count on the native

--- a/sdk/lib/io/file_impl.dart
+++ b/sdk/lib/io/file_impl.dart
@@ -203,17 +203,19 @@ class _FileStreamConsumer extends StreamConsumer<List<int>> {
 
 // Class for encapsulating the native implementation of files.
 class _File extends FileSystemEntity implements File {
-  Uint8List rawPath;
+  Uint8List _rawPath;
 
   _File(String path) {
     if (path is! String) {
       throw new ArgumentError(
           '${Error.safeToString(path)} is not a String');
     }
-    this.rawPath = new Uint8List.fromList(utf8.encode(path));
+    this._rawPath = new Uint8List.fromList(utf8.encode(path));
   }
 
-  _File.fromRawPath(this.rawPath) {}
+  _File.fromRawPath(this._rawPath);
+
+  Uint8List get rawPath => _rawPath;
 
   // WARNING:
   // Calling this function will increase the reference count on the native

--- a/sdk/lib/io/file_system_entity.dart
+++ b/sdk/lib/io/file_system_entity.dart
@@ -243,8 +243,14 @@ FileStat: type $type
  *   files and directories.
  */
 abstract class FileSystemEntity {
-  String get path => utf8.decode(rawPath);
   Uint8List get rawPath;
+
+  String _cachedPath;
+
+  String get path {
+    if (_cachedPath != null) return _cachedPath;
+    return _cachedPath = utf8.decode(rawPath);
+  }
 
   /**
    * Returns a [Uri] representing the file system entity's location.

--- a/sdk/lib/io/file_system_entity.dart
+++ b/sdk/lib/io/file_system_entity.dart
@@ -243,7 +243,8 @@ FileStat: type $type
  *   files and directories.
  */
 abstract class FileSystemEntity {
-  String get path;
+  String get path => utf8.decode(rawPath);
+  Uint8List get rawPath;
 
   /**
    * Returns a [Uri] representing the file system entity's location.

--- a/sdk/lib/io/link.dart
+++ b/sdk/lib/io/link.dart
@@ -150,13 +150,14 @@ abstract class Link implements FileSystemEntity {
 }
 
 class _Link extends FileSystemEntity implements Link {
-  final String path;
+  Uint8List rawPath;
 
-  _Link(this.path) {
+  _Link(String path) {
     if (path is! String) {
       throw new ArgumentError('${Error.safeToString(path)} '
           'is not a String');
     }
+    this.rawPath = new Uint8List.fromList(utf8.encode(path));
   }
 
   String toString() => "Link: '$path'";

--- a/sdk/lib/io/link.dart
+++ b/sdk/lib/io/link.dart
@@ -150,15 +150,19 @@ abstract class Link implements FileSystemEntity {
 }
 
 class _Link extends FileSystemEntity implements Link {
-  Uint8List rawPath;
+  Uint8List _rawPath;
 
   _Link(String path) {
     if (path is! String) {
       throw new ArgumentError('${Error.safeToString(path)} '
           'is not a String');
     }
-    this.rawPath = new Uint8List.fromList(utf8.encode(path));
+    this._rawPath = new Uint8List.fromList(utf8.encode(path));
   }
+
+  _Link.fromRawPath(this._rawPath);
+
+  Uint8List get rawPath => _rawPath;
 
   String toString() => "Link: '$path'";
 


### PR DESCRIPTION
In FileSystemEntity, have a rawPath getter in addition to a path getter.
rawPath is a Uint8List, wheras path is a String which is utf8 decoded from rawPath.
This can throw a FormatException, from _Utf8Decoder.convert.

Each implementation of FileSystemEntity must provide rawPath.
This could break client code if it implements FileSystemEntity.
In this PR I've fixed it so things build, by editing File, Directory, and Link
so that each of their existing constructors (which take a String)
encode into rawPath.

To show that we can now list directories with file names that have invalid bytes
in file names, I've added a File.fromRawPath factory, which exposes a way to create
a FileSystemEntity representing a file with uninterpreted bytes as their name.

SyncDirectoryListing::HandleFile in directory.cc makes use of this.

The net effect is that the original test file from
https://github.com/dart-lang/sdk/issues/29451
now prints "done", because the rawPath never gets converted into a String.

However, if a print is added to dump the directory listing ...

```
import 'dart:io';

void main() {
  print(Directory.current.listSync());
  print('done');
}
```

instead of dying without a stack trace as in https://github.com/dart-lang/sdk/issues/29451,
we get this:

```
Unhandled exception:                                                                                                                                                     
FormatException: Bad UTF-8 encoding 0xb6 (at offset 14)                                                                                                                  
#0      _Utf8Decoder.convert (dart:convert/utf.dart:574)                                                                                                                 
#1      Utf8Decoder.convert (dart:convert/utf.dart:350)                                                                                                                  
#2      Utf8Codec.decode (dart:convert/utf.dart:72)                                                                                                                      
#3      FileSystemEntity.path (dart:io/file_system_entity.dart:246)                                                                                                      
#4      _File.toString (dart:io/file_impl.dart:626)                                                                                                                      
#5      _StringBase._interpolateSingle (dart:core-patch/dart:core/string_patch.dart:799)                                                                                 
#6      StringBuffer.write (dart:core-patch/dart:core/string_buffer_patch.dart:64)                                                                                       
#7      StringBuffer.writeAll (dart:core-patch/dart:core/string_buffer_patch.dart:100)                                                                                   
#8      IterableBase.iterableToFullString (dart:collection/iterable.dart:285)                                                                                            
#9      ListBase.listToString (dart:collection/list.dart:32)                                                                                                             
#10     List.toString (dart:core-patch/dart:core/growable_array.dart:360)                                                                                                
#11     _StringBase._interpolateSingle (dart:core-patch/dart:core/string_patch.dart:799)                                                                                 
#12     print (dart:core/print.dart:9)                                                                                                                                   
#13     main (file:///tmp/darttest/test.dart:5:3)                                                                                                                        
#14     _startIsolate.<anonymous closure> (dart:isolate-patch/dart:isolate/isolate_patch.dart:279)                                                                       
#15     _RawReceivePortImpl._handleMessage (dart:isolate-patch/dart:isolate/isolate_patch.dart:165) 
```                                                                     

Client code may access the rawPath instead of trying to print the path, in which case there won't be an exception.