### PR TITLE
`frequency` from Stopwatch constructor to lazy

### DIFF
--- a/sdk/lib/core/stopwatch.dart
+++ b/sdk/lib/core/stopwatch.dart
@@ -28,15 +28,16 @@ class Stopwatch {
    * var stopwatch = new Stopwatch()..start();
    * ```
    */
-  Stopwatch() {
-    if (_frequency == null) _initTicker();
-  }
 
   /**
    * Frequency of the elapsed counter in Hz.
    */
-  int get frequency => _frequency;
-
+  int get frequency {
+    if(_frequency == null){
+      _initTicker();
+    }
+    return _frequency;
+  }
   /**
    * Starts the [Stopwatch].
    *


### PR DESCRIPTION
Will allow for class to be used as a mixin without a constructor. Lazily set the `frequency` on first get.