### PR TITLE
Support latest analyzer in analyzer_plugin

### DIFF
--- a/pkg/analyzer_plugin/CHANGELOG.md
+++ b/pkg/analyzer_plugin/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.2.2
+- Bump maximum supported version of the analyzer to `<0.40.0`
+
 ## 0.2.1
 - Bump maximum supported version of the analyzer to `<0.39.0`.
 - Bug fixes: #37916, #38326.

--- a/pkg/analyzer_plugin/CHANGELOG.md
+++ b/pkg/analyzer_plugin/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 0.2.2
-- Bump maximum supported version of the analyzer to `<0.40.0`
+- Change supported analyzer version to `^0.39.0`
 
 ## 0.2.1
 - Bump maximum supported version of the analyzer to `<0.39.0`.

--- a/pkg/analyzer_plugin/pubspec.yaml
+++ b/pkg/analyzer_plugin/pubspec.yaml
@@ -19,6 +19,7 @@ dependencies:
 dev_dependencies:
   analysis_tool:
     path: ../analysis_tool
-  front_end: ^0.1.29
+  front_end:
+    path: ../front_end
   test_reflective_loader: ^0.1.8
   test: ^1.0.0

--- a/pkg/analyzer_plugin/pubspec.yaml
+++ b/pkg/analyzer_plugin/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: '>=2.0.0 <3.0.0'
 
 dependencies:
-  analyzer: '>=0.35.3 <0.40.0'
+  analyzer: '^0.39.0'
   charcode: '^1.1.0'
   dart_style: '^1.2.0'
   html: '>=0.13.1 <0.15.0'

--- a/pkg/analyzer_plugin/pubspec.yaml
+++ b/pkg/analyzer_plugin/pubspec.yaml
@@ -1,6 +1,6 @@
 name: analyzer_plugin
 description: A framework and support code for building plugins for the analysis server.
-version: 0.2.1
+version: 0.2.2
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/sdk/tree/master/pkg/analyzer_plugin
 
@@ -8,7 +8,7 @@ environment:
   sdk: '>=2.0.0 <3.0.0'
 
 dependencies:
-  analyzer: '>=0.35.3 <0.39.0'
+  analyzer: '>=0.35.3 <0.40.0'
   charcode: '^1.1.0'
   dart_style: '^1.2.0'
   html: '>=0.13.1 <0.15.0'
@@ -19,7 +19,6 @@ dependencies:
 dev_dependencies:
   analysis_tool:
     path: ../analysis_tool
-  front_end:
-    path: ../front_end
+  front_end: ^0.1.29
   test_reflective_loader: ^0.1.8
   test: ^1.0.0


### PR DESCRIPTION
I've raised the upper constraint for the analyzer to `<0.40.0` so that `0.39.1` can be supported. The latest `build_resolvers` package requires analyzer `^0.39.0`, it would be nice to use those packages together.