### PR TITLE
Add innerText field to Element class

### DIFF
--- a/sdk/lib/html/dart2js/html_dart2js.dart
+++ b/sdk/lib/html/dart2js/html_dart2js.dart
@@ -13818,6 +13818,8 @@ class Element extends Node
   @JSName('innerHTML')
   String _innerHtml;
 
+  String innerText;
+
   @JSName('localName')
   final String _localName;
 


### PR DESCRIPTION
As mentioned in #28303 Dart needs the innerText getter/setter.

This seems like all thats needed.