### PR TITLE
Added Iterable<Comparable> Extensions: .min and .max

### DIFF
--- a/sdk/lib/collection/iterable_comparable_extensions.dart
+++ b/sdk/lib/collection/iterable_comparable_extensions.dart
@@ -1,0 +1,39 @@
+// Copyright (c) 2012, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// @dart = 2.6
+
+part of dart.collection;
+
+extension IterableComparableExtensions<T extends Comparable> on Iterable<T> {
+  /*
+  * Returns the largest value in the iterable determined via
+  * [Comparable.toCompare()].
+  *
+  * The iterable must have at least one element, otherwise
+  * [IterableElementError] gets thrown.
+  * If it has only one element, that element is returned.
+  *
+  * If multiple items are maximal, the function returns the first one encountered.
+  */
+  Comparable get max {
+    return this.reduce((Comparable value, Comparable element) =>
+        value.compareTo(element) >= 0 ? value : element);
+  }
+
+  /*
+  * Returns the largest value in the iterable determined via
+  * [Comparable.toCompare()].
+  *
+  * The iterable must have at least one element, otherwise
+  * [IterableElementError] gets thrown.
+  * If it has only one element, that element is returned.
+  *
+  * If multiple items are maximal, the function returns the first one encountered.
+  */
+  Comparable get min {
+    return this.reduce((Comparable value, Comparable element) =>
+        value.compareTo(element) <= 0 ? value : element);
+  }
+}

--- a/tests/lib/collection/iterable_comparable_extensions_test.dart
+++ b/tests/lib/collection/iterable_comparable_extensions_test.dart
@@ -1,0 +1,36 @@
+// Copyright (c) 2011, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import "dart:collection";
+import "package:expect/expect.dart";
+
+void main() {
+  test('Iterable<int>.max return the highest int', () {
+    expect([2, 1, 3, 0].max, 3);
+    expect([2, 1, 3, 10].max, 10);
+  });
+  test('Iterable<int>.max return the lowest int', () {
+    expect([-2, 1, -1, 0].min, -2);
+    expect([2, -1, -1, 0].min, -1);
+  });
+  test('Iterable<double>.min handles nan as bigger then any other double', () {
+    expect([double.infinity, double.nan].min, double.infinity);
+  });
+  test('Iterable<Duration>.max return the longest Duration', () {
+    expect([Duration(hours: 2), Duration(hours: 1)].max, Duration(hours: 2));
+  });
+  test('Iterable<Duration>.min return the shortest Duration', () {
+    expect([Duration(hours: 2), Duration(hours: 1)].min, Duration(hours: 1));
+  });
+  test(
+      'Iterable<Duration>.min returns the first item when '
+      'multiple items have the same value', () {
+    Duration firstDuration = Duration(hours: 1);
+    Duration secondDuration = Duration(hours: 1);
+    Duration minimumDuration = [firstDuration, secondDuration].min;
+
+    expect(identical(firstDuration, minimumDuration), true);
+    expect(identical(secondDuration, minimumDuration), false);
+  });
+}


### PR DESCRIPTION
As discussed in https://github.com/dart-lang/sdk/issues/41902 I created two extensions to Iterable<Comparable>. .min that returns the smallest element and .max return s the largest one.

When it comes to the question of what to do when multiple elements have the same value I orientied myself with Pythons implementation of min() and max() that returns that both return the first value. 

I copied the headers from other files in their respective folders. 