### PR TITLE
[vm/ffi] Changed Pointer::New 'native_address' type back to 'uword'

### DIFF
--- a/runtime/vm/object.cc
+++ b/runtime/vm/object.cc
@@ -23476,7 +23476,7 @@ const char* ExternalTypedData::ToCString() const {
 }
 
 PointerPtr Pointer::New(const AbstractType& type_arg,
-                        size_t native_address,
+                        uword native_address,
                         Heap::Space space) {
   Thread* thread = Thread::Current();
   Zone* zone = thread->zone();

--- a/runtime/vm/object.h
+++ b/runtime/vm/object.h
@@ -10167,7 +10167,7 @@ class ByteBuffer : public AllStatic {
 class Pointer : public Instance {
  public:
   static PointerPtr New(const AbstractType& type_arg,
-                        size_t native_address,
+                        uword native_address,
                         Heap::Space space = Heap::kNew);
 
   static intptr_t InstanceSize() {


### PR DESCRIPTION
As mentioned @mraleph here: https://github.com/dart-lang/sdk/pull/42451#pullrequestreview-440858928 it is better to use  `uword` instead of `size_t` for `Pointer::New( .. , native_address , ..)`. @dcharkes please verify it