### PR TITLE
 Fix bug of calculation decodable immediate under arm architecture

### DIFF
--- a/runtime/vm/instructions_arm.cc
+++ b/runtime/vm/instructions_arm.cc
@@ -228,7 +228,9 @@ uword InstructionPattern::DecodeLoadWordFromPool(uword end,
     } else {
       ASSERT((instr & 0xffff0000) == (0xe0800000 | (PP << 16)));
       // add reg, pp, reg
-      end = DecodeLoadWordImmediate(end, reg, &offset);
+      intptr_t value = 0;
+      start = DecodeLoadWordImmediate(start, reg, &value);
+      offset += value;
     }
   }
   *index = ObjectPool::IndexFromOffset(offset);


### PR DESCRIPTION
1、
First,I generated such code for the InstanceCall instruction：

`

0x90d2a574    e59d0004      ldr r0, [sp, #+4]
0x90d2a578    e306e000      movw lr, #0x6000
0x90d2a57c    e340e010      movt lr, #0x10
0x90d2a580    e085e00e      add lr, pp, lr
0x90d2a584    e59eef8b      ldr lr, [lr, #+3979]
0x90d2a588    e3069000      movw r9, #0x6000
0x90d2a58c    e3409010      movt r9, #0x10
0x90d2a590    e0859009      add r9, pp, r9
0x90d2a594    e5999f8f      ldr r9, [r9, #+3983]
0x90d2a598    e12fff3e      blx lr
`

Because the offset of the data and target objects is too large, it uses decodable immediate.

2、
When I execute the code, the VM calculates the index of the data and target objects in the ObjectPool through CodePatcher, but the calculation result is wrong.

The wrong calculation logic is in the "InstructionPattern :: DecodeLoadWordFromPool" method of the "runtime/vm/instructions_arm.cc" file .