### PR TITLE
Switch to TLS 1.2 as minimum requirement

### DIFF
--- a/runtime/bin/security_context.cc
+++ b/runtime/bin/security_context.cc
@@ -805,7 +805,7 @@ void FUNCTION_NAME(SecurityContext_Allocate)(Dart_NativeArguments args) {
   SSLFilter::InitializeLibrary();
   SSL_CTX* ctx = SSL_CTX_new(TLS_method());
   SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, SSLCertContext::CertificateCallback);
-  SSL_CTX_set_min_proto_version(ctx, TLS1_VERSION);
+  SSL_CTX_set_min_proto_version(ctx, TLS1_2_VERSION);
   SSL_CTX_set_cipher_list(ctx, "HIGH:MEDIUM");
   SSLCertContext* context = new SSLCertContext(ctx);
   Dart_Handle err = SetSecurityContext(args, context);


### PR DESCRIPTION
According to https://tools.ietf.org/id/draft-ietf-tls-oldversions-deprecate-06.txt