### PR TITLE
Update list.dart

### DIFF
--- a/sdk/lib/collection/list.dart
+++ b/sdk/lib/collection/list.dart
@@ -482,7 +482,7 @@ abstract class ListMixin<E> implements List<E> {
     }
   }
 
-  int indexOf(Object? element, [int start = 0]) {
+  int indexOf(E? element, [int start = 0]) {
     if (start < 0) start = 0;
     for (int i = start; i < this.length; i++) {
       if (this[i] == element) return i;
@@ -498,7 +498,7 @@ abstract class ListMixin<E> implements List<E> {
     return -1;
   }
 
-  int lastIndexOf(Object? element, [int? start]) {
+  int lastIndexOf(E? element, [int? start]) {
     if (start == null || start >= this.length) start = this.length - 1;
 
     // TODO(38493): The previous line should promote.


### PR DESCRIPTION
It shall be consistent with `List<E>` since List is what the caller access, and it makes the overriding easier:

```
class Foo<E extends Base> with ListMixin<E> implements List<E> {
  @override
   int indexOf(E element, [int start = 0]) {
      //then we can access Base's member directly without casting it to E first
```