### PR TITLE
Fix remaining instance where DateTime accesses the private member _value

### DIFF
--- a/sdk/lib/_internal/vm/lib/date_patch.dart
+++ b/sdk/lib/_internal/vm/lib/date_patch.dart
@@ -200,7 +200,7 @@ class DateTime {
 
   @patch
   Duration difference(DateTime other) {
-    return new Duration(microseconds: _value - other._value);
+    return new Duration(microseconds: _value - other.microsecondsSinceEpoch);
   }
 
   @patch


### PR DESCRIPTION
This does not work if the DateTime accessed is an implementation of
the DateTime interface, rather than an instance of the same class.

Related issues:

* https://github.com/dart-lang/sdk/issues/34962
* https://github.com/srawlins/timezone/issues/57

Related changes:

* https://dart-review.googlesource.com/c/sdk/+/81828