### PR TITLE
feat: remove constructor to allow for use as mixin

### DIFF
--- a/sdk/lib/core/stopwatch.dart
+++ b/sdk/lib/core/stopwatch.dart
@@ -28,14 +28,11 @@ class Stopwatch {
    * var stopwatch = new Stopwatch()..start();
    * ```
    */
-  Stopwatch() {
-    if (_frequency == null) _initTicker();
-  }
 
   /**
    * Frequency of the elapsed counter in Hz.
    */
-  int get frequency => _frequency;
+  int get frequency => _frequency ?? _initTicker() ?? _frequency;
 
   /**
    * Starts the [Stopwatch].


### PR DESCRIPTION
Lazily set `_frequency` rather than initialize it in Constructor. Without constructor, can use class as a mixin.