### PR TITLE
Update _getVMTimeline to getVMTimeline

### DIFF
--- a/runtime/observatory/web/timeline.js
+++ b/runtime/observatory/web/timeline.js
@@ -648,7 +648,7 @@ function fetchTimeline(vmAddress, isolateIds, mode) {
                    ':' +
                    parser.port +
                    parser.pathname.replace(/\/ws$/, "") +
-                   '/_getVMTimeline';
+                   '/getVMTimeline';
   fetchUri(requestUri, function(event) {
     // Grab the response.
     var xhr = event.target;


### PR DESCRIPTION
The method name was changed in service.cc in https://github.com/dart-lang/sdk/commit/a75ded625e4cbffbe775f49afa75eaf6d99696f4#diff-243e54ec47a7b6d9b6088b2200bbf298