### PR TITLE
core: Update Map methods that use Object instead of K

### DIFF
--- a/sdk/lib/core/map.dart
+++ b/sdk/lib/core/map.dart
@@ -213,7 +213,7 @@ abstract class Map<K, V> {
    * Returns true if any of the values in the map are equal to `value`
    * according to the `==` operator.
    */
-  bool containsValue(Object value);
+  bool containsValue(V value);
 
   /**
    * Returns true if this map contains the given [key].
@@ -221,7 +221,7 @@ abstract class Map<K, V> {
    * Returns true if any of the keys in the map are equal to `key`
    * according to the equality used by the map.
    */
-  bool containsKey(Object key);
+  bool containsKey(K key);
 
   /**
    * Returns the value for the given [key] or null if [key] is not in the map.
@@ -233,7 +233,7 @@ abstract class Map<K, V> {
    * Methods like [containsKey] or [putIfAbsent] can be use if the distinction
    * is important.
    */
-  V operator [](Object key);
+  V operator [](K key);
 
   /**
    * Associates the [key] with the given [value].
@@ -332,7 +332,7 @@ abstract class Map<K, V> {
    * Note that values can be `null` and a returned `null` value doesn't
    * always mean that the key was absent.
    */
-  V remove(Object key);
+  V remove(K key);
 
   /**
    * Removes all pairs from the map.


### PR DESCRIPTION
Currently some of the method signatures use `Object` instead of the `K`
type.  Change them to accept an object of type `K` instead.