### PR TITLE
Add defined() guard for checkout_llvm build flag

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -16,7 +16,7 @@ group("default") {
   deps = [
     ":runtime",
   ]
-  if (checkout_llvm) {
+  if (defined(checkout_llvm) && checkout_llvm) {
     deps += [
       ":llvm_codegen"
     ]
@@ -126,7 +126,7 @@ group("analysis_server") {
 }
 
 group("check_llvm") {
-  if (checkout_llvm) {
+  if (defined(checkout_llvm) && checkout_llvm) {
     deps = [
       "runtime/llvm_codegen/test",
     ]
@@ -134,7 +134,7 @@ group("check_llvm") {
 }
 
 group("llvm_codegen") {
-  if (checkout_llvm) {
+  if (defined(checkout_llvm) && checkout_llvm) {
     deps = [
       "runtime/llvm_codegen/codegen",
       "runtime/llvm_codegen/bit",

--- a/runtime/bin/BUILD.gn
+++ b/runtime/bin/BUILD.gn
@@ -924,7 +924,7 @@ executable("run_vm_tests") {
     "..:libdart_nosnapshot_with_precompiler",
     "//third_party/zlib",
   ]
-  if (checkout_llvm) {
+  if (defined(checkout_llvm) && checkout_llvm) {
     deps += [ "//runtime/llvm_codegen/bit:test" ]
   }
   include_dirs = [


### PR DESCRIPTION
Adds a guard before uses of the checkout_llvm flag, defaulting it to
false when unset. This prevents breakages when used in trees that hasn't
defined that gn flag.

Also fixed manually in topaz in:
https://turquoise-internal-review.googlesource.com/c/integration/+/133882