### PR TITLE
Fix dartvm re-init Flag check crash

### DIFF
--- a/runtime/vm/dart.cc
+++ b/runtime/vm/dart.cc
@@ -186,11 +186,6 @@ char* Dart::Init(const uint8_t* vm_isolate_snapshot,
     return Utils::StrDup("VM already initialized or flags not initialized.");
   }
 
-  if (FLAG_causal_async_stacks && FLAG_lazy_async_stacks) {
-    return Utils::StrDup(
-        "To use --lazy-async-stacks, please disable --causal-async-stacks!");
-  }
-
   const Snapshot* snapshot = nullptr;
   if (vm_isolate_snapshot != nullptr) {
     snapshot = Snapshot::SetupFromBuffer(vm_isolate_snapshot);
@@ -209,6 +204,10 @@ char* Dart::Init(const uint8_t* vm_isolate_snapshot,
     if (error != nullptr) {
       return error;
     }
+  }
+  if (FLAG_causal_async_stacks && FLAG_lazy_async_stacks) {
+    return Utils::StrDup(
+        "To use --lazy-async-stacks, please disable --causal-async-stacks!");
   }
 
   FrameLayout::Init();


### PR DESCRIPTION
Fix dartvm re-init Flag check crash,if dartvm first init set FLAG_causal_async_stacks and FLAG_lazy_async_stacks both true, when we re-init dart vm we will get a crash,it's better to read flag before flag check.

I got this crash when we modified flutter engine [common/settings.h](https://github.com/flutter/engine/blob/master/common/settings.h), because we want to destory dartvm to release memory，but when we recreate the Flutter engine ,we got crash below
```dart
 [VERBOSE-3:dart_vm.cc(421)] Error while initializing the Dart VM: To use --lazy-async-stacks, please disable --causal-async-stacks!
```
So I changed the code order, First to initialize flag from snopshot,then we check the Flag  is legal or not