### PR TITLE
Check window.MediaSource before call constructor

### DIFF
--- a/pkg/dev_compiler/tool/input_sdk/private/ddc_runtime/runtime.dart
+++ b/pkg/dev_compiler/tool/input_sdk/private/ddc_runtime/runtime.dart
@@ -90,8 +90,10 @@ bool polyfill(window) => JS('', '''(() => {
       }
     }
     if (typeof $window.SourceBufferList == "undefined") {
-      $window.SourceBufferList =
-        new $window.MediaSource().sourceBuffers.constructor;
+      if ('MediaSource' in $window) {
+        $window.SourceBufferList =
+          new $window.MediaSource().sourceBuffers.constructor; 
+      }
     }
     if (typeof $window.SpeechRecognition == "undefined") {
       $window.SpeechRecognition = $window.webkitSpeechRecognition;


### PR DESCRIPTION
MediaSource is an experimental technology. Not compatible with iOS Safary, even with current last iOS version (v12 April 2019).

This JS  function (polyfill) crashes web compiled Dart load on iOS.