### PR TITLE
Fix the lack of '`' in the doc.

### DIFF
--- a/sdk/lib/core/symbol.dart
+++ b/sdk/lib/core/symbol.dart
@@ -68,7 +68,7 @@ abstract class Symbol {
    * a private symbol literal like `#_foo`.
    * ```dart
    * const Symbol("_foo") // Invalid
-   * ``
+   * ```
    *
    * The created instance overrides [Object.==].
    *


### PR DESCRIPTION
The lack of '`' would broken the IDE syntax render.