### PR TITLE
Bump analyzer_plugin's maximum supported analyzer version

### DIFF
--- a/pkg/analyzer_plugin/pubspec.yaml
+++ b/pkg/analyzer_plugin/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: '>=2.0.0 <3.0.0'
 
 dependencies:
-  analyzer: '>=0.35.3 <0.38.0'
+  analyzer: '>=0.35.3 <0.38.4'
   charcode: '^1.1.0'
   dart_style: '^1.2.0'
   html: '>=0.13.1 <0.15.0'

--- a/pkg/analyzer_plugin/pubspec.yaml
+++ b/pkg/analyzer_plugin/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: '>=2.0.0 <3.0.0'
 
 dependencies:
-  analyzer: '>=0.35.3 <0.38.4'
+  analyzer: '>=0.35.3 <0.39.0'
   charcode: '^1.1.0'
   dart_style: '^1.2.0'
   html: '>=0.13.1 <0.15.0'


### PR DESCRIPTION
analyzer_plugin has max constraint to analyzer version 0.38.0 while the latest version is 0.38.3 and it causes a lot of issues for libraries that use it (built_value for instance) 
