### PR TITLE
Rotate method for ListQueue

### DIFF
--- a/sdk/lib/collection/queue.dart
+++ b/sdk/lib/collection/queue.dart
@@ -807,6 +807,21 @@ class ListQueue<E> extends ListIterable<E> implements Queue<E> {
     return result;
   }
 
+  void rotate(int val){
+    if (this.isNotEmpty){
+      if (val > 0){
+        for (var i = 0; i < val; i++) {
+          this.addFirst(this.removeLast());
+        }
+      }
+      if (val < 0){
+        for (var i = 0; i < val.abs(); i++) {
+          this.addLast(this.removeFirst());
+        }
+      }
+    }
+  }
+
   // Internal helper functions.
 
   /**

--- a/sdk/lib/collection/queue.dart
+++ b/sdk/lib/collection/queue.dart
@@ -728,6 +728,21 @@ class ListQueue<E> extends ListIterable<E> implements Queue<E> {
     return false;
   }
 
+  void rotate(int val){
+    if (this.isNotEmpty){
+      if (val > 0){
+        for (var i = 0; i < val; i++) {
+          this.addFirst(this.removeLast());
+        }
+      }
+      if (val < 0){
+        for (var i = 0; i < val.abs(); i++) {
+          this.addLast(this.removeFirst());
+        }
+      }
+    }
+  }
+
   void _filterWhere(bool test(E element), bool removeMatching) {
     int modificationCount = _modificationCount;
     int i = _head;
@@ -806,22 +821,6 @@ class ListQueue<E> extends ListIterable<E> implements Queue<E> {
     _table[_tail] = null;
     return result;
   }
-
-  void rotate(int val){
-    if (this.isNotEmpty){
-      if (val > 0){
-        for (var i = 0; i < val; i++) {
-          this.addFirst(this.removeLast());
-        }
-      }
-      if (val < 0){
-        for (var i = 0; i < val.abs(); i++) {
-          this.addLast(this.removeFirst());
-        }
-      }
-    }
-  }
-
   // Internal helper functions.
 
   /**

--- a/tests/corelib_2/queue_test.dart
+++ b/tests/corelib_2/queue_test.dart
@@ -348,6 +348,25 @@ class ListQueueTest extends QueueTest {
     trickyTest();
   }
 
+  void rotateTest(){
+  List<int> initialVals = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+  List<int> afterRotateRightOnce = [10, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+  List<int> afterRotateRightThrice = [7, 8, 9, 10, 1, 2, 3, 4, 5, 6];
+  List<int> afterRotateLeftOnce = [8, 9, 10, 1, 2, 3, 4, 5, 6, 7];
+
+  ListQueue<int> queue = new ListQueue.from(new List.generate(10, (i) => i + 1));
+  Expect.equals(initialVals, new List.from(queue.map((v) => v)));
+  queue.rotate(1);
+  Expect.equals(afterRotateRightOnce, new List.from(queue.map((v) => v)));
+  queue.rotate(3);
+  Expect.equals(afterRotateRightThrice, new List.from(queue.map((v) => v)));
+  queue.rotate(-1);
+  Expect.equals(afterRotateLeftOnce, new List.from(queue.map((v) => v)));
+  queue.rotate(-3);
+  Expect.equals(initialVals, new List.from(queue.map((v) => v)));
+
+  }
+
   void trickyTest() {
     // Test behavior around the know growing capacities of a ListQueue.
     Queue q = new ListQueue();

--- a/tests/corelib_2/queue_test.dart
+++ b/tests/corelib_2/queue_test.dart
@@ -346,6 +346,7 @@ class ListQueueTest extends QueueTest {
   void testMain() {
     super.testMain();
     trickyTest();
+    rotateTest();
   }
 
   void rotateTest(){


### PR DESCRIPTION
Added a `rotate` method in ListQueue class which is expected in double-ended queue-like data structure.
Added a test method to test if the functionality working or not.