### PR TITLE
Use setAttribute instead of the IDL property for CSP nonce assignment

### DIFF
--- a/sdk/lib/_internal/js_runtime/lib/js_helper.dart
+++ b/sdk/lib/_internal/js_runtime/lib/js_helper.dart
@@ -3508,7 +3508,7 @@ Future<Null> _loadHunk(String hunkName) {
     JS('', '#.type = "text/javascript"', script);
     JS('', '#.src = #', script, uri);
     if (_cspNonce != null && _cspNonce != '') {
-      JS('', '#.nonce = #', script, _cspNonce);
+      JS('', '#.setAttribute("nonce", #)', script, _cspNonce);
     }
     if (_crossOrigin != null && _crossOrigin != '') {
       JS('', '#.crossOrigin = #', script, _crossOrigin);


### PR DESCRIPTION
We should use ``HTMLElement.setAttribute('nonce', nonceValue)`` instead of directly assigning the IDL property ``element.nonce = nonceValue`` due to Firefox not supporting the nonce IDL property ([Bugzilla](https://bugzilla.mozilla.org/show_bug.cgi?id=1389421)).

Fixes: #35784 