### PR TITLE
Delete unnecessary new keyword in Stopwatch dartdoc.

### DIFF
--- a/sdk/lib/core/stopwatch.dart
+++ b/sdk/lib/core/stopwatch.dart
@@ -27,7 +27,7 @@ class Stopwatch {
    * The following example shows how to start a [Stopwatch]
    * immediately after allocation.
    * ```
-   * var stopwatch = new Stopwatch()..start();
+   * var stopwatch = Stopwatch()..start();
    * ```
    */
   Stopwatch() {


### PR DESCRIPTION
This is not recommended: http://go/effective-dart/usage#dont-use-new.