### PR TITLE
Bug with interpreter NullCheck bytecode instruction

### DIFF
--- a/runtime/vm/interpreter.cc
+++ b/runtime/vm/interpreter.cc
@@ -2804,13 +2804,13 @@ SwitchDispatch:
 
   {
     BYTECODE(NullCheck, D);
-    SP -= 1;
 
     if (UNLIKELY(SP[0] == null_value)) {
       // Load selector.
       SP[0] = LOAD_CONSTANT(rD);
       goto ThrowNullError;
     }
+    SP -= 1;
 
     DISPATCH();
   }


### PR DESCRIPTION
1. Let's look at the generation of NullCheck bytecode instruction.

 pkg/vm/lib/bytecode/gen_bytecode.dart

```
if (checkForNull) {

      asm.emitPush(receiverTemp);

      asm.emitNullCheck(cp.addSelectorName(node.name, InvocationKind.method));

    }
```

First push the receiver onto the stack, then check if it is null.
 
2. Related code in the interpreter.

runtime/vm/interpreter.cc

```
{
    BYTECODE(Push, X);
    *++SP = FP[rX];
    DISPATCH();
}

{
    BYTECODE(NullCheck, D);
    SP -= 1;

    if (UNLIKELY(SP[0] == null_value)) {
      // Load selector.
      SP[0] = LOAD_CONSTANT(rD);
      goto ThrowNullError;
    }

    DISPATCH();
  }
```

After the Push instruction is processed, now SP[0] is receiver.

But the NullCheck instruction first decrements SP by one,  causing the SP to be checked later is not a receiver.

After my testing, this is a bug.

3. fix like this

```
{
    BYTECODE(NullCheck, D);

    if (UNLIKELY(SP[0] == null_value)) {
      // Load selector.
      SP[0] = LOAD_CONSTANT(rD);
      goto ThrowNullError;
    }
    SP -= 1;

    DISPATCH();
}
```