### PR TITLE
Enable fix for always_use_package_imports

### DIFF
--- a/pkg/analysis_server/lib/src/edit/fix/dartfix_info.dart
+++ b/pkg/analysis_server/lib/src/edit/fix/dartfix_info.dart
@@ -42,6 +42,7 @@ final allFixes = <DartFixInfo>[
 //  LintFixInfo.alwaysDeclareReturnTypes,
 //  LintFixInfo.alwaysRequireNonNullNamedParameters
 //  LintFixInfo.alwaysSpecifyTypes,
+  LintFixInfo.alwaysUsePackageImports,
   LintFixInfo.annotateOverrides,
   LintFixInfo.avoidAnnotatingWithDynamic,
   LintFixInfo.avoidEmptyElse,
@@ -165,6 +166,12 @@ class LintFixInfo extends DartFixInfo {
     'always_specify_types',
     DartFixKind.ADD_TYPE_ANNOTATION,
     'Add a type annotation.',
+  );
+
+  static final alwaysUsePackageImports = LintFixInfo(
+    'always_use_package_imports',
+    DartFixKind.CONVERT_TO_PACKAGE_IMPORT,
+    'Convert to a package import.',
   );
 
   static final annotateOverrides = LintFixInfo(


### PR DESCRIPTION
Currently `dart fix` can do package to relative import but not the other way around.
This PR enabled the other direction by simply using the already available fix.