### PR TITLE
ffi example: android.md - fix example code

### DIFF
--- a/samples/ffi/sqlite/docs/android.md
+++ b/samples/ffi/sqlite/docs/android.md
@@ -41,7 +41,7 @@ android {
     // ...
     sourceSets {
         main {
-            jniLibs.srcDir '${project.projectDir.path}/../../native-libraries'
+            jniLibs.srcDir "${project.projectDir.path}/../../native-libraries"
         }
     }
 }


### PR DESCRIPTION
gradle does not expand variables if the string has single quotes