### PR TITLE
Correct a typo in the documentation

### DIFF
--- a/sdk/lib/core/symbol.dart
+++ b/sdk/lib/core/symbol.dart
@@ -60,7 +60,7 @@ abstract class Symbol {
    * assert(new Symbol("[]=") == #[]=]);
    * assert(new Symbol("foo.bar") == #foo.bar);
    * assert(identical(const Symbol("foo"), #foo));
-   * assert(identical(const Symbol("[]="), #[]=]));
+   * assert(identical(const Symbol("[]="), #[]=));
    * assert(identical(const Symbol("foo.bar"), #foo.bar));
    * ```
    *


### PR DESCRIPTION
`Symbol("[]=")` is identical with `#[]=` not `#[]=]`