### PR TITLE
Signature mismatch fix of Pointer::New()

### DIFF
--- a/runtime/vm/object.h
+++ b/runtime/vm/object.h
@@ -10165,7 +10165,7 @@ class ByteBuffer : public AllStatic {
 class Pointer : public Instance {
  public:
   static PointerPtr New(const AbstractType& type_arg,
-                        uword native_address,
+                        size_t native_address,
                         Heap::Space space = Heap::kNew);
 
   static intptr_t InstanceSize() {


### PR DESCRIPTION
Signature mismatch in header/source file causes vm build failure, by using `arm-linux-gnueabihf-gcc-5` (yep, for embedded device). Proposed to use same type: `size_t` in both files (header & source).

- [vm/object.h :: Pointer::New](https://github.com/dart-lang/sdk/blob/master/runtime/vm/object.h#L10167) (header file)
```cpp
class Pointer : public Instance {
 public:
  static PointerPtr New(const AbstractType& type_arg,
                        uword native_address, // <══════════ uword here
                        Heap::Space space = Heap::kNew);
  // ...
};
```

- [vm/object.cc :: Pointer::New](https://github.com/dart-lang/sdk/blob/master/runtime/vm/object.cc#L23462) (source file)
```cpp
PointerPtr Pointer::New(const AbstractType& type_arg,
                        size_t native_address, // <══════════ size_t here
                        Heap::Space space) {
  Thread* thread = Thread::Current();
  Zone* zone = thread->zone();

  TypeArguments& type_args = TypeArguments::Handle(zone);
  type_args = TypeArguments::New(1);
  type_args.SetTypeAt(Pointer::kNativeTypeArgPos, type_arg);
  type_args = type_args.Canonicalize();

  const Class& cls =
      Class::Handle(Isolate::Current()->class_table()->At(kFfiPointerCid));
  cls.EnsureIsFinalized(Thread::Current());

  Pointer& result = Pointer::Handle(zone);
  result ^= Object::Allocate(kFfiPointerCid, Pointer::InstanceSize(), space);
  result.SetTypeArguments(type_args);
  result.SetNativeAddress(native_address); // <══════════ Pointer::SetNativeAddress() receive size_t

  return result.raw();
}
```

- [vm/object.h :: Pointer::SetNativeAddress](https://github.com/dart-lang/sdk/blob/master/runtime/vm/object.h#L10181)
```cpp
void SetNativeAddress(size_t address) const { // <══════════ accept size_t
    uint8_t* value = reinterpret_cast<uint8_t*>(address);
    StoreNonPointer(&raw_ptr()->data_, value);
}
```