### PR TITLE
Fix SocketException's logging the wrong port number

### DIFF
--- a/runtime/bin/socket_patch.dart
+++ b/runtime/bin/socket_patch.dart
@@ -463,6 +463,7 @@ class _NativeSocket extends _NativeSocketNativeWrapper with _ServiceObject {
         final _InternetAddress address = it.current;
         var socket = new _NativeSocket.normal();
         socket.localAddress = address;
+        socket.localPort = port;
         var result;
         if (sourceAddress == null) {
           result = socket.nativeCreateConnect(address._in_addr, port);


### PR DESCRIPTION
This trivial change fixes the following bug. Consider a testcase like this:

```dart
import 'dart:io';

void main() {
    Socket.connect("127.0.0.1", 40411).catchError((err) {
        print(err);
    });
}
```
In words: we use [Socket.connect][] to make a TCP connection which will intentionally fail. We expect a **Connection refused** error printed when the above runs.

------

The bug is in the error message:

> $ dart ~/rpm/test.dart
> SocketException: OS Error: Connection refused, errno = 111, address = 127.0.0.1, **port = 36934**
> $ dart ~/rpm/test.dart
> SocketException: OS Error: Connection refused, errno = 111, address = 127.0.0.1, **port = 36936**
> $ dart ~/rpm/test.dart
> SocketException: OS Error: Connection refused, errno = 111, address = 127.0.0.1, **port = 36938**

Expected error message is:
> SocketException: OS Error: Connection refused, errno = 111, address = 127.0.0.1, port = 40411

It might not be [obvious][tcp 101] to everyone, but the current (buggy) code prints the **source port**  of failed connection — instead of the **destination port**. The source port is usually left unspecified by Socket API programmers, and instead selected by the OS somewhere from the 32768~60999 range (that's why it's different each time we run the test above). As such, source ports are not useful to see in logs — destination ports are! — and it is actively confusing to display *source port* right next to *destination address*.

Another confusion resident in the code is that `_NativeSocket.localAddress` and `_NativeSocket.localPort` are better thought of as *remote address and port*. **I abstain from correcting this here**, to preserve simplicity and ease-of-review.

Finally, regarding tests — I'm perfectly content with only a manual test based on the above `main()` sample. If required, I think I can code up an explicit unit test for this (but please point me in the right direction for it).

Please review & merge. Best regards

[Socket.connect]: https://api.dartlang.org/stable/2.1.1/dart-io/Socket/connect.html
[tcp 101]: https://stackoverflow.com/a/489047/531179