### PR TITLE
Add --no-sound-null-safety option to dart2native.

### DIFF
--- a/pkg/dart2native/bin/dart2native.dart
+++ b/pkg/dart2native/bin/dart2native.dart
@@ -31,6 +31,12 @@ E.g.: dart2native -Da=1,b=2 main.dart''')
     ..addFlag('enable-asserts',
         negatable: false, help: 'Enable assert statements.')
     ..addMultiOption(
+      'extra-gen-kernel-options',
+      help: 'Pass additional options to gen_kernel.',
+      hide: true,
+      valueHelp: 'opt1,opt2,...',
+    )
+    ..addMultiOption(
       'extra-gen-snapshot-options',
       help: 'Pass additional options to gen_snapshot.',
       hide: true,
@@ -64,8 +70,11 @@ Remove debugging information from the output and save it separately to the speci
         defaultsTo: '', valueHelp: 'feature', hide: true, help: '''
 Comma separated list of experimental features.
 ''')
-    ..addFlag('verbose',
-        abbr: 'v', negatable: false, help: 'Show verbose output.');
+    ..addFlag('sound-null-safety',
+      help: 'Compile for sound null safety at runtime.',
+      defaultsTo: false,
+    )
+    ..addFlag('verbose', abbr: 'v', negatable: false, help: 'Show verbose output.');
 
   ArgResults parsedArgs;
   try {
@@ -96,6 +105,7 @@ Comma separated list of experimental features.
   }
 
   try {
+    final soundNullSafety = parsedArgs['sound-null-safety'] as bool;
     await generateNative(
         kind: parsedArgs['output-kind'],
         sourceFile: sourceFile,
@@ -106,7 +116,11 @@ Comma separated list of experimental features.
         enableExperiment: parsedArgs['enable-experiment'],
         enableAsserts: parsedArgs['enable-asserts'],
         verbose: parsedArgs['verbose'],
-        extraOptions: parsedArgs['extra-gen-snapshot-options']);
+        extraGenKernelOptions: [
+          ...(parsedArgs['extra-gen-kernel-options'] as List),
+          soundNullSafety ? '--sound-null-safety' : '--no-sound-null-safety',
+        ],
+        extraGenSnapshotOptions: parsedArgs['extra-gen-snapshot-options']);
   } catch (e) {
     stderr.writeln('Failed to generate native files:');
     stderr.writeln(e);

--- a/pkg/dart2native/lib/generate.dart
+++ b/pkg/dart2native/lib/generate.dart
@@ -27,7 +27,8 @@ Future<void> generateNative({
   String enableExperiment = '',
   bool enableAsserts = false,
   bool verbose = false,
-  List<String> extraOptions = const [],
+  List<String> extraGenKernelOptions = const [],
+  List<String> extraGenSnapshotOptions = const [],
 }) async {
   final Directory tempDir = Directory.systemTemp.createTempSync();
   try {
@@ -57,7 +58,7 @@ Future<void> generateNative({
     final String kernelFile = path.join(tempDir.path, 'kernel.dill');
     final kernelResult = await generateAotKernel(Platform.executable, genKernel,
         productPlatformDill, sourcePath, kernelFile, packages, defines,
-        enableExperiment: enableExperiment);
+        enableExperiment: enableExperiment, extraGenKernelOptions: extraGenKernelOptions);
     if (kernelResult.exitCode != 0) {
       stderr.writeln(kernelResult.stdout);
       stderr.writeln(kernelResult.stderr);
@@ -73,7 +74,7 @@ Future<void> generateNative({
         ? outputPath
         : path.join(tempDir.path, 'snapshot.aot'));
     final snapshotResult = await generateAotSnapshot(genSnapshot, kernelFile,
-        snapshotFile, debugPath, enableAsserts, extraOptions);
+        snapshotFile, debugPath, enableAsserts, extraGenSnapshotOptions);
     if (snapshotResult.exitCode != 0) {
       stderr.writeln(snapshotResult.stdout);
       stderr.writeln(snapshotResult.stderr);


### PR DESCRIPTION
Currently running `dart compile exe` does not support `--no-sound-null-safety` meaning currently during the null safety transition period we cannot build binary files. The `dart compile exe` wrapper executes the `dart2native` tool.

This PR fixes this by adding: `--no-sound-null-safety`, `--sound-null-safety`.

We also match the `--extra-gen-snapshot-options`  hidden option by also adding `--extra-gen-kernel-options` (hidden) option so the tool is flexible in the future.

Fixes: #44553

/cc @mit-mit I guess you are the right person to initially review this.