### PR TITLE
Remove duplicate check for space character (32)

### DIFF
--- a/sdk/lib/_http/http_parser.dart
+++ b/sdk/lib/_http/http_parser.dart
@@ -932,7 +932,6 @@ class _HttpParser extends Stream<_HttpIncoming> {
 
   static bool _isValueChar(int byte) {
     return (byte > 31 && byte < 128) ||
-        (byte == _CharCode.SP) ||
         (byte == _CharCode.HT);
   }
 


### PR DESCRIPTION
`_CharCode.SP` is 32, which is already covered by the `byte > 31` part.

Should I do this change also in the NNBD version, or how are these kept in sync?