### PR TITLE
Remove unused secure include in utils

### DIFF
--- a/runtime/bin/secure_socket_utils.cc
+++ b/runtime/bin/secure_socket_utils.cc
@@ -10,11 +10,9 @@
 #include <openssl/ssl.h>
 
 #include "platform/globals.h"
+#include "platform/syslog.h"
 
 #include "bin/file.h"
-#include "bin/secure_socket_filter.h"
-#include "bin/security_context.h"
-#include "platform/syslog.h"
 
 namespace dart {
 namespace bin {

--- a/runtime/bin/secure_socket_utils.cc
+++ b/runtime/bin/secure_socket_utils.cc
@@ -13,6 +13,7 @@
 #include "platform/syslog.h"
 
 #include "bin/file.h"
+#include "bin/utils.h"
 
 namespace dart {
 namespace bin {


### PR DESCRIPTION
`bin/secure_socket_filter.h` && `bin/security_context.h` is unused in `secure_socket_utils.cc` file.