### PR TITLE
Fix typo in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ CupertinoPageScaffold(
 );
 ```
 
-If you the expression might evaluate to null and you want to treat that as
+If you know the expression might evaluate to null and you want to treat that as
 equivalent to zero elements, you can use the null-aware spread `?...`.
 
 #### Collection if


### PR DESCRIPTION
The word 'know' is missing from 'If you the expression' in CHANGELOG.md.