### PR TITLE
[vm, service] Dump complete gc roots.

### DIFF
--- a/runtime/vm/object_graph.cc
+++ b/runtime/vm/object_graph.cc
@@ -1140,8 +1140,8 @@ void HeapSnapshotWriter::Write() {
 
     // Root "object".
     ++object_count_;
-    isolate()->VisitObjectPointers(&visitor,
-                                   ValidationPolicy::kDontValidateFrames);
+    isolate()->group()->VisitObjectPointers(&visitor,
+                                            ValidationPolicy::kDontValidateFrames);
 
     // Heap objects.
     iteration.IterateVMIsolateObjects(&visitor);
@@ -1162,11 +1162,11 @@ void HeapSnapshotWriter::Write() {
     WriteUnsigned(0);  // shallowSize
     WriteUnsigned(kNoData);
     visitor.DoCount();
-    isolate()->VisitObjectPointers(&visitor,
-                                   ValidationPolicy::kDontValidateFrames);
+    isolate()->group()->VisitObjectPointers(&visitor,
+                                            ValidationPolicy::kDontValidateFrames);
     visitor.DoWrite();
-    isolate()->VisitObjectPointers(&visitor,
-                                   ValidationPolicy::kDontValidateFrames);
+    isolate()->group()->VisitObjectPointers(&visitor,
+                                            ValidationPolicy::kDontValidateFrames);
 
     // Heap objects.
     visitor.set_discount_sizes(true);


### PR DESCRIPTION
Incomplete gc roots causes many objects to be placed in the uncollected garbage when load the Snapshot file.