### PR TITLE
Add support for @Unsafe to analyzer

### DIFF
--- a/pkg/analyzer/CHANGELOG.md
+++ b/pkg/analyzer/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.39.6
+* Add support for `@Unsafe` annotation as `isUnsafe` and `hasUnsafe`.
+
 ## 0.39.5-dev
 * Deprecated `ClassElement.instantiateToBounds()` and
   `FunctionTypeAliasElement.instantiateToBounds()`. With the null-safety

--- a/pkg/analyzer/lib/dart/element/element.dart
+++ b/pkg/analyzer/lib/dart/element/element.dart
@@ -585,6 +585,9 @@ abstract class Element implements AnalysisTarget {
   /// Return `true` if this element has an annotation of the form `@sealed`.
   bool get hasSealed;
 
+  /// Return `true` if this element has an annotation of the form `@Unsafe`.
+  bool get hasUnsafe;
+
   /// Return `true` if this element has an annotation of the form
   /// `@visibleForTemplate`.
   bool get hasVisibleForTemplate;
@@ -781,6 +784,9 @@ abstract class ElementAnnotation implements ConstantEvaluationTarget {
   /// Return `true` if this annotation marks the associated class as being
   /// sealed.
   bool get isSealed;
+
+  /// Return `true` if this annotation marks a method or field as unsafe.
+  bool get isUnsafe;
 
   /// Return `true` if this annotation marks the associated member as being
   /// visible for template files.

--- a/pkg/analyzer/lib/src/dart/element/element.dart
+++ b/pkg/analyzer/lib/src/dart/element/element.dart
@@ -2392,6 +2392,9 @@ class ElementAnnotationImpl implements ElementAnnotation {
   /// The name of the top-level variable used to mark a class as being sealed.
   static const String _SEALED_VARIABLE_NAME = "sealed";
 
+  /// The name of the top-level variable used to mark a method as unsafe.
+  static const String _UNSAFE_VARIABLE_NAME = "Unsafe";
+
   /// The name of the top-level variable used to mark a method as being
   /// visible for templates.
   static const String _VISIBLE_FOR_TEMPLATE_VARIABLE_NAME =
@@ -2538,6 +2541,12 @@ class ElementAnnotationImpl implements ElementAnnotation {
   bool get isSealed =>
       element is PropertyAccessorElement &&
       element.name == _SEALED_VARIABLE_NAME &&
+      element.library?.name == _META_LIB_NAME;
+
+  @override
+  bool get isUnsafe =>
+      element is PropertyAccessorElement &&
+      element.name == _UNSAFE_VARIABLE_NAME &&
       element.library?.name == _META_LIB_NAME;
 
   @override
@@ -2858,6 +2867,18 @@ abstract class ElementImpl implements Element {
     for (var i = 0; i < metadata.length; i++) {
       var annotation = metadata[i];
       if (annotation.isSealed) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  @override
+  bool get hasUnsafe {
+    var metadata = this.metadata;
+    for (var i = 0; i < metadata.length; i++) {
+      var annotation = metadata[i];
+      if (annotation.isUnsafe) {
         return true;
       }
     }

--- a/pkg/analyzer/lib/src/dart/element/element.dart
+++ b/pkg/analyzer/lib/src/dart/element/element.dart
@@ -2392,8 +2392,8 @@ class ElementAnnotationImpl implements ElementAnnotation {
   /// The name of the top-level variable used to mark a class as being sealed.
   static const String _SEALED_VARIABLE_NAME = "sealed";
 
-  /// The name of the top-level variable used to mark a method as unsafe.
-  static const String _UNSAFE_VARIABLE_NAME = "Unsafe";
+  /// The name of the top-level class used to mark an API as unsafe.
+  static const String _UNSAFE_CLASS_NAME = "Unsafe";
 
   /// The name of the top-level variable used to mark a method as being
   /// visible for templates.
@@ -2545,8 +2545,8 @@ class ElementAnnotationImpl implements ElementAnnotation {
 
   @override
   bool get isUnsafe =>
-      element is PropertyAccessorElement &&
-      element.name == _UNSAFE_VARIABLE_NAME &&
+      element is ClassElement &&
+      element.name == _UNSAFE_CLASS_NAME &&
       element.library?.name == _META_LIB_NAME;
 
   @override

--- a/pkg/analyzer/lib/src/dart/element/member.dart
+++ b/pkg/analyzer/lib/src/dart/element/member.dart
@@ -486,6 +486,9 @@ abstract class Member implements Element {
   bool get hasSealed => _declaration.hasSealed;
 
   @override
+  bool get hasUnsafe => _declaration.hasUnsafe;
+
+  @override
   bool get hasVisibleForTemplate => _declaration.hasVisibleForTemplate;
 
   @override

--- a/pkg/analyzer/pubspec.yaml
+++ b/pkg/analyzer/pubspec.yaml
@@ -1,5 +1,5 @@
 name: analyzer
-version: 0.39.4
+version: 0.39.6
 description: This package provides a library that performs static analysis of Dart code.
 homepage: https://github.com/dart-lang/sdk/tree/master/pkg/analyzer
 


### PR DESCRIPTION
Add support for `@Unsafe` annotation as `isUnsafe` and `hasUnsafe`.

See: https://github.com/dart-lang/sdk/pull/40429 for the definition of the annotation.