### PR TITLE
docs: Fixed a Typo in bigint.dart

### DIFF
--- a/sdk/lib/core/bigint.dart
+++ b/sdk/lib/core/bigint.dart
@@ -141,7 +141,7 @@ abstract class BigInt implements Comparable<BigInt> {
   /// of `this` and [other]
   ///
   /// If both operands are non-negative, the result is non-negative,
-  /// otherwise the result us negative.
+  /// otherwise the result is negative.
   BigInt operator |(BigInt other);
 
   /// Bit-wise exclusive-or operator.


### PR DESCRIPTION
I fixed a Typo in the documentation of the bit-wise or operator.

edit: I fixed a mistake in the sentence that describes how I fixed a mistake