### PR TITLE
Validate cookie values wrapped in double-quotes

### DIFF
--- a/sdk/lib/_http/http_headers.dart
+++ b/sdk/lib/_http/http_headers.dart
@@ -986,7 +986,7 @@ class _Cookie implements Cookie {
       }
     }
     
-    if (value[0] == '"' || value[value.length - 1] == '"')
+    if (value[0] == '"' && value[value.length - 1] == '"')
       value = value.slice(1, value.length - 2)
     
     for (int i = 0; i < value.length; i++) {

--- a/sdk/lib/_http/http_headers.dart
+++ b/sdk/lib/_http/http_headers.dart
@@ -987,7 +987,7 @@ class _Cookie implements Cookie {
     }
     
     if (value[0] == '"' && value[value.length - 1] == '"')
-      value = value.slice(1, value.length - 1)
+      value = value.subString(1, value.length - 1)
     
     for (int i = 0; i < value.length; i++) {
       int codeUnit = value.codeUnits[i];

--- a/sdk/lib/_http/http_headers.dart
+++ b/sdk/lib/_http/http_headers.dart
@@ -987,7 +987,7 @@ class _Cookie implements Cookie {
     }
     
     if (value[0] == '"' && value[value.length - 1] == '"')
-      value = value.slice(1, value.length - 2)
+      value = value.slice(1, value.length - 1)
     
     for (int i = 0; i < value.length; i++) {
       int codeUnit = value.codeUnits[i];

--- a/sdk/lib/_http/http_headers.dart
+++ b/sdk/lib/_http/http_headers.dart
@@ -985,6 +985,10 @@ class _Cookie implements Cookie {
             "Invalid character in cookie name, code unit: '$codeUnit'");
       }
     }
+    
+    if (value[0] == '"' || value[value.length - 1] == '"')
+      value = value.slice(1, value.length - 2)
+    
     for (int i = 0; i < value.length; i++) {
       int codeUnit = value.codeUnits[i];
       if (!(codeUnit == 0x21 ||


### PR DESCRIPTION
Servers sometimes send headers with cookie values that are encapsulated in double-quotes. Dart should validate values surrounded with double-quotes instead of throwing a FormatException.

This addresses Issue #33327 directly. I applied the solution to this problem that was [solved in Go's code base](https://github.com/golang/go/blob/master/src/net/http/cookie.go#L369).