### PR TITLE
Increase analysis server version to 1.20.1

### DIFF
--- a/pkg/analysis_server/doc/api.html
+++ b/pkg/analysis_server/doc/api.html
@@ -109,7 +109,7 @@ a:focus, a:hover {
 <body>
 <h1>Analysis Server API Specification</h1>
 <h1 style="color:#999999">Version
-  1.20.0
+  1.20.1
 </h1>
 <p>
   This document contains a specification of the API provided by the

--- a/pkg/analysis_server/lib/src/analysis_server.dart
+++ b/pkg/analysis_server/lib/src/analysis_server.dart
@@ -108,7 +108,7 @@ class AnalysisServer {
    * The version of the analysis server. The value should be replaced
    * automatically during the build.
    */
-  static final String VERSION = '1.20.0';
+  static final String VERSION = '1.20.1';
 
   /**
    * The options of this server instance.

--- a/pkg/analysis_server/tool/spec/spec_input.html
+++ b/pkg/analysis_server/tool/spec/spec_input.html
@@ -7,7 +7,7 @@
 <body>
 <h1>Analysis Server API Specification</h1>
 <h1 style="color:#999999">Version
-  <version>1.20.0</version>
+  <version>1.20.1</version>
 </h1>
 <p>
   This document contains a specification of the API provided by the


### PR DESCRIPTION
So clients can detect when the workaround for #29414 is not required.