### PR TITLE
Add validation test for cookie values enclosed in double-quoted characters 

### DIFF
--- a/tests/standalone_2/io/http_cookie_test.dart
+++ b/tests/standalone_2/io/http_cookie_test.dart
@@ -58,6 +58,15 @@ void testCookies() {
   });
 }
 
+void testValidateCookieWithDoubleQuotes() {
+  try {
+    Cookie cookie = Cookie('key', '"double-quoted value"');
+  } catch (e) {
+    Expect.fail("Unexpected error $e.\nUnable to parse cookie with value enclosed in ASCII double-quote characters.");
+  }
+}
+
 void main() {
   testCookies();
+  testValidateCookieWithDoubleQuotes();
 }


### PR DESCRIPTION
Test added as per https://dart-review.googlesource.com/c/sdk/+/63920

This test compliments the fix in #33765 along with changes made [here](https://github.com/dart-lang/sdk/pull/33765/commits/d7f0907108e8d5b7a4712837c47da9d7c74ea8e1).