### PR TITLE
Test that a mixin getter is not treated as a concrete field.

### DIFF
--- a/pkg/analyzer/test/src/diagnostics/const_constructor_with_mixin_with_field_test.dart
+++ b/pkg/analyzer/test/src/diagnostics/const_constructor_with_mixin_with_field_test.dart
@@ -110,7 +110,7 @@ class X extends Object with M {
 }
 ''');
   }
-  
+
   test_mixin_getter() async {
     await assertNoErrorsInCode('''
 mixin M {

--- a/pkg/analyzer/test/src/diagnostics/const_constructor_with_mixin_with_field_test.dart
+++ b/pkg/analyzer/test/src/diagnostics/const_constructor_with_mixin_with_field_test.dart
@@ -111,7 +111,7 @@ class X extends Object with M {
 ''');
   }
   
-  test_mixin_noFields() async {
+  test_mixin_getter() async {
     await assertNoErrorsInCode('''
 mixin M {
   get x;

--- a/pkg/analyzer/test/src/diagnostics/const_constructor_with_mixin_with_field_test.dart
+++ b/pkg/analyzer/test/src/diagnostics/const_constructor_with_mixin_with_field_test.dart
@@ -110,6 +110,18 @@ class X extends Object with M {
 }
 ''');
   }
+  
+  test_mixin_noFields() async {
+    await assertNoErrorsInCode('''
+mixin M {
+  get x;
+}
+
+class X extends Object with M {
+  const X();
+}
+''');
+  }
 
   test_mixin_static() async {
     await assertNoErrorsInCode('''

--- a/pkg/analyzer/test/src/diagnostics/const_constructor_with_mixin_with_field_test.dart
+++ b/pkg/analyzer/test/src/diagnostics/const_constructor_with_mixin_with_field_test.dart
@@ -117,7 +117,7 @@ mixin M {
   get x;
 }
 
-class X extends Object with M {
+abstract class X extends Object with M {
   const X();
 }
 ''');


### PR DESCRIPTION
Sorry if this should go to a different branch. This is just a test to help support #37810