### PR TITLE
Update math.dart:atan2 in relation to atan comment

### DIFF
--- a/sdk/lib/math/math.dart
+++ b/sdk/lib/math/math.dart
@@ -77,7 +77,7 @@ external T max<T extends num>(T a, T b);
 /// and the vector ([b],[a]).
 /// The result is in the range -PI..PI.
 ///
-/// If [b] is positive, this is the same as `atan(b/a)`.
+/// If [b] is positive, this is the same as `atan(a/b)`.
 ///
 /// The result is negative when [a] is negative (including when [a] is the
 /// double -0.0).


### PR DESCRIPTION
It's a **typo**. It should say **atan(a/b).** 
The way the _atan2(a,b)_ is defined _x=b, y=a => atan2(y,x) = atan(y/x) if x is positive_. 

So _atan2(a,b) = atan(a/b) if b is positive._

Indeed:
```
import 'dart:math'; 

void main() {
    double a = 1, b = 2;
    assert(atan2(a, b) == atan(a / b));
    assert(atan2(a, b) != atan(b / a));
}
```