### PR TITLE
Improve null-safe package dependency error message

### DIFF
--- a/pkg/front_end/messages.yaml
+++ b/pkg/front_end/messages.yaml
@@ -1325,7 +1325,7 @@ StrongModeNNBDButOptOut:
 
 StrongModeNNBDPackageOptOut:
   template:  |
-    Cannot run with sound null safety as one or more dependencies do not
+    This project cannot run with sound null safety, because one or more project dependencies do not
     support null safety:
 
     #names


### PR DESCRIPTION
Make it even clearer that the null safe package error is not a bug in Dart, but a missing dependency in the user's project. This is intended to reduce user confusion, as in https://github.com/flutter/flutter/issues/68787. 