### PR TITLE
[front-end] bugfix: fix bug in constant eval .

### DIFF
--- a/pkg/front_end/lib/src/fasta/kernel/constant_evaluator.dart
+++ b/pkg/front_end/lib/src/fasta/kernel/constant_evaluator.dart
@@ -2302,6 +2302,14 @@ class ConstantEvaluator extends RecursiveVisitor<Constant> {
       if (a.value.isNaN && b.value.isNaN) return falseConstant;
       if (a.value == 0.0 && b.value == 0.0) return trueConstant;
     }
+
+    if (a is DoubleConstant && b is IntConstant) {
+      return makeBoolConstant(a.value == b.value);
+    }
+
+    if (a is IntConstant && b is DoubleConstant) {
+      return makeBoolConstant(a.value == b.value);
+    }
     return null;
   }
 

--- a/tests/language_2/regress/regress42946_test.dart
+++ b/tests/language_2/regress/regress42946_test.dart
@@ -1,17 +1,21 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'package:expect/expect.dart';
 
 /// https://github.com/dart-lang/sdk/issues/42946
 void main() {
-    // fix bug in constant eval
-    const x = (2.0 == 2);
-    const a = (2.0 == 2.0);
-    const b = (0.0 == 0.0);
-    const c = (double.nan == double.nan);
-    const d = (2.0 == 1.0);
-    
-    Expect.isTrue(x);
-    Expect.isTrue(a);
-    Expect.isTrue(b);
-    Expect.isFalse(c);
-    Expect.isFalse(d);
+  // fix bug in constant eval
+  const x = (2.0 == 2);
+  const a = (2.0 == 2.0);
+  const b = (0.0 == 0.0);
+  const c = (double.nan == double.nan);
+  const d = (2.0 == 1.0);
+
+  Expect.isTrue(x);
+  Expect.isTrue(a);
+  Expect.isTrue(b);
+  Expect.isFalse(c);
+  Expect.isFalse(d);
 }

--- a/tests/language_2/regress/regress42946_test.dart
+++ b/tests/language_2/regress/regress42946_test.dart
@@ -1,0 +1,17 @@
+import 'package:expect/expect.dart';
+
+/// https://github.com/dart-lang/sdk/issues/42946
+void main() {
+    // fix bug in constant eval
+    const x = (2.0 == 2);
+    const a = (2.0 == 2.0);
+    const b = (0.0 == 0.0);
+    const c = (double.nan == double.nan);
+    const d = (2.0 == 1.0);
+    
+    Expect.isTrue(x);
+    Expect.isTrue(a);
+    Expect.isTrue(b);
+    Expect.isFalse(c);
+    Expect.isFalse(d);
+}


### PR DESCRIPTION
fix bug in constant eval.
https://github.com/dart-lang/sdk/issues/42946

``` dart
main() {
  const x = (2 == 2.0);
  print(x); // prints `true`
}
```

@mraleph 