### PR TITLE
Support latest analyzer in analyzer_plugin

### DIFF
--- a/pkg/analyzer_plugin/CHANGELOG.md
+++ b/pkg/analyzer_plugin/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Deprecated the method `ChangeBuilder.addFileEdit` and introduced
   `ChangeBuilder.addDartFileEdit` and `ChangeBuilder.addGenericFileEdit` to be
   the replacements for it.
+- Bump maximum supported version of the analyzer to `<0.41.0`.
 
 ## 0.3.0
 - Removed deprecated `Plugin.getResolveResult`. Use `getResolvedUnitResult`.

--- a/pkg/analyzer_plugin/pubspec.yaml
+++ b/pkg/analyzer_plugin/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: '>=2.3.0 <3.0.0'
 
 dependencies:
-  analyzer: '^0.39.12'
+  analyzer: '>=0.39.12 <0.41.0'
   charcode: '^1.1.0'
   dart_style: '^1.2.0'
   pub_semver: '^1.3.2'


### PR DESCRIPTION
I've raised the upper constraint for the analyzer to <0.41.0.