### PR TITLE
Analysis server: Highlight null and throw keywords

### DIFF
--- a/pkg/analysis_server/lib/src/computer/computer_highlights2.dart
+++ b/pkg/analysis_server/lib/src/computer/computer_highlights2.dart
@@ -755,6 +755,12 @@ class _DartUnitHighlightsComputerVisitor2 extends RecursiveAstVisitor<void> {
   }
 
   @override
+  void visitNullLiteral(NullLiteral node) {
+    computer._addRegion_token(node.literal, HighlightRegionType.KEYWORD);
+    super.visitNullLiteral(node);
+  }
+
+  @override
   void visitOnClause(OnClause node) {
     computer._addRegion_token(node.onKeyword, HighlightRegionType.BUILT_IN);
     super.visitOnClause(node);
@@ -854,6 +860,12 @@ class _DartUnitHighlightsComputerVisitor2 extends RecursiveAstVisitor<void> {
   void visitThisExpression(ThisExpression node) {
     computer._addRegion_token(node.thisKeyword, HighlightRegionType.KEYWORD);
     super.visitThisExpression(node);
+  }
+
+  @override
+  void visitThrowExpression(ThrowExpression node) {
+    computer._addRegion_token(node.throwKeyword, HighlightRegionType.KEYWORD);
+    super.visitThrowExpression(node);
   }
 
   @override

--- a/pkg/analysis_server/test/src/computer/highlights2_computer_test.dart
+++ b/pkg/analysis_server/test/src/computer/highlights2_computer_test.dart
@@ -51,6 +51,20 @@ main() {
     _check(HighlightRegionType.IDENTIFIER_DEFAULT, 'foo');
   }
 
+  test_nullLiteral() async {
+    await _computeHighlights('var x = null;');
+    _check(HighlightRegionType.KEYWORD, 'null');
+  }
+
+  test_throwExpression() async {
+    await _computeHighlights('''
+void main() {
+  throw 'foo';
+}
+  ''');
+    _check(HighlightRegionType.KEYWORD, 'throw');
+  }
+
   void _check(HighlightRegionType expectedType, String expectedText) {
     for (var region in highlights) {
       if (region.type == expectedType) {


### PR DESCRIPTION
The `DartUnitHighlightsComputer2` does not highlight the `null` and `throw` keywords. This PR implements the two missing cases and adds a simple test case for them.