### PR TITLE
Don't write dill to disk when there is compilation error during dill generation(Flutter's Debug mode)

### DIFF
--- a/pkg/vm/lib/frontend_server.dart
+++ b/pkg/vm/lib/frontend_server.dart
@@ -349,8 +349,10 @@ class FrontendCompiler implements CompilerInterface {
         transformer.transform(component);
       }
 
-      await writeDillFile(component, _kernelBinaryFilename,
-          filterExternal: importDill != null);
+      if (errors.isEmpty) {
+        await writeDillFile(component, _kernelBinaryFilename,
+            filterExternal: importDill != null);
+      }
 
       _outputStream
           .writeln('$boundaryKey $_kernelBinaryFilename ${errors.length}');
@@ -456,7 +458,9 @@ class FrontendCompiler implements CompilerInterface {
     if (deltaProgram != null && transformer != null) {
       transformer.transform(deltaProgram);
     }
-    await writeDillFile(deltaProgram, _kernelBinaryFilename);
+    if (errors.isEmpty) {
+      await writeDillFile(deltaProgram, _kernelBinaryFilename);
+    }
     _outputStream
         .writeln('$boundaryKey $_kernelBinaryFilename ${errors.length}');
     _kernelBinaryFilename = _kernelBinaryFilenameIncremental;


### PR DESCRIPTION
This PR comes from https://github.com/flutter/flutter/issues/23121
I found that app.dill will always generate no matter if there is any compilation problem when generating dill.
1. Create a hello_world project without error
app.dill is generated without reporting any error.
2. Mock a error(First dill compilation)
app.dill is generated with reporting error.
3. Second dill compilation
app.dill is not changed as already compiled and no changes. Henceforth, it reports no error.

@mraleph 
Please have a look if this is a bug or as designed.