### PR TITLE
Fix undefined behavior in UnboxedFieldBitmap

### DIFF
--- a/runtime/platform/utils.h
+++ b/runtime/platform/utils.h
@@ -364,6 +364,7 @@ class Utils {
 
   template <typename T>
   DART_FORCE_INLINE static bool TestBit(T mask, intptr_t position) {
+    ASSERT(position < sizeof(T) * kBitsPerByte);
     return ((mask >> position) & 1) != 0;
   }
 

--- a/runtime/platform/utils.h
+++ b/runtime/platform/utils.h
@@ -364,7 +364,7 @@ class Utils {
 
   template <typename T>
   DART_FORCE_INLINE static bool TestBit(T mask, intptr_t position) {
-    ASSERT(position < sizeof(T) * kBitsPerByte);
+    ASSERT(position < static_cast<intptr_t>(sizeof(T) * kBitsPerByte));
     return ((mask >> position) & 1) != 0;
   }
 

--- a/runtime/vm/class_table.h
+++ b/runtime/vm/class_table.h
@@ -42,9 +42,11 @@ class UnboxedFieldBitmap {
   UnboxedFieldBitmap& operator=(const UnboxedFieldBitmap&) = default;
 
   DART_FORCE_INLINE bool Get(intptr_t position) const {
+    if (position >= Length()) return false;
     return Utils::TestBit(bitmap_, position);
   }
   DART_FORCE_INLINE void Set(intptr_t position) {
+    ASSERT(position < Length());
     bitmap_ |= Utils::Bit<decltype(bitmap_)>(position);
   }
   DART_FORCE_INLINE uint64_t Value() const { return bitmap_; }


### PR DESCRIPTION
UnboxedFieldBitmap was relying that shifting operations would
result in 0 if `position` is larger than the number of bits in the
bitmap, but this is UB.