### PR TITLE
Analyzer pkg: output required keyword in ToSourceVisitor

### DIFF
--- a/pkg/analyzer/lib/src/dart/ast/to_source_visitor.dart
+++ b/pkg/analyzer/lib/src/dart/ast/to_source_visitor.dart
@@ -367,9 +367,6 @@ class ToSourceVisitor implements AstVisitor<void> {
 
   @override
   void visitDefaultFormalParameter(DefaultFormalParameter node) {
-    if (node.isRequiredNamed) {
-      sink.write('required ');
-    }
     safelyVisitNode(node.parameter);
     if (node.separator != null) {
       if (node.separator!.lexeme != ":") {
@@ -974,6 +971,7 @@ class ToSourceVisitor implements AstVisitor<void> {
   @override
   void visitSimpleFormalParameter(SimpleFormalParameter node) {
     safelyVisitNodeListWithSeparatorAndSuffix(node.metadata, ' ', ' ');
+    safelyVisitTokenWithSuffix(node.requiredKeyword, ' ');
     safelyVisitTokenWithSuffix(node.covariantKeyword, ' ');
     safelyVisitTokenWithSuffix(node.keyword, " ");
     safelyVisitNode(node.type);

--- a/pkg/analyzer/test/src/dart/ast/to_source_visitor_test.dart
+++ b/pkg/analyzer/test/src/dart/ast/to_source_visitor_test.dart
@@ -1090,6 +1090,24 @@ class ToSourceVisitor2Test {
         ]));
   }
 
+  void test_visitFormalParameterList_namedRequired() {
+    _assertSource(
+        "({required a, required A b})",
+        AstTestFactory.formalParameterList([
+          AstTestFactory.namedFormalParameter(
+              AstTestFactory.simpleFormalParameter3("a")
+                ..requiredKeyword =
+                    TokenFactory.tokenFromKeyword(Keyword.REQUIRED),
+              null),
+          AstTestFactory.namedFormalParameter(
+              AstTestFactory.simpleFormalParameter2(
+                  null, AstTestFactory.typeName4('A'), "b")
+                ..requiredKeyword =
+                    TokenFactory.tokenFromKeyword(Keyword.REQUIRED),
+              null),
+        ]));
+  }
+
   void test_visitFormalParameterList_nn() {
     _assertSource(
         "({a: 0, b: 1})",
@@ -1216,24 +1234,6 @@ class ToSourceVisitor2Test {
           AstTestFactory.namedFormalParameter(
               AstTestFactory.simpleFormalParameter3("d"),
               AstTestFactory.integer(4))
-        ]));
-  }
-
-  void test_visitFormalParameterList_namedRequired() {
-    _assertSource(
-        "({required a, required A b})",
-        AstTestFactory.formalParameterList([
-          AstTestFactory.namedFormalParameter(
-              AstTestFactory.simpleFormalParameter3("a")
-                ..requiredKeyword =
-                    TokenFactory.tokenFromKeyword(Keyword.REQUIRED),
-              null),
-          AstTestFactory.namedFormalParameter(
-              AstTestFactory.simpleFormalParameter2(
-                  null, AstTestFactory.typeName4('A'), "b")
-                ..requiredKeyword =
-                    TokenFactory.tokenFromKeyword(Keyword.REQUIRED),
-              null),
         ]));
   }
 

--- a/pkg/analyzer/test/src/dart/ast/to_source_visitor_test.dart
+++ b/pkg/analyzer/test/src/dart/ast/to_source_visitor_test.dart
@@ -1219,6 +1219,24 @@ class ToSourceVisitor2Test {
         ]));
   }
 
+  void test_visitFormalParameterList_namedRequired() {
+    _assertSource(
+        "({required a, required A b})",
+        AstTestFactory.formalParameterList([
+          AstTestFactory.namedFormalParameter(
+              AstTestFactory.simpleFormalParameter3("a")
+                ..requiredKeyword =
+                    TokenFactory.tokenFromKeyword(Keyword.REQUIRED),
+              null),
+          AstTestFactory.namedFormalParameter(
+              AstTestFactory.simpleFormalParameter2(
+                  null, AstTestFactory.typeName4('A'), "b")
+                ..requiredKeyword =
+                    TokenFactory.tokenFromKeyword(Keyword.REQUIRED),
+              null),
+        ]));
+  }
+
   void test_visitFormalParameterList_rrp() {
     _assertSource(
         "(a, b, [c = 3])",


### PR DESCRIPTION
This fix `SimpleFormalParameter` in `ToSourceVisitor` to output `required` keyword