### PR TITLE
Fast GetHash implementation for 32 bit architectures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,5 +104,6 @@ editor/util/testing/mac/Samples.suite/Results
 /generated/
 /crash_logs/
 /build/config/gclient_args.gni
+/runtime/vm_icatalud
 
 runtime/vm_icatalud/

--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,5 @@ editor/util/testing/mac/Samples.suite/Results
 /generated/
 /crash_logs/
 /build/config/gclient_args.gni
+
+runtime/vm_icatalud/

--- a/runtime/lib/object.cc
+++ b/runtime/lib/object.cc
@@ -40,32 +40,7 @@ DEFINE_NATIVE_ENTRY(Object_getHash, 0, 1) {
 #if defined(HASH_IN_OBJECT_HEADER)
   return Smi::New(Object::GetCachedHash(arguments->NativeArgAt(0)));
 #elif defined(FAST_HASH_FOR_32_BIT)
- /* RawObject* raw = arguments->NativeArgAt(0);
-  if (raw->HasAppendedHashObject()) {
-    return *reinterpret_cast<RawSmi**>(RawObject::AppendedHashAddress(raw));
-  }
-  uintptr_t value = (reinterpret_cast<uintptr_t>(raw) << 1) >> 1;
-  if (!raw->HashCodeWasRetrieved()) {
-    raw->SetHashCodeRetrievedBit();
-  }
-  return Smi::New(static_cast<uint32_t>(value));*/
-  RawObject* raw = arguments->NativeArgAt(0);
-  intptr_t cid = raw->GetClassId();
-  if (true || cid > kInstanceCid || cid < kInstanceCid || cid==kInstanceCid ) { // kContextCid, kContextScopeCid
-    if (cid == kInstanceCid) {
-      RawClass* clazz_ptr = Isolate::Current()->class_table()->At(cid);
-      Class& clazz = Class::Handle(clazz_ptr);
-      //OS::Print("Object_getHash for object %p of class %s, class id: %d, HasAppendedHashCode: %d, hash value: 0x%X\n",
-      //          RawObject::ToAddr(raw), clazz.ToCString(), cid, raw->HasAppendedHashObject(), raw->GetHash());
-    }
-    //OS::Print("Getting hash for class %d\n", raw->GetClassId());
-    return Smi::New(arguments->NativeArgAt(0)->GetHash());
-  } else {
-    Heap* heap = isolate->heap();
-    ASSERT(arguments->NativeArgAt(0)->IsDartInstance());
-    return Smi::New(heap->GetHash(arguments->NativeArgAt(0)));
-  }
-  
+  return Smi::New(arguments->NativeArgAt(0)->GetHash());
 #else
   Heap* heap = isolate->heap();
   ASSERT(arguments->NativeArgAt(0)->IsDartInstance());

--- a/runtime/lib/object.cc
+++ b/runtime/lib/object.cc
@@ -32,17 +32,17 @@ DEFINE_NATIVE_ENTRY(Object_equals, 0, 1) {
 }
 
 DEFINE_NATIVE_ENTRY(Object_getHash, 0, 1) {
-// Please note that no handle is created for the argument.
-// This is safe since the argument is only used in a tail call.
-// The performance benefit is more than 5% when using hashCode.
-#if defined(HASH_IN_OBJECT_HEADER)
+  // Please note that no handle is created for the argument.
+  // This is safe since the argument is only used in a tail call.
+  // The performance benefit is more than 5% when using hashCode.
+  // #if defined(HASH_IN_OBJECT_HEADER)
   return Smi::New(Object::GetCachedHash(arguments->NativeArgAt(0)));
-#else  // 32bit architectures
+  // #else  // 32bit architectures
   // Heap* heap = isolate->heap();
   // ASSERT(arguments->NativeArgAt(0)->IsDartInstance());
   // return Smi::New(heap->GetHash(arguments->NativeArgAt(0)));
-  return Smi::New(Object::GetHash(arguments->NativeArgAt(0)));
-#endif
+  //   return Smi::New(Object::GetHash(arguments->NativeArgAt(0)));
+  // #endif
 }
 
 DEFINE_NATIVE_ENTRY(Object_setHash, 0, 2) {

--- a/runtime/lib/object.cc
+++ b/runtime/lib/object.cc
@@ -37,10 +37,11 @@ DEFINE_NATIVE_ENTRY(Object_getHash, 0, 1) {
 // The performance benefit is more than 5% when using hashCode.
 #if defined(HASH_IN_OBJECT_HEADER)
   return Smi::New(Object::GetCachedHash(arguments->NativeArgAt(0)));
-#else
-  Heap* heap = isolate->heap();
-  ASSERT(arguments->NativeArgAt(0)->IsDartInstance());
-  return Smi::New(heap->GetHash(arguments->NativeArgAt(0)));
+#else  // 32bit architectures
+  // Heap* heap = isolate->heap();
+  // ASSERT(arguments->NativeArgAt(0)->IsDartInstance());
+  // return Smi::New(heap->GetHash(arguments->NativeArgAt(0)));
+  return Smi::New(Object::GetHash(arguments->NativeArgAt(0)));
 #endif
 }
 

--- a/runtime/lib/object.cc
+++ b/runtime/lib/object.cc
@@ -35,14 +35,20 @@ DEFINE_NATIVE_ENTRY(Object_getHash, 0, 1) {
   // Please note that no handle is created for the argument.
   // This is safe since the argument is only used in a tail call.
   // The performance benefit is more than 5% when using hashCode.
-  // #if defined(HASH_IN_OBJECT_HEADER)
+//#if defined(HASH_IN_OBJECT_HEADER)
   return Smi::New(Object::GetCachedHash(arguments->NativeArgAt(0)));
-  // #else  // 32bit architectures
-  // Heap* heap = isolate->heap();
-  // ASSERT(arguments->NativeArgAt(0)->IsDartInstance());
-  // return Smi::New(heap->GetHash(arguments->NativeArgAt(0)));
-  //   return Smi::New(Object::GetHash(arguments->NativeArgAt(0)));
-  // #endif
+//#else  // 32bit architectures
+  //intptr_t cid = arguments->NativeArgAt(0)->GetClassId();
+  //OS::Print("Retrieving hash for cid %d\n", cid);
+  //if (cid > 0) { //|| cid == kInstanceCid
+  //  //OS::Print("Cached hash for cid %d\n", cid);
+  //  return Smi::New(Object::GetCachedHash(arguments->NativeArgAt(0)));
+  //}
+  //return 0;
+   //Heap* heap = isolate->heap();
+   //ASSERT(arguments->NativeArgAt(0)->IsDartInstance());
+   //return Smi::New(heap->GetHash(arguments->NativeArgAt(0)));
+//#endif
 }
 
 DEFINE_NATIVE_ENTRY(Object_setHash, 0, 2) {

--- a/runtime/lib/object.cc
+++ b/runtime/lib/object.cc
@@ -37,7 +37,8 @@ DEFINE_NATIVE_ENTRY(Object_getHash, 0, 1) {
   // The performance benefit is more than 5% when using hashCode.
 //#if defined(HASH_IN_OBJECT_HEADER)
   return Smi::New(Object::GetCachedHash(arguments->NativeArgAt(0)));
-//#else  // 32bit architectures
+  //return Smi::New(arguments->NativeArgAt(0)->GetHash());
+  //#else  // 32bit architectures
   //intptr_t cid = arguments->NativeArgAt(0)->GetClassId();
   //OS::Print("Retrieving hash for cid %d\n", cid);
   //if (cid > 0) { //|| cid == kInstanceCid

--- a/runtime/platform/utils.h
+++ b/runtime/platform/utils.h
@@ -108,12 +108,12 @@ class Utils {
   static int CountOneBits64(uint64_t x);
   static int CountOneBits32(uint32_t x);
 
-  static int CountOneBitsWord(uword x) {
-#ifdef ARCH_IS_64_BIT
-    return CountOneBits64(x);
-#else
-    return CountOneBits32(x);
-#endif
+  static int CountOneBitsWord(uint64_t x) {
+    #ifdef ARCH_IS_64_BIT
+        return CountOneBits64(x);
+    #else
+        return CountOneBits32(x);
+    #endif
   }
 
   static int HighestBit(int64_t v);
@@ -341,7 +341,7 @@ class Utils {
     ASSERT(n <= kBitsPerWord);
     if (n == kBitsPerWord) {
       static_assert((sizeof(uword) * kBitsPerByte) == kBitsPerWord,
-                            "Unexpected uword size");
+                    "Unexpected uword size");
       return std::numeric_limits<uword>::max();
     }
     return (1ll << n) - 1;

--- a/runtime/vm/class_id.h
+++ b/runtime/vm/class_id.h
@@ -214,6 +214,11 @@ enum ClassId {
   kVoidCid,
   kNeverCid,
 
+  // Used for objects that are an extension of another object. There should
+  // be no pointers referencing them.
+  // FAST_HAST_FOR_32_BIT uses this id for appended hash objects.
+  kAppendedObjectCid,
+
   kNumPredefinedCids,
 };
 

--- a/runtime/vm/compiler/asm_intrinsifier_ia32.cc
+++ b/runtime/vm/compiler/asm_intrinsifier_ia32.cc
@@ -1888,7 +1888,47 @@ void AsmIntrinsifier::StringBaseSubstringMatches(Assembler* assembler,
 
 void AsmIntrinsifier::Object_getHash(Assembler* assembler,
                                      Label* normal_ir_body) {
+  //__ movq(EAX, Address(ESP, +1 * target::kWordSize));  // Object.
+  ////__ movl(EAX, FieldAddress(EAX, target::String::hash_offset()));
+  //__ SmiTag(EAX);
+  //__ ret();
+
+	 //Write the object address in the registry Check if the HasHashCode bit tag is
+  //    set If it is
+  //    : Substract kWordSize to the register value(
+  //          and replace) return the value where the register points to If
+  //          is not jump Set the value HashCodeRetrieved tag bit Shift
+  //              the register value 1 bit to the left return the register value
+  Label use_address_as_hash;
+  //, compute_address_hash;
+ 
   UNREACHABLE();
+  
+  __ cmpl(EAX, Immediate(0));
+  __ j(EQUAL, &compute_hash, Assembler::kNearJump);
+  __ ret();
+  //__ movl(EAX, FieldAddress(EAX, target::Type::hash_offset()));
+
+	
+  //__ movl(EBX, Address(ESP, +1 * target::kWordSize));
+  //__ movl(EBX, FieldAddress(EBX, +1 * target::kWordSize));
+  __ movl(EAX, Address(ESP, +1 * target::kWordSize))
+  __ movl(EDI, FieldAddress(EAX, target::Object::tags_offset()));
+  __ testl(EDI, Immediate(1 << kTrailingHashCodeBit));
+  __ j(NOT_EQUAL, &use_address_as_hash, Assembler::kNearJump);
+  //__ movl(EAX, FieldAddress(ESP, -1 * target::kWordSize));
+  __ movl(EAX, FieldAddress(EBX, -1 * target::kWordSize));
+  __ ret();
+
+
+  __ Bind(&use_address_as_hash);
+  // Set the the HashCodeRetrievedBit
+  __ orl(EDI, Immediate(1 << kHashCodeRetrievedBit));
+  __ movl(FieldAddress(EAX, target::Object::tags_offset()), EDI);
+
+  __ sarl(EAX, Immediate(1));  // shift address 1 bit to the left to convert to RawSmi
+  //__ movl(EAX, FieldAddress(EAX, -1 * target::kWordSize));
+  __ ret();
 }
 
 void AsmIntrinsifier::Object_setHash(Assembler* assembler,

--- a/runtime/vm/compiler/asm_intrinsifier_ia32.cc
+++ b/runtime/vm/compiler/asm_intrinsifier_ia32.cc
@@ -1894,7 +1894,7 @@ void AsmIntrinsifier::Object_getHash(Assembler* assembler,
   __ movl(ECX, Address(ESP, +1 * target::kWordSize));
   __ movl(EAX, FieldAddress(
                    ECX, 1 * target::Object::tags_offset()));  // Load the tags
-  __ testl(EAX, Immediate(1 << target::RawObject::kTrailingHashCodeBit));
+  __ testl(EAX, Immediate(1 << target::RawObject::kHasAppendedHashBit));
   __ j(ZERO, &check_hash_was_retrieved, Assembler::kNearJump);
   
   // Return the appended hashcode (one word before the object).
@@ -1903,11 +1903,11 @@ void AsmIntrinsifier::Object_getHash(Assembler* assembler,
 
   // Check if the HashRetrievedBit is set
   __ Bind(&check_hash_was_retrieved);
-  __ testl(EAX, Immediate(1 << target::RawObject::kHashCodeRetrievedBit));
+  __ testl(EAX, Immediate(1 << target::RawObject::kHashWasRetrievedBit));
   __ j(NOT_ZERO, &use_address_as_hash, Assembler::kNearJump);
 
   // Set the HashCodeRetrievedBit
-  __ orl(EAX, Immediate(1 << target::RawObject::kHashCodeRetrievedBit));
+  __ orl(EAX, Immediate(1 << target::RawObject::kHashWasRetrievedBit));
   __ movl(FieldAddress(ECX, +1 * target::Object::tags_offset()), EAX);
 
   // Use the address value as the hash
@@ -1923,6 +1923,7 @@ void AsmIntrinsifier::Object_setHash(Assembler* assembler,
 }
 
 void AsmIntrinsifier::StringBaseCharAt(Assembler* assembler,
+
                                        Label* normal_ir_body) {
   Label try_two_byte_string;
   __ movl(EBX, Address(ESP, +1 * target::kWordSize));  // Index.

--- a/runtime/vm/compiler/asm_intrinsifier_ia32.cc
+++ b/runtime/vm/compiler/asm_intrinsifier_ia32.cc
@@ -1888,46 +1888,32 @@ void AsmIntrinsifier::StringBaseSubstringMatches(Assembler* assembler,
 
 void AsmIntrinsifier::Object_getHash(Assembler* assembler,
                                      Label* normal_ir_body) {
-  //__ movq(EAX, Address(ESP, +1 * target::kWordSize));  // Object.
-  ////__ movl(EAX, FieldAddress(EAX, target::String::hash_offset()));
-  //__ SmiTag(EAX);
-  //__ ret();
-
-	 //Write the object address in the registry Check if the HasHashCode bit tag is
-  //    set If it is
-  //    : Substract kWordSize to the register value(
-  //          and replace) return the value where the register points to If
-  //          is not jump Set the value HashCodeRetrieved tag bit Shift
-  //              the register value 1 bit to the left return the register value
-  Label use_address_as_hash;
-  //, compute_address_hash;
+  Label check_hash_was_retrieved, use_address_as_hash;
  
-  UNREACHABLE();
+  // Check if the object has an appended hash
+  __ movl(ECX, Address(ESP, +1 * target::kWordSize));
+  __ movl(EAX, FieldAddress(
+                   ECX, 1 * target::Object::tags_offset()));  // Load the tags
+  __ testl(EAX, Immediate(1 << target::RawObject::kTrailingHashCodeBit));
+  __ j(ZERO, &check_hash_was_retrieved, Assembler::kNearJump);
   
-  __ cmpl(EAX, Immediate(0));
-  __ j(EQUAL, &compute_hash, Assembler::kNearJump);
-  __ ret();
-  //__ movl(EAX, FieldAddress(EAX, target::Type::hash_offset()));
-
-	
-  //__ movl(EBX, Address(ESP, +1 * target::kWordSize));
-  //__ movl(EBX, FieldAddress(EBX, +1 * target::kWordSize));
-  __ movl(EAX, Address(ESP, +1 * target::kWordSize))
-  __ movl(EDI, FieldAddress(EAX, target::Object::tags_offset()));
-  __ testl(EDI, Immediate(1 << kTrailingHashCodeBit));
-  __ j(NOT_EQUAL, &use_address_as_hash, Assembler::kNearJump);
-  //__ movl(EAX, FieldAddress(ESP, -1 * target::kWordSize));
-  __ movl(EAX, FieldAddress(EBX, -1 * target::kWordSize));
+  // Return the appended hashcode (one word before the object).
+  __ movl(EAX, FieldAddress(ECX, -1 * target::kWordSize));
   __ ret();
 
+  // Check if the HashRetrievedBit is set
+  __ Bind(&check_hash_was_retrieved);
+  __ testl(EAX, Immediate(1 << target::RawObject::kHashCodeRetrievedBit));
+  __ j(NOT_ZERO, &use_address_as_hash, Assembler::kNearJump);
 
+  // Set the HashCodeRetrievedBit
+  __ orl(EAX, Immediate(1 << target::RawObject::kHashCodeRetrievedBit));
+  __ movl(FieldAddress(ECX, +1 * target::Object::tags_offset()), EAX);
+
+  // Use the address value as the hash
   __ Bind(&use_address_as_hash);
-  // Set the the HashCodeRetrievedBit
-  __ orl(EDI, Immediate(1 << kHashCodeRetrievedBit));
-  __ movl(FieldAddress(EAX, target::Object::tags_offset()), EDI);
-
-  __ sarl(EAX, Immediate(1));  // shift address 1 bit to the left to convert to RawSmi
-  //__ movl(EAX, FieldAddress(EAX, -1 * target::kWordSize));
+  __ movl(EAX, ECX);
+  __ shll(EAX, Immediate(1));  // shift 1 bit to the left to convert to RawSmi
   __ ret();
 }
 

--- a/runtime/vm/compiler/intrinsifier.cc
+++ b/runtime/vm/compiler/intrinsifier.cc
@@ -192,7 +192,7 @@ bool Intrinsifier::Intrinsify(const ParsedFunction& parsed_function,
   // identity hash is not stored in the header of the object.  We
   // therefore don't intrinsify them, falling back on the native C++
   // implementations.
-  if (function.recognized_kind() == MethodRecognizer::kObject_getHash ||
+  if (//function.recognized_kind() == MethodRecognizer::kObject_getHash ||
       function.recognized_kind() == MethodRecognizer::kObject_setHash) {
     return false;
   }

--- a/runtime/vm/compiler/runtime_api.cc
+++ b/runtime/vm/compiler/runtime_api.cc
@@ -285,6 +285,12 @@ const word RawAbstractType::kTypeStateFinalizedInstantiated =
 const word RawObject::kBarrierOverlapShift =
     dart::RawObject::kBarrierOverlapShift;
 
+const word RawObject::kHashCodeRetrievedBit =
+    dart::RawObject::kHashCodeRetrievedBit;
+
+const word RawObject::kTrailingHashCodeBit =
+    dart::RawObject::kTrailingHashCodeBit;
+
 bool RawObject::IsTypedDataClassId(intptr_t cid) {
   return dart::RawObject::IsTypedDataClassId(cid);
 }

--- a/runtime/vm/compiler/runtime_api.cc
+++ b/runtime/vm/compiler/runtime_api.cc
@@ -285,11 +285,11 @@ const word RawAbstractType::kTypeStateFinalizedInstantiated =
 const word RawObject::kBarrierOverlapShift =
     dart::RawObject::kBarrierOverlapShift;
 
-const word RawObject::kHashCodeRetrievedBit =
-    dart::RawObject::kHashCodeRetrievedBit;
+const word RawObject::kHashWasRetrievedBit =
+    dart::RawObject::kHashWasRetrievedBit;
 
-const word RawObject::kTrailingHashCodeBit =
-    dart::RawObject::kTrailingHashCodeBit;
+const word RawObject::kHasAppendedHashBit =
+    dart::RawObject::kHasAppendedHashBit;
 
 bool RawObject::IsTypedDataClassId(intptr_t cid) {
   return dart::RawObject::IsTypedDataClassId(cid);

--- a/runtime/vm/compiler/runtime_api.h
+++ b/runtime/vm/compiler/runtime_api.h
@@ -356,8 +356,8 @@ class RawObject : public AllStatic {
   static const word kSizeTagMaxSizeTag;
   static const word kTagBitsSizeTagPos;
   static const word kBarrierOverlapShift;
-  static const word kHashCodeRetrievedBit;     // only used in 32bit
-  static const word kTrailingHashCodeBit;   // only used in 32bit
+  static const word kHashWasRetrievedBit;     // only used in 32bit
+  static const word kHasAppendedHashBit;   // only used in 32bit
 
   static bool IsTypedDataClassId(intptr_t cid);
 };

--- a/runtime/vm/compiler/runtime_api.h
+++ b/runtime/vm/compiler/runtime_api.h
@@ -356,6 +356,8 @@ class RawObject : public AllStatic {
   static const word kSizeTagMaxSizeTag;
   static const word kTagBitsSizeTagPos;
   static const word kBarrierOverlapShift;
+  static const word kHashCodeRetrievedBit;     // only used in 32bit
+  static const word kTrailingHashCodeBit;   // only used in 32bit
 
   static bool IsTypedDataClassId(intptr_t cid);
 };

--- a/runtime/vm/globals.h
+++ b/runtime/vm/globals.h
@@ -99,7 +99,7 @@ const intptr_t kDefaultMaxOldGenHeapSize = (kWordSize <= 4) ? 1536 : 30720;
 #define HASH_IN_OBJECT_HEADER 1
 #endif
 
-#if true  //!HASH_IN_OBJECT_HEADER TODO: testing
+#if !defined(HASH_IN_OBJECT_HEADER)
 #define FAST_HASH_FOR_32_BIT 1
 #endif
 

--- a/runtime/vm/globals.h
+++ b/runtime/vm/globals.h
@@ -99,6 +99,10 @@ const intptr_t kDefaultMaxOldGenHeapSize = (kWordSize <= 4) ? 1536 : 30720;
 #define HASH_IN_OBJECT_HEADER 1
 #endif
 
+#if true  //!HASH_IN_OBJECT_HEADER TODO: testing
+#define FAST_HASH_FOR_32_BIT 1
+#endif
+
 // The expression OFFSET_OF(type, field) computes the byte-offset of
 // the specified field relative to the containing type.
 //

--- a/runtime/vm/heap/compactor.cc
+++ b/runtime/vm/heap/compactor.cc
@@ -180,8 +180,6 @@ class CompactorTask : public ThreadPool::Task {
         free_end_(0) {}
 
  private:
-  //friend RawObject* class RawObject::ptr();
-
   void Run();
   void PlanPage(HeapPage* page);
   void SlidePage(HeapPage* page);
@@ -534,7 +532,7 @@ uword CompactorTask::PlanBlock(uword first_object,
   }
 
 #if defined(REALLOCATION_EXTRA_SIZE_ENABLED)
-  intptr_t next_page_start = free_page_->next()->object_start();
+  uword next_page_start = free_page_->next()->object_start();
 #endif
 
   // 2. Find the next contiguous space that can fit the live objects that
@@ -542,12 +540,12 @@ uword CompactorTask::PlanBlock(uword first_object,
   PlanMoveToContiguousSize(block_live_size);
 
 #if defined(REALLOCATION_EXTRA_SIZE_ENABLED)
-  // If the block is reallocated to a new page, the block needs to be
-  // planned again when the block size increases, because some reallocation
-  // addresses could match. This check ensures that the heap does not increase
-  // it's used space during compaction and that the reallocated object doesn't
-  // overlap the next object.
-  RawObject* raw_first = RawObject::FromAddr(first_object);
+  // If the block is reallocated to a new page, the block is planned again
+  // when the block size increases and the first object address matches the
+  // start of the next page, because some reallocation addresses could match
+  // having an effect in the reallocation size. This check ensures that the
+  // heap does not increase its used space during compaction and that the
+  // reallocated object doesn't overlap the next object.
   if (UNLIKELY(free_current_ == next_page_start &&
 	  free_current_ == first_object &&
       block_live_size > kBlockSize)) {

--- a/runtime/vm/heap/compactor.cc
+++ b/runtime/vm/heap/compactor.cc
@@ -550,7 +550,7 @@ uword CompactorTask::PlanBlock(uword first_object,
 #if defined(REALLOCATION_EXTRA_SIZE_ENABLED)
   // Because the block size could increase when an object requires extra
   // reallocation space to store the trailing hashCode, the block is planned
-  // again if moved to a new page and the block first object address
+  // again when moving to a new page and the block first object address
   // matches the page start address.
   if (free_current_ == next_page_start && free_current_ == first_object) {
     forwarding_block->Clear();

--- a/runtime/vm/heap/compactor.cc
+++ b/runtime/vm/heap/compactor.cc
@@ -610,6 +610,9 @@ uword CompactorTask::SlideBlock(uword first_object,
 #if defined(REALLOCATION_EXTRA_SIZE_ENABLED)
         extra_size = old_obj->ReallocationExtraSize();
 		old_obj->Reallocate(new_addr, size);
+        if (extra_size > 0) {
+		  OS::Print("Compactor reallocated %X, hash: %X, to %X, with trailing hash: %X, cid: %d\n", old_addr, old_obj->GetHash(), new_addr, new_obj->GetHash(), old_obj->GetClassId());
+		}
 #else
         old_obj->MoveTo(new_addr, size);
 #endif
@@ -629,13 +632,12 @@ uword CompactorTask::SlideBlock(uword first_object,
       free_current_ += size;
 #if defined(REALLOCATION_EXTRA_SIZE_ENABLED)
       free_current_ += extra_size;
-      if (extra_size > 0) {
+      if (extra_size > 0 && new_addr!=old_addr) {
         if (new_obj->HasTrailingHashCode()) {
-          OS::Print("Good. Added trailing hashCode. 0x%X == 0x%X\n",
+          OS::Print("Good. Compactor added trailing hashCode. 0x%X == 0x%X\n",
                     new_obj->GetHash(), old_obj->GetHash());
-
         } else {
-          OS::PrintErr("Bad. Didn't add trailing hashCode. 0x%X != 0x%X\n",
+          OS::PrintErr("Bad. Compactor didn't add trailing hashCode. 0x%X != 0x%X\n",
                        new_obj->GetHash(), old_obj->GetHash());
         }
       }

--- a/runtime/vm/heap/scavenger.cc
+++ b/runtime/vm/heap/scavenger.cc
@@ -265,11 +265,11 @@ class ScavengerVisitor : public ObjectPointerVisitor {
 #if defined(FAST_HASH_FOR_32_BIT)
         if (raw_obj->ReallocationExtraSize() > 0) {
           if (new_obj->HasTrailingHashCode()) {
-            // OS::Print("Good. Added trailing hashCode. 0x% == 0x%\n",
-            //           new_obj->GetHash(), raw_obj->GetHash());
+             //OS::Print("Good. Scavenger added trailing hashCode. 0x%X == 0x%X\n",
+             //          new_obj->GetHash(), raw_obj->GetHash());
           } else {
-            /*OS::PrintErr("Bad. Didn't add trailing hashCode. 0x% != 0x%\n",
-                         new_obj->GetHash(), raw_obj->GetHash());*/
+            OS::PrintErr("Bad. Scavenger didn't add trailing hashCode. 0x%X != 0x%X\n",
+                         new_obj->GetHash(), raw_obj->GetHash());
           }
         }
 #endif

--- a/runtime/vm/heap/scavenger.cc
+++ b/runtime/vm/heap/scavenger.cc
@@ -60,7 +60,7 @@ static inline void ForwardTo(uword original, uword target) {
   *reinterpret_cast<uword*>(original) = target | kForwarded;
 }
 
-static inline void objcpy(void* dst, const void* src, size_t size) {
+static inline void objcpy(void* dst, void* src, size_t size) {
   // A memcopy specialized for objects. We can assume:
   //  - dst and src do not overlap
   ASSERT(
@@ -74,15 +74,17 @@ static inline void objcpy(void* dst, const void* src, size_t size) {
   //  - size is a multiple of double words
   ASSERT(Utils::IsAligned(size, 2 * sizeof(uword)));
 
-  uword* __restrict dst_cursor = reinterpret_cast<uword*>(dst);
-  const uword* __restrict src_cursor = reinterpret_cast<const uword*>(src);
-  do {
-    uword a = *src_cursor++;
-    uword b = *src_cursor++;
-    *dst_cursor++ = a;
-    *dst_cursor++ = b;
-    size -= (2 * sizeof(uword));
-  } while (size > 0);
+  // uword* __restrict dst_cursor = reinterpret_cast<uword*>(dst);
+  // const uword* __restrict src_cursor = reinterpret_cast<const uword*>(src);
+  // do {
+  //   uword a = *src_cursor++;
+  //   uword b = *src_cursor++;
+  //   *dst_cursor++ = a;
+  //   *dst_cursor++ = b;
+  //   size -= (2 * sizeof(uword));
+  // } while (size > 0);
+  reinterpret_cast<RawObject*>(src)->Reallocate(reinterpret_cast<uword>(dst),
+                                                size);
 }
 
 class ScavengerVisitor : public ObjectPointerVisitor {

--- a/runtime/vm/heap/scavenger.cc
+++ b/runtime/vm/heap/scavenger.cc
@@ -189,7 +189,7 @@ class ScavengerVisitor : public ObjectPointerVisitor {
       // Get the new location of the object.
       new_addr = ForwardedAddr(header);
     } else {
-      intptr_t size = raw_obj->HeapSize();
+      intptr_t size = raw_obj->ReallocationHeapSize();
       // Check whether object should be promoted.
       if (scavenger_->survivor_end_ <= raw_addr) {
         // Not a survivor of a previous scavenge. Just copy the object into the
@@ -207,6 +207,8 @@ class ScavengerVisitor : public ObjectPointerVisitor {
           // If promotion succeeded then we need to remember it so that it can
           // be traversed later.
           scavenger_->PushToPromotedStack(new_addr);
+          // Question: Is there is an inconsistency consquence if bytes_promoted
+          // does not match expected promoted bytes?
           bytes_promoted_ += size;
         } else {
           // Promotion did not succeed. Copy into the to space instead.

--- a/runtime/vm/heap/scavenger.cc
+++ b/runtime/vm/heap/scavenger.cc
@@ -224,8 +224,6 @@ class ScavengerVisitor : public ObjectPointerVisitor {
       // current objects to the to space.
       ASSERT(new_addr != 0);
       // Copy the object to the new location.
-
-
 #if defined(FAST_HASH_FOR_32_BIT)
         raw_obj->Reallocate(new_addr, size - extra_size);
 #else

--- a/runtime/vm/heap/scavenger.cc
+++ b/runtime/vm/heap/scavenger.cc
@@ -232,16 +232,7 @@ class ScavengerVisitor : public ObjectPointerVisitor {
     } else {
       intptr_t size = raw_obj->HeapSize();
 #if defined(FAST_HASH_FOR_32_BIT)
-      intptr_t extra_size =
-          raw_obj
-              ->ReallocationExtraSize();  // - raw_obj->AppendedSize();  // TODO: testing *0
-      int cid_limit = 0; // 75 works, cids 119 and 104 cause failure (I suspect that because too many of those objects are moved)
-      int cid = raw_obj->GetClassId();
-      //if (cid < cid_limit || cid == kTypedDataUint32ArrayCid ||
-      //    cid == kTypedDataUint8ArrayCid) {
-	  if (cid < cid_limit) {
-        extra_size = 0;
-      }
+      intptr_t extra_size = raw_obj->ReallocationExtraSize();
       size += extra_size;
 #endif
       // Check whether object should be promoted.
@@ -259,11 +250,7 @@ class ScavengerVisitor : public ObjectPointerVisitor {
         new_addr = page_space_->TryAllocatePromoLocked(size);
         if (new_addr != 0) {
 #if defined(FAST_HASH_FOR_32_BIT)
-          if (extra_size > 0) {
-            scavenger_->PushToPromotedStack(new_addr + extra_size);
-          } else {
-            scavenger_->PushToPromotedStack(new_addr);
-          }
+          scavenger_->PushToPromotedStack(new_addr + extra_size);
 #else
           // If promotion succeeded then we need to remember it so that it can
           // be traversed later.

--- a/runtime/vm/object.h
+++ b/runtime/vm/object.h
@@ -376,18 +376,17 @@ class Object {
 
   static RawObject* null() { return null_; }
 
+static uint32_t GetCachedHash(const RawObject* obj) {
 #if defined(HASH_IN_OBJECT_HEADER)
-  static uint32_t GetCachedHash(const RawObject* obj) {
     return obj->ptr()->hash_;
+#else
+    return obj->GetHash();
+#endif
   }
 
+#if defined(HASH_IN_OBJECT_HEADER)
   static void SetCachedHash(RawObject* obj, uint32_t hash) {
     obj->ptr()->hash_ = hash;
-  }
-#else
-  static uint32_t GetHash(const RawObject* obj) {
-    if(obj->ptr())
-    return obj->ptr()->GetHash();
   }
 #endif
 

--- a/runtime/vm/object.h
+++ b/runtime/vm/object.h
@@ -378,12 +378,13 @@ class Object {
 
 #if defined(HASH_IN_OBJECT_HEADER)
   static uint32_t GetCachedHash(const RawObject* obj) {
+#if defined(FAST_HASH_FOR_32_BIT)
+    obj->GetHash();
+#endif
     return obj->ptr()->hash_;
   }
 #elif defined(FAST_HASH_FOR_32_BIT)
-  static uint32_t GetCachedHash(const RawObject* obj) {
-    return obj->GetHash();
-  }
+  static uint32_t GetCachedHash(const RawObject* obj) { return obj->GetHash(); }
 #endif
 
 #if defined(HASH_IN_OBJECT_HEADER)

--- a/runtime/vm/object.h
+++ b/runtime/vm/object.h
@@ -378,7 +378,8 @@ class Object {
 
 static uint32_t GetCachedHash(const RawObject* obj) {
 #if defined(HASH_IN_OBJECT_HEADER)
-    return obj->ptr()->hash_;
+    // return obj->ptr()->hash_;  // TODO: testing address hash
+    return obj->GetHash();
 #else
     return obj->GetHash();
 #endif

--- a/runtime/vm/object.h
+++ b/runtime/vm/object.h
@@ -378,9 +378,6 @@ class Object {
 
 #if defined(HASH_IN_OBJECT_HEADER)
   static uint32_t GetCachedHash(const RawObject* obj) {
-#if defined(FAST_HASH_FOR_32_BIT)
-    obj->GetHash();
-#endif
     return obj->ptr()->hash_;
   }
 #elif defined(FAST_HASH_FOR_32_BIT)

--- a/runtime/vm/object.h
+++ b/runtime/vm/object.h
@@ -378,8 +378,7 @@ class Object {
 
 static uint32_t GetCachedHash(const RawObject* obj) {
 #if defined(HASH_IN_OBJECT_HEADER)
-    // return obj->ptr()->hash_;  // TODO: testing address hash
-    return obj->GetHash();
+    return obj->ptr()->hash_;
 #else
     return obj->GetHash();
 #endif

--- a/runtime/vm/object.h
+++ b/runtime/vm/object.h
@@ -384,6 +384,11 @@ class Object {
   static void SetCachedHash(RawObject* obj, uint32_t hash) {
     obj->ptr()->hash_ = hash;
   }
+#else
+  static uint32_t GetHash(const RawObject* obj) {
+    if(obj->ptr())
+    return obj->ptr()->GetHash();
+  }
 #endif
 
   // The list below enumerates read-only handles for singleton
@@ -7626,6 +7631,7 @@ class Integer : public Number {
   friend class Class;
 };
 
+// Small integer (smi) class
 class Smi : public Integer {
  public:
   static const intptr_t kBits = kSmiBits;

--- a/runtime/vm/object.h
+++ b/runtime/vm/object.h
@@ -376,13 +376,15 @@ class Object {
 
   static RawObject* null() { return null_; }
 
-static uint32_t GetCachedHash(const RawObject* obj) {
 #if defined(HASH_IN_OBJECT_HEADER)
+  static uint32_t GetCachedHash(const RawObject* obj) {
     return obj->ptr()->hash_;
-#else
-    return obj->GetHash();
-#endif
   }
+#elif defined(FAST_HASH_FOR_32_BIT)
+  static uint32_t GetCachedHash(const RawObject* obj) {
+    return obj->GetHash();
+  }
+#endif
 
 #if defined(HASH_IN_OBJECT_HEADER)
   static void SetCachedHash(RawObject* obj, uint32_t hash) {

--- a/runtime/vm/pointer_tagging.h
+++ b/runtime/vm/pointer_tagging.h
@@ -81,6 +81,13 @@ inline intptr_t ValueFromRawSmi(const RawSmi* raw_value) {
   return (value >> kSmiTagShift);
 }
 
+inline RawSmi* ValueToRawSmi(intptr_t value) {
+  RawSmi* raw_smi = reinterpret_cast<RawSmi*>(
+      (static_cast<uintptr_t>(value) << kSmiTagShift) | kSmiTag);
+  ASSERT(ValueFromRawSmi(raw_smi) == value);
+  return raw_smi;
+}
+
 }  // namespace dart
 
 #endif  // RUNTIME_VM_POINTER_TAGGING_H_

--- a/runtime/vm/pointer_tagging.h
+++ b/runtime/vm/pointer_tagging.h
@@ -19,10 +19,11 @@ namespace dart {
 
 class RawSmi;
 
-// How are word misaligned in the new space??
-
 // Dart VM aligns all objects by 2 words in in the old space and misaligns them
 // in new space. This allows to distinguish new and old pointers by their bits.
+//
+// new space alignment:   address % kObjectAlignment == kWordSize
+// old space alignment:   address % kObjectAlignment == 0
 //
 // Note: these bits depend on the word size.
 template <intptr_t word_size, intptr_t word_size_log2>

--- a/runtime/vm/pointer_tagging.h
+++ b/runtime/vm/pointer_tagging.h
@@ -19,6 +19,8 @@ namespace dart {
 
 class RawSmi;
 
+// How are word misaligned in the new space??
+
 // Dart VM aligns all objects by 2 words in in the old space and misaligns them
 // in new space. This allows to distinguish new and old pointers by their bits.
 //

--- a/runtime/vm/raw_object.cc
+++ b/runtime/vm/raw_object.cc
@@ -235,15 +235,15 @@ intptr_t RawObject::HeapSizeFromClass() const {
     }
   }
   ASSERT(instance_size != 0);
-#if defined(FAST_HASH_FOR_32_BIT)
-  intptr_t t_size = SizeTag::decode(ptr()->tags_);
-  // Special case when the trailing size couldn't be added to the size tag.
-  if (HasTrailingHashCode() && (t_size == 0 || HashCodeWasRetrieved())) {
-    instance_size += ExtraSize();
-  } else if (t_size > instance_size) {
-    instance_size = t_size;
-  }
-#endif
+//#if defined(FAST_HASH_FOR_32_BIT)
+//  intptr_t t_size = SizeTag::decode(ptr()->tags_);
+//  // Special case when the trailing size couldn't be added to the size tag.
+//  if (HasAppendedHashObject() && (t_size == 0 || HashCodeWasRetrieved())) {
+//    instance_size += AppendedSize();
+//  } else if (t_size > instance_size) {
+//    instance_size = t_size;
+//  }
+//#endif
 #if defined(DEBUG)
   uint32_t tags = ptr()->tags_;
   intptr_t tags_size = SizeTag::decode(tags);
@@ -380,8 +380,8 @@ intptr_t RawObject::VisitPointersPredefined(ObjectPointerVisitor* visitor,
 //    size = tags_size;
 //  }
 //#endif
-  //return size;
-  return HeapSize();
+  return size;
+  //return HeapSize();
 #endif
 }
 

--- a/runtime/vm/raw_object.cc
+++ b/runtime/vm/raw_object.cc
@@ -236,12 +236,12 @@ intptr_t RawObject::HeapSizeFromClass() const {
   }
   ASSERT(instance_size != 0);
 #if defined(FAST_HASH_FOR_32_BIT)
-  intptr_t tags_size = SizeTag::decode(ptr()->tags_);
+  intptr_t t_size = SizeTag::decode(ptr()->tags_);
   // Special case when the trailing size couldn't be added to the size tag.
-  if (HasTrailingHashCode() && (tags_size == 0 || HashCodeWasRetrieved())) {
+  if (HasTrailingHashCode() && (t_size == 0 || HashCodeWasRetrieved())) {
     instance_size += ExtraSize();
-  } else if(tags_size>instance_size) {
-    instance_size = tags_size;
+  } else if (t_size > instance_size) {
+    instance_size = t_size;
   }
 #endif
 #if defined(DEBUG)

--- a/runtime/vm/raw_object.cc
+++ b/runtime/vm/raw_object.cc
@@ -209,6 +209,12 @@ intptr_t RawObject::HeapSizeFromClass() const {
       instance_size = element->HeapSize();
       break;
     }
+#if defined(FAST_HASH_FOR_32_BIT)
+    case kAppendedObjectCid: {
+      instance_size = kObjectAlignment;
+      break;
+    }
+#endif
     default: {
       // Get the (constant) instance size out of the class object.
       // TODO(koda): Add Size(ClassTable*) interface to allow caching in loops.
@@ -235,15 +241,6 @@ intptr_t RawObject::HeapSizeFromClass() const {
     }
   }
   ASSERT(instance_size != 0);
-//#if defined(FAST_HASH_FOR_32_BIT)
-//  intptr_t t_size = SizeTag::decode(ptr()->tags_);
-//  // Special case when the trailing size couldn't be added to the size tag.
-//  if (HasAppendedHashObject() && (t_size == 0 || HashCodeWasRetrieved())) {
-//    instance_size += AppendedSize();
-//  } else if (t_size > instance_size) {
-//    instance_size = t_size;
-//  }
-//#endif
 #if defined(DEBUG)
   uint32_t tags = ptr()->tags_;
   intptr_t tags_size = SizeTag::decode(tags);
@@ -349,6 +346,12 @@ intptr_t RawObject::VisitPointersPredefined(ObjectPointerVisitor* visitor,
       size = forwarder->HeapSize();
       break;
     }
+#if defined(FAST_HASH_FOR_32_BIT)
+    case kAppendedObjectCid: {
+      size = HeapSize();
+      break;
+    }
+#endif
     case kNullCid:
       size = HeapSize();
       break;
@@ -371,17 +374,7 @@ intptr_t RawObject::VisitPointersPredefined(ObjectPointerVisitor* visitor,
          (class_id == kArrayCid && size > expected_size));
   return size;  // Prefer larger size.
 #else
-//#if defined(FAST_HASH_FOR_32_BIT)
-//  intptr_t tags_size = SizeTag::decode(ptr()->tags_);
-//  // Special case when the trailing size couldn't be added to the size tag.
-//  if (HasTrailingHashCode() && (tags_size > size || tags_size == 0 && HashCodeRetrievedBit())) {
-//    size += TrailingExtraSize();
-//  } else if (tags_size > size) {
-//    size = tags_size;
-//  }
-//#endif
   return size;
-  //return HeapSize();
 #endif
 }
 

--- a/runtime/vm/raw_object.cc
+++ b/runtime/vm/raw_object.cc
@@ -239,7 +239,7 @@ intptr_t RawObject::HeapSizeFromClass() const {
   intptr_t tags_size = SizeTag::decode(ptr()->tags_);
   // Special case when the trailing size couldn't be added to the size tag.
   if (HasTrailingHashCode() && (tags_size == 0 || HashCodeWasRetrieved())) {
-    instance_size += TrailingExtraSize();
+    instance_size += ExtraSize();
   } else if(tags_size>instance_size) {
     instance_size = tags_size;
   }

--- a/runtime/vm/raw_object.cc
+++ b/runtime/vm/raw_object.cc
@@ -636,14 +636,14 @@ intptr_t RawInstance::VisitInstancePointers(RawInstance* raw_obj,
   }
 
   // Calculate the first and last raw object pointer fields.
-  // uword obj_addr = RawObject::ToAddr(raw_obj);
-  // uword from = obj_addr + sizeof(RawObject);
-  // uword to = obj_addr + instance_size - kWordSize;
-  // visitor->VisitPointers(reinterpret_cast<RawObject**>(from),
-  //                        reinterpret_cast<RawObject**>(to));
-  visitor->VisitPointers(
-      reinterpret_cast<RawObject**>(FirstPointerAddr(raw_obj)),
-      reinterpret_cast<RawObject**>(LastPointerAddr(raw_obj)));
+  uword obj_addr = RawObject::ToAddr(raw_obj);
+  uword from = obj_addr + sizeof(RawObject);
+  uword to = obj_addr + instance_size - kWordSize;
+  visitor->VisitPointers(reinterpret_cast<RawObject**>(from),
+                         reinterpret_cast<RawObject**>(to));
+  // visitor->VisitPointers(
+  //     reinterpret_cast<RawObject**>(FirstPointerAddr(raw_obj)),
+  //     reinterpret_cast<RawObject**>(LastPointerAddr(raw_obj)));
   return instance_size;
 }
 

--- a/runtime/vm/raw_object.cc
+++ b/runtime/vm/raw_object.cc
@@ -235,6 +235,9 @@ intptr_t RawObject::HeapSizeFromClass() const {
     }
   }
   ASSERT(instance_size != 0);
+#if !defined(HASH_IN_OBJECT_HEADER)
+  instance_size += TrailingExtraSize();
+#endif
 #if defined(DEBUG)
   uint32_t tags = ptr()->tags_;
   intptr_t tags_size = SizeTag::decode(tags);
@@ -255,9 +258,6 @@ intptr_t RawObject::HeapSizeFromClass() const {
            instance_size, tags_size, tags);
   }
 #endif  // DEBUG
-#if !defined(HASH_IN_OBJECT_HEADER)
-  instance_size += TrailingExtraSize();
-#endif
   return instance_size;
 }
 
@@ -383,13 +383,13 @@ void RawObject::VisitPointersPrecise(ObjectPointerVisitor* visitor) {
                                 ->next_field_offset_in_words_
                             << kWordSizeLog2;
   ASSERT(next_field_offset > 0);
-  // uword obj_addr = RawObject::ToAddr(this);
-  // uword from = obj_addr + sizeof(RawObject);
-  // uword to = obj_addr + next_field_offset - kWordSize;
+  uword obj_addr = RawObject::ToAddr(this);
+  uword from = obj_addr + sizeof(RawObject);
+  uword to = obj_addr + next_field_offset - kWordSize;
 
   // Not sure how next_field_offset should be interpreted
-  uword from = RawObject::FirstPointerAddr(this);
-  uword to = RawObject::ToAddr(this) + next_field_offset - kWordSize;
+  // uword from = RawObject::FirstPointerAddr(this);
+  // uword to = RawObject::ToAddr(this) + next_field_offset - kWordSize;
   visitor->VisitPointers(reinterpret_cast<RawObject**>(from),
                          reinterpret_cast<RawObject**>(to));
 }

--- a/runtime/vm/raw_object.h
+++ b/runtime/vm/raw_object.h
@@ -121,8 +121,8 @@ class RawObject {
     // kReservedTagPos = 6,
     // kReservedTagSize = 2,
     // Headers used to check status of the hashCode in 32bit platforms.
-    kHashCodeRetrievedBit = 6,  // only used in 32bit
-    kTrailingHashCodeBit = 7,   // only used in 32bit
+    kHashWasRetrievedBit = 6,  // only used in 32bit
+    kHasAppendedHashBit = 7,   // only used in 32bit
 
     kSizeTagPos = 8,  // = 8
     kSizeTagSize = 8,
@@ -738,8 +738,6 @@ class RawObject {
   friend class ForwardPointersVisitor;  // StorePointer
   friend class FreeListElement;
   friend class Function;
-  friend class GCMarker;
-  friend class CompactorTask;
   friend class ExternalTypedData;
   friend class ForwardList;
   friend class GrowableObjectArray;  // StorePointer

--- a/runtime/vm/raw_object.h
+++ b/runtime/vm/raw_object.h
@@ -537,8 +537,8 @@ class RawObject {
   }
 
   static uword LastPointerAddr(const RawObject* raw_obj) {
-    return reinterpret_cast<uword>(raw_obj->ptr()) + raw_obj->HeapSize() -
-           kWordSize;
+    return (reinterpret_cast<uword>(raw_obj->ptr()) + raw_obj->HeapSize() -
+            kWordSize);
   }
 
   static bool IsCanonical(intptr_t value) {

--- a/runtime/vm/raw_object.h
+++ b/runtime/vm/raw_object.h
@@ -739,6 +739,7 @@ class RawObject {
   friend class FreeListElement;
   friend class Function;
   friend class GCMarker;
+  friend class CompactorTask;
   friend class ExternalTypedData;
   friend class ForwardList;
   friend class GrowableObjectArray;  // StorePointer

--- a/runtime/vm/raw_object.h
+++ b/runtime/vm/raw_object.h
@@ -436,10 +436,6 @@ class RawObject {
     return IsHeapObject() ? GetClassId() : static_cast<intptr_t>(kSmiCid);
   }
 
-  intptr_t GetClassIdMayBeSmi() const {
-    return IsHeapObject() ? GetClassId() : static_cast<intptr_t>(kSmiCid);
-  }
-
   intptr_t HeapSize() const {
     ASSERT(IsHeapObject());
     uint32_t tags = ptr()->tags_;
@@ -507,6 +503,7 @@ class RawObject {
 
     // Calculate the first and last raw object pointer fields.
     intptr_t instance_size = HeapSize();
+    uword obj_addr = ToAddr(this);
     uword from = obj_addr + sizeof(RawObject);
     uword to = obj_addr + instance_size - kWordSize;
 

--- a/runtime/vm/raw_object.h
+++ b/runtime/vm/raw_object.h
@@ -171,7 +171,7 @@ class RawObject {
 
     static uword increaseSize(intptr_t extraSize, uword tag) {
       intptr_t oldSize = decode(tag);
-      if (oldSize >= kMaxSizeTag) {
+      if (oldSize == 0) {
         return tag;
       }
       return update(oldSize + extraSize, tag);
@@ -530,6 +530,10 @@ class RawObject {
 
   static uword FirstPointerAddr(const RawObject* raw_obj) {
     return reinterpret_cast<uword>(raw_obj->ptr()) + sizeof(RawObject);
+  }
+
+  static RawObject* LastPointer(const RawObject* raw_obj) {
+    return reinterpret_cast<RawObject*>(LastPointerAddr(raw_obj));
   }
 
   static uword LastPointerAddr(const RawObject* raw_obj) {


### PR DESCRIPTION
#24206 

This is an outline of the hashCode implementation for 32 bit platforms. I have not even tried to compile. 

- Please check if the logic suits the proposed idea.
- There is a lot of code where the size is retrieved from the object's InstanceSize method. This changes are not compatible with that method and to make it so it would require changing them one by one or to standardize the size retrieval to one method (HeapSize).
