### PR TITLE
Fixed some links

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ See [LICENSE][license] and [PATENTS][patents].
 [repo]: https://github.com/dart-lang/sdk
 [lang]: https://www.dartlang.org/docs/dart-up-and-running/ch02.html
 [tools]: https://www.dartlang.org/tools/
-[codelab]: https://www.dartlang.org/codelabs/darrrt/
+[codelab]: https://dart.dev/codelabs
 [dartbug]: http://dartbug.com
 [contrib]: https://github.com/dart-lang/sdk/wiki/Contributing
 [pubsite]: https://pub.dartlang.org

--- a/build/sanitizers/tsan_suppressions.cc
+++ b/build/sanitizers/tsan_suppressions.cc
@@ -263,7 +263,7 @@ char kTSanDefaultSuppressions[] =
 // http://crbug.com/380554
 "deadlock:g_type_add_interface_static\n"
 
-// http:://crbug.com/386385
+// http://crbug.com/386385
 "race:content::AppCacheStorageImpl::DatabaseTask::CallRunCompleted\n"
 
 // http://crbug.com/388730

--- a/pkg/analyzer/test/utils.dart
+++ b/pkg/analyzer/test/utils.dart
@@ -216,7 +216,7 @@ class AstFinder {
  */
 class TypeAssertions {
   // TODO(leafp): Make these matchers.
-  // https://www.dartdocs.org/documentation/matcher/0.12.0%2B1/matcher/Matcher-class.html
+  // https://pub.dev/documentation/matcher/latest/matcher/Matcher-class.html
 
   /**
    * Provides primitive types for basic type assertions.

--- a/pkg/dev_compiler/lib/src/js_ast/printer.dart
+++ b/pkg/dev_compiler/lib/src/js_ast/printer.dart
@@ -972,7 +972,7 @@ class Printer implements NodeVisitor {
       spaceOut();
       // Object initializers require parenthesis to disambiguate
       // AssignmentExpression from FunctionBody. See:
-      // https://people.mozilla.org/~jorendorff/es6-draft.html#sec-arrow-function-definitions
+      // https://tc39.github.io/ecma262/#sec-arrow-function-definitions
       var needsParen = fun.body is ObjectInitializer;
       if (needsParen) out("(");
       visitNestedExpression(body, ASSIGNMENT,

--- a/pkg/sourcemap_testing/README.md
+++ b/pkg/sourcemap_testing/README.md
@@ -112,8 +112,7 @@ places where the debugger stopped.
 ### Technical details
 
 Some of the logic comes from https://github.com/ChromeDevTools/devtools-frontend/, for instance see
-https://github.com/ChromeDevTools/devtools-frontend/blob/fa18d70a995f06cb73365b2e5b8ae974cf60bd3a/
-front_end/sources/JavaScriptSourceFrame.js#L1520-L1523
+https://github.com/ChromeDevTools/devtools-frontend/blob/fa18d70a995f06cb73365b2e5b8ae974cf60bd3a/front_end/sources/JavaScriptSourceFrame.js#L1520-L1523
 for how a line breakpoint is resolved:
 Basically the line asked to break on in user code (e.g. in dart code) is asked for first and last
 javascript positions; these are then used to get possible breakpoints in that part. If there are

--- a/runtime/platform/utils.cc
+++ b/runtime/platform/utils.cc
@@ -98,6 +98,7 @@ uint32_t Utils::StringHash(const char* data, int length) {
 uint32_t Utils::WordHash(intptr_t key) {
   // TODO(iposva): Need to check hash spreading.
   // This example is from http://www.concentric.net/~Ttwang/tech/inthash.htm
+  // via. http://web.archive.org/web/20071223173210/http://www.concentric.net/~Ttwang/tech/inthash.htm
   uword a = static_cast<uword>(key);
   a = (a + 0x7ed55d16) + (a << 12);
   a = (a ^ 0xc761c23c) ^ (a >> 19);

--- a/runtime/vm/libfuzzer/dart_libfuzzer.cc
+++ b/runtime/vm/libfuzzer/dart_libfuzzer.cc
@@ -31,7 +31,7 @@ static int TestUnicode(const uint8_t* Data, size_t Size) {
 }
 
 // Target function that stresses various utilities.
-// Found: http:/dartbug.com/36818
+// Found: http://dartbug.com/36818
 static int TestUtilities(const uint8_t* Data, size_t Size) {
   dart::Utils::StringHash(reinterpret_cast<const char*>(Data), Size);
   dart::bin::DartUtils::SniffForMagicNumber(Data, Size);

--- a/runtime/vm/timeline.h
+++ b/runtime/vm/timeline.h
@@ -908,8 +908,7 @@ class TimelineEventPlatformRecorder : public TimelineEventRecorder {
 };
 
 #if defined(HOST_OS_FUCHSIA) && !defined(FUCHSIA_SDK)
-// A recorder that sends events to Fuchsia's tracing app. See:
-// https://fuchsia.googlesource.com/garnet/+/master/docs/tracing_usage_guide.md
+// A recorder that sends events to Fuchsia's tracing app.
 class TimelineEventFuchsiaRecorder : public TimelineEventPlatformRecorder {
  public:
   TimelineEventFuchsiaRecorder() {}

--- a/samples-dev/swarm/swarm_ui_lib/util/Uri.dart
+++ b/samples-dev/swarm/swarm_ui_lib/util/Uri.dart
@@ -6,7 +6,7 @@ part of utilslib;
 
 /**
  * A parsed URI, inspired by:
- * http://closure-library.googlecode.com/svn/docs/class_goog_Uri.html
+ * https://github.com/google/closure-library/blob/master/closure/goog/uri/uri.js
  */
 class SwarmUri {
   /**

--- a/sdk/lib/_internal/js_runtime/lib/async_patch.dart
+++ b/sdk/lib/_internal/js_runtime/lib/async_patch.dart
@@ -58,7 +58,6 @@ class _AsyncRun {
         storedCallback = callback;
         // Because of a broken shadow-dom polyfill we have to change the
         // children instead a cheap property.
-        // See https://github.com/Polymer/ShadowDOM/issues/468
         JS('', '#.firstChild ? #.removeChild(#): #.appendChild(#)', div, div,
             span, div, span);
       };

--- a/sdk/lib/html/dart2js/html_dart2js.dart
+++ b/sdk/lib/html/dart2js/html_dart2js.dart
@@ -18414,7 +18414,7 @@ class InputElement extends HtmlElement
 
 // Interfaces representing the InputElement APIs which are supported
 // for the various types of InputElement. From:
-// http://www.w3.org/html/wg/drafts/html/master/forms.html#the-input-element.
+// https://w3c.github.io/html/sec-forms.html#the-input-element.
 
 /**
  * Exposes the functionality common between all InputElement types.
@@ -36423,7 +36423,7 @@ abstract class ImmutableListMixin<E> implements List<E> {
 abstract class KeyCode {
   // These constant names were borrowed from Closure's Keycode enumeration
   // class.
-  // http://closure-library.googlecode.com/svn/docs/closure_goog_events_keycodes.js.source.html
+  // https://github.com/google/closure-library/blob/master/closure/goog/events/keycodes.js
   static const int WIN_KEY_FF_LINUX = 0;
   static const int MAC_ENTER = 3;
   static const int BACKSPACE = 8;
@@ -37283,7 +37283,7 @@ abstract class _KeyName {
  */
 class _KeyboardEventHandler extends EventStreamProvider<KeyEvent> {
   // This code inspired by Closure's KeyHandling library.
-  // http://closure-library.googlecode.com/svn/docs/closure_goog_events_keyhandler.js.source.html
+  // https://github.com/google/closure-library/blob/master/closure/goog/events/keyhandler.js
 
   /**
    * The set of keys that have been pressed down without seeing their
@@ -37308,7 +37308,7 @@ class _KeyboardEventHandler extends EventStreamProvider<KeyEvent> {
   /**
    * An enumeration of key identifiers currently part of the W3C draft for DOM3
    * and their mappings to keyCodes.
-   * http://www.w3.org/TR/DOM-Level-3-Events/keyset.html#KeySet-Set
+   * https://www.w3.org/TR/2003/NOTE-DOM-Level-3-Events-20031107/keyset.html#KeySet-Set
    */
   static const Map<String, int> _keyIdentifier = const {
     'Up': KeyCode.UP,

--- a/tests/compiler/dart2js_extra/22776_test.dart
+++ b/tests/compiler/dart2js_extra/22776_test.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// Regression test for http://dartbug.com/22776/
+// Regression test for http://dartbug.com/22776
 
 import "package:expect/expect.dart";
 

--- a/tests/compiler/dart2js_extra/22868_test.dart
+++ b/tests/compiler/dart2js_extra/22868_test.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// Regression test for http://dartbug.com/22868/ and http://dartbug.com/22895/.
+// Regression test for http://dartbug.com/22868 and http://dartbug.com/22895
 // Ensure that the closure tracer properly handles await.
 
 main() async {

--- a/tests/compiler/dart2js_extra/23404_test.dart
+++ b/tests/compiler/dart2js_extra/23404_test.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// Regression test for http://dartbug.com/23404/
+// Regression test for http://dartbug.com/23404
 import 'package:expect/expect.dart';
 
 // Dart2js crashed when the global metadata had escaped characters. That

--- a/tests/compiler/dart2js_extra/23404_test.dart
+++ b/tests/compiler/dart2js_extra/23404_test.dart
@@ -3,11 +3,12 @@
 // BSD-style license that can be found in the LICENSE file.
 
 // Regression test for http://dartbug.com/23404
-import 'package:expect/expect.dart';
-
+//
 // Dart2js crashed when the global metadata had escaped characters. That
 // happens, for example, when tearing off a function that uses a default
 // argument containing escape characters.
+import 'package:expect/expect.dart';
+
 foo([a = '\u00a0']) => a;
 bar() => '';
 

--- a/tests/compiler/dart2js_extra/23486_test.dart
+++ b/tests/compiler/dart2js_extra/23486_test.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// Regression test for http://dartbug.com/23486/
+// Regression test for http://dartbug.com/23486
 //
 // Dart2js used to crash when using `super` and prefixes inside parenthesized
 // expressions.

--- a/tests/compiler/dart2js_extra/23804_test.dart
+++ b/tests/compiler/dart2js_extra/23804_test.dart
@@ -2,7 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// Regression test for http://dartbug.com/23804/
+// Regression test for http://dartbug.com/23804
+//
 // Inference incorrectly assumed that `any` and `every` didn't escape the values
 // in the collections.
 

--- a/tests/compiler/dart2js_extra/23828_test.dart
+++ b/tests/compiler/dart2js_extra/23828_test.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// Regression test for http://dartbug.com/23828/
+// Regression test for http://dartbug.com/23828
 // Used to fail when methods contain a name starting with `get`
 import 'package:expect/expect.dart';
 

--- a/tests/compiler/dart2js_extra/invalid_annotation_test.dart
+++ b/tests/compiler/dart2js_extra/invalid_annotation_test.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// Regression test for http://dartbug.com/23893/
+// Regression test for http://dartbug.com/23893
 //
 // Because annotations are parsed lazily, dart2js used to crash when an
 // annotation had a syntax error.

--- a/tests/compiler/dart2js_extra/no_such_method_strong11_test.dart
+++ b/tests/compiler/dart2js_extra/no_such_method_strong11_test.dart
@@ -5,7 +5,7 @@
 // dart2jsOptions=--strong
 
 // Regression test checking that nsm-forwarders do not get installed for private
-// members of other libraries. See  https://dartbug.com/33665
+// members of other libraries. See http://dartbug.com/33665
 
 import 'package:expect/expect.dart';
 import 'no_such_method_strong11_lib.dart';

--- a/tests/language_2/fannkuch_test.dart
+++ b/tests/language_2/fannkuch_test.dart
@@ -1,8 +1,8 @@
 // Copyright (c) 2011, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
-// The Great Computer Language Shootout
-// http://shootout.alioth.debian.org/
+// The Computer Language Benchmarks Game
+// https://benchmarksgame-team.pages.debian.net/benchmarksgame/
 // Ported from JavaScript contributed by Isaac Gouy.
 // Description: Repeatedly access a tiny integer-sequence.
 

--- a/tools/dom/scripts/CSSPropertyNames.in
+++ b/tools/dom/scripts/CSSPropertyNames.in
@@ -2,6 +2,7 @@
 // https://codereview.chromium.org/444453006/ has been committed, in which case
 // it will be pulled in from DEPS!
 // Copied from http://trac.webkit.org/browser/trunk/WebCore/css/CSSPropertyNames.in
+// via. http://web.archive.org/web/20100722083519/http://trac.webkit.org/browser/trunk/WebCore/css/CSSPropertyNames.in
 //
 // CSS property names
 //

--- a/tools/dom/src/KeyCode.dart
+++ b/tools/dom/src/KeyCode.dart
@@ -15,7 +15,7 @@ part of html;
 abstract class KeyCode {
   // These constant names were borrowed from Closure's Keycode enumeration
   // class.
-  // http://closure-library.googlecode.com/svn/docs/closure_goog_events_keycodes.js.source.html
+  // https://github.com/google/closure-library/blob/master/closure/goog/events/keycodes.js
   static const int WIN_KEY_FF_LINUX = 0;
   static const int MAC_ENTER = 3;
   static const int BACKSPACE = 8;

--- a/tools/dom/src/KeyboardEventStream.dart
+++ b/tools/dom/src/KeyboardEventStream.dart
@@ -10,7 +10,7 @@ part of html;
  */
 class _KeyboardEventHandler extends EventStreamProvider<KeyEvent> {
   // This code inspired by Closure's KeyHandling library.
-  // http://closure-library.googlecode.com/svn/docs/closure_goog_events_keyhandler.js.source.html
+  // https://github.com/google/closure-library/blob/master/closure/goog/events/keyhandler.js
 
   /**
    * The set of keys that have been pressed down without seeing their

--- a/tools/dom/src/KeyboardEventStream.dart
+++ b/tools/dom/src/KeyboardEventStream.dart
@@ -35,7 +35,7 @@ class _KeyboardEventHandler extends EventStreamProvider<KeyEvent> {
   /**
    * An enumeration of key identifiers currently part of the W3C draft for DOM3
    * and their mappings to keyCodes.
-   * http://www.w3.org/TR/DOM-Level-3-Events/keyset.html#KeySet-Set
+   * https://www.w3.org/TR/2003/NOTE-DOM-Level-3-Events-20031107/keyset.html#KeySet-Set
    */
   static const Map<String, int> _keyIdentifier = const {
     'Up': KeyCode.UP,

--- a/tools/dom/templates/html/impl/impl_HTMLInputElement.darttemplate
+++ b/tools/dom/templates/html/impl/impl_HTMLInputElement.darttemplate
@@ -44,7 +44,7 @@ $!MEMBERS
 
 // Interfaces representing the InputElement APIs which are supported
 // for the various types of InputElement. From:
-// http://www.w3.org/html/wg/drafts/html/master/forms.html#the-input-element.
+// https://w3c.github.io/html/sec-forms.html#the-input-element.
 
 /**
  * Exposes the functionality common between all InputElement types.


### PR DESCRIPTION
**I fixed some links and some other minor flaws.**

I also found the following outdated links, which I didn't fix:

- [This link](https://github.com/dart-lang/pool/tree/zone.strong) in [this file](https://github.com/dart-lang/sdk/blob/master/docs/newsletter/20170728.md) (didn't fix because don't know new location and this is some sort of archive so the link should probably stay the original)
- [This link](https://www.dartlang.org/tools/analyzer) in [this file](https://github.com/dart-lang/sdk/blob/master/pkg/analyzer_cli/lib/src/options.dart) (didn't fix since the link is still working, it just gets redirected and the link is part of the programm, I don't want to break anything by changing it, all other links are in comments)
- [This link](https://github.com/domokit/mojo/issues/728) in [this file](https://github.com/dart-lang/sdk/blob/master/build/config/compiler/BUILD.gn) (didn't fix since probably has no new location and is part of TODO, which I don't want to change)

While doing all this I also noticed that [these tests](https://github.com/dart-lang/sdk/tree/master/tests/compiler/dart2js_extra) contain a lot of other inconsistencies in their comments and the location of the import-statements (I only fixed one which was not link-related), could be target of another PR.