### PR TITLE
Export CommentToken in token.dart

### DIFF
--- a/pkg/analyzer/lib/dart/ast/token.dart
+++ b/pkg/analyzer/lib/dart/ast/token.dart
@@ -5,4 +5,4 @@
 /// Defines the tokens that are produced by the scanner, used by the parser, and
 /// referenced from the [AST structure](ast.dart).
 export 'package:_fe_analyzer_shared/src/scanner/token.dart'
-    show Keyword, Token, TokenType, LanguageVersionToken;
+    show Keyword, Token, TokenType, LanguageVersionToken, CommentToken;


### PR DESCRIPTION
This exports `CommentToken`

That class may be reached when doing:

```dart
AstNode node;
CommentToken = node.beginToken.precedingComments;
```

