### PR TITLE
Fix example syntax

### DIFF
--- a/sdk/lib/_http/overrides.dart
+++ b/sdk/lib/_http/overrides.dart
@@ -26,7 +26,7 @@ const _asyncRunZoned = runZoned;
 ///     // Operations will use MyHttpClient instead of the real HttpClient
 ///     // implementation whenever HttpClient is used.
 ///     ...
-///   }, createHttpClient: (SecurityContext c) => new MyHttpClient(c));
+///   }, createHttpClient: (SecurityContext c) => HttpClient(context: c));
 /// }
 /// ```
 abstract class HttpOverrides {


### PR DESCRIPTION
Update example syntax - HttpClient has a named argument for SecurityContext