### PR TITLE
Remove legacy mozart.internal reference

### DIFF
--- a/pkg/vm/lib/target/flutter_runner.dart
+++ b/pkg/vm/lib/target/flutter_runner.dart
@@ -43,6 +43,5 @@ class FlutterRunnerTarget extends VmTarget {
         'dart:fuchsia',
         'dart:vmservice_io',
         'dart:ui',
-        'dart:mozart.internal',
       ];
 }


### PR DESCRIPTION
This is no longer used by flutter_runner on Fuchsia.