### PR TITLE
List.removeLast() docs error occurs if empty

### DIFF
--- a/sdk/lib/core/list.dart
+++ b/sdk/lib/core/list.dart
@@ -537,6 +537,8 @@ abstract class List<E> implements EfficientLengthIterable<E> {
   /**
    * Pops and returns the last object in this list.
    *
+   * The list must not be empty.
+   *
    * Throws an [UnsupportedError] if this is a fixed-length list.
    */
   E removeLast();


### PR DESCRIPTION
Seems like this should be explicitly stated in the docs. I did not indicate the specific type of error because of #26087.