### PR TITLE
Clarify error message for instantiating abstract classes

### DIFF
--- a/pkg/analyzer/lib/src/error/codes.dart
+++ b/pkg/analyzer/lib/src/error/codes.dart
@@ -6435,7 +6435,7 @@ class StaticWarningCode extends AnalyzerErrorCode {
    */
   static const StaticWarningCode NEW_WITH_ABSTRACT_CLASS =
       const StaticWarningCode('NEW_WITH_ABSTRACT_CLASS',
-          "Abstract classes can't be created with a 'new' expression.",
+          "Abstract classes can't be instantiated.",
           correction: "Try creating an instance of a subtype.");
 
   /**


### PR DESCRIPTION
Fixes https://github.com/dart-lang/sdk/issues/38695

Consistent with terminology in https://dart.dev/guides/language/language-tour#abstract-classes