### PR TITLE
Add @TypeArguments as a valid type for BoundVariable.value in VM service spec

### DIFF
--- a/runtime/vm/service/service.md
+++ b/runtime/vm/service/service.md
@@ -1021,7 +1021,7 @@ _BeingInitialized_ [Sentinel](#sentinel).
 ```
 class BoundVariable {
   string name;
-  @Instance|Sentinel value;
+  @Instance|@TypeArguments|Sentinel value;
 
   // The token position where this variable was declared.
   int declarationTokenPos;

--- a/runtime/vm/service/service_dev.md
+++ b/runtime/vm/service/service_dev.md
@@ -1021,7 +1021,7 @@ _BeingInitialized_ [Sentinel](#sentinel).
 ```
 class BoundVariable {
   string name;
-  @Instance|Sentinel value;
+  @Instance|@TypeArguments|Sentinel value;
 
   // The token position where this variable was declared.
   int declarationTokenPos;


### PR DESCRIPTION
I hit [an issue](https://github.com/dart-lang/vm_service_client/issues/41) in the `vm_service_client` library because it asserts that the type of a BoundVariable is an `@Instance` or `Sentinel` but I'm getting a `@TypeArguments`

It looks like the package may be following the spec, and the spec doesn't list this. Here's an example:

```js
{
	"type": "BoundVariable",
	"name": "function_type_arguments_var",
	"value": {
		"type": "@TypeArguments",
		"class": {
			"type": "@Class",
			"fixedId": true,
			"id": "classes\/41",
			"name": "TypeArguments"
		},
		"id": "objects\/137",
		"name": "<FutureOr<dynamic>, bool>"
	},
	"declarationTokenPos": -1,
	"scopeStartTokenPos": -1,
	"scopeEndTokenPos": 50428
}
```

Which came back in a stack frame's `vars` for this code:

```dart
Future<void> doAsyncStuff() async {
  print("test"); // BREAKPOINT
  await new Future.value(true);
  print("test2");
  await new Future.microtask(() => true);
  print("test3");
  await new Future.delayed(const Duration(milliseconds: 1));
  print("done!");
}
```

I'm assuming the spec just needs updating (rather than it being a bug in the VM service) so I've added it in this PR (I don't know if it's correct to update, or whether the version number should be updated, etc. - please advise), but let me know if you think this isn't the case.