### PR TITLE
Introduce @Unsafe annotation

### DIFF
--- a/pkg/meta/CHANGELOG.md
+++ b/pkg/meta/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.1.9
+
+* Introduce `@Unsafe` to annotate methods or values that typically require
+  a security audit to use.
+
 ## 1.1.8
 
 * Introduce `@nonVirtual` to annotate instance members that should not be

--- a/pkg/meta/lib/meta.dart
+++ b/pkg/meta/lib/meta.dart
@@ -277,6 +277,24 @@ class Required {
   const Required([this.reason = '']);
 }
 
+
+/// Used to annotate an unsafe method or value in a class.
+///
+/// This annotation is expected to be used in sensitive libraries where API
+/// usage typically requires a security review.
+class Unsafe {
+
+  /// Human readable reason of why this construct is unsafe.
+  ///
+  /// This is required because unsafe annotations are not self-explanatory.
+  /// Explanation should give alternative APIs to use if applicable. It should
+  /// also link to documentation with more details as to why the API is unsafe.
+  final String reason;
+
+  /// Initialize a newly created instance with a given reason.
+  const Unsafe(this.reason);
+}
+
 class _AlwaysThrows {
   const _AlwaysThrows();
 }

--- a/pkg/meta/pubspec.yaml
+++ b/pkg/meta/pubspec.yaml
@@ -1,5 +1,5 @@
 name: meta
-version: 1.1.8
+version: 1.1.9
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/sdk/tree/master/pkg/meta
 description: >


### PR DESCRIPTION
Introduce `@Unsafe` to annotate methods or values that typically require a security audit to use.

See go/flutter-lints-dd for rationale.