### PR TITLE
Uri: complete hashCode property description.

### DIFF
--- a/sdk/lib/core/uri.dart
+++ b/sdk/lib/core/uri.dart
@@ -609,7 +609,8 @@ abstract class Uri {
 
   /// Returns a hash code computed as `toString().hashCode`.
   ///
-  /// This guarantees that URIs with the same normalized
+  /// This guarantees that URIs with the same normalized string representation
+  /// have the same hash code.
   int get hashCode;
 
   /// A URI is equal to another URI with the same normalized representation.


### PR DESCRIPTION
The documentation for the Uri `hashCode` property is incomplete.

Complete the description of the property.
