### PR TITLE
Hide dart:cli in api docs

### DIFF
--- a/sdk/lib/cli/cli.dart
+++ b/sdk/lib/cli/cli.dart
@@ -5,6 +5,7 @@
 // @dart = 2.6
 
 /// {@category VM}
+/// {@nodoc}
 library dart.cli;
 
 import 'dart:async';


### PR DESCRIPTION
This is experimental, and not ready for general consumption, so we shouldn't be advertizing it