### PR TITLE
[CFE] add compile-time error when deriving a mixin from a class with a non-Object superclass

### DIFF
--- a/pkg/_fe_analyzer_shared/lib/src/messages/codes_generated.dart
+++ b/pkg/_fe_analyzer_shared/lib/src/messages/codes_generated.dart
@@ -6804,6 +6804,31 @@ const MessageCode messageMixinFunction = const MessageCode("MixinFunction",
 // DO NOT EDIT. THIS FILE IS GENERATED. SEE TOP OF FILE.
 const Template<
     Message Function(
+        String
+            name)> templateMixinInheritsNotFromObject = const Template<
+        Message Function(String name)>(
+    messageTemplate:
+        r"""The class '#name' can't be used as a mixin because it extends a class other than Object.""",
+    withArguments: _withArgumentsMixinIneritsNotFromObject);
+
+// DO NOT EDIT. THIS FILE IS GENERATED. SEE TOP OF FILE.
+const Code<Message Function(String name)> codeMixinIneritsNotFromObject =
+    const Code<Message Function(String name)>("MixinIneritsNotFromObject",
+        analyzerCodes: <String>["MIXIN_INHERITS_FROM_NOT_OBJECT"]);
+
+// DO NOT EDIT. THIS FILE IS GENERATED. SEE TOP OF FILE.
+Message _withArgumentsMixinIneritsNotFromObject(String name) {
+  if (name.isEmpty) throw 'No name provided';
+  name = demangleMixinApplicationName(name);
+  return new Message(codeMixinIneritsNotFromObject,
+      message:
+          """The class '${name}' can't be used as a mixin because it extends a class other than Object.""",
+      arguments: {'name': name});
+}
+
+// DO NOT EDIT. THIS FILE IS GENERATED. SEE TOP OF FILE.
+const Template<
+    Message Function(
         String string,
         String
             string2)> templateModifierOutOfOrder = const Template<

--- a/pkg/front_end/lib/src/fasta/source/source_library_builder.dart
+++ b/pkg/front_end/lib/src/fasta/source/source_library_builder.dart
@@ -1983,6 +1983,20 @@ class SourceLibraryBuilder extends LibraryBuilderImpl {
         return false;
       }
 
+      /// Verify that the given mixin has the 'Object' superclass.
+      if (type.supertype == null ||
+          type.supertype == loader.target.objectType) {
+        if (type.mixins.length > 1) {
+          addProblem(
+              templateMixinInheritsNotFromObject.withArguments(subclassName),
+              charOffset, subclassName.length, fileUri);
+        }
+      } else {
+        addProblem(
+            templateMixinInheritsNotFromObject.withArguments(subclassName),
+            charOffset, subclassName.length, fileUri);
+      }
+
       /// Iterate over the mixins from left to right. At the end of each
       /// iteration, a new [supertype] is computed that is the mixin
       /// application of [supertype] with the current mixin.

--- a/pkg/front_end/messages.yaml
+++ b/pkg/front_end/messages.yaml
@@ -398,6 +398,10 @@ ExpectedInstead:
   script:
     - "class B {} mixin A extends B { }"
 
+MixinIneritsNotFromObject:
+  template: "The class '#name' can't be used as a mixin because it extends a class other than Object."
+  analyzerCode: MIXIN_INHERITS_FROM_NOT_OBJECT # CompileTimeErrorCode
+
 MultipleLibraryDirectives:
   index: 27
   template: "Only one library directive may be declared in a file."

--- a/pkg/front_end/testcases/general/mixin_inherits_non_object.dart
+++ b/pkg/front_end/testcases/general/mixin_inherits_non_object.dart
@@ -1,0 +1,21 @@
+// Copyright (c) 2021, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+void main() async {
+  final a = A();
+  print(a is N);
+  print(a is M);
+}
+
+mixin M {
+  int get number => 20;
+}
+
+mixin N {
+  String get text => 'Foo';
+}
+
+class Mixed = Object with N, M;
+
+class A with Mixed {}

--- a/pkg/front_end/testcases/general/mixin_inherits_non_object.dart.textual_outline.expect
+++ b/pkg/front_end/testcases/general/mixin_inherits_non_object.dart.textual_outline.expect
@@ -1,0 +1,10 @@
+void main() async {}
+mixin M {
+  int get number => 20;
+}
+mixin N {
+  String get text => 'Foo';
+}
+class Mixed = Object with N, M;
+
+class A with Mixed {}

--- a/pkg/front_end/testcases/general/mixin_inherits_non_object.dart.textual_outline_modelled.expect
+++ b/pkg/front_end/testcases/general/mixin_inherits_non_object.dart.textual_outline_modelled.expect
@@ -1,0 +1,10 @@
+class A with Mixed {}
+
+class Mixed = Object with N, M;
+mixin M {
+  int get number => 20;
+}
+mixin N {
+  String get text => 'Foo';
+}
+void main() async {}

--- a/pkg/front_end/testcases/general/mixin_inherits_non_object.dart.weak.expect
+++ b/pkg/front_end/testcases/general/mixin_inherits_non_object.dart.weak.expect
@@ -1,0 +1,64 @@
+library /*isNonNullableByDefault*/;
+//
+// Problems in library:
+//
+// pkg/front_end/testcases/general/mixin_inherits_non_object.dart:19:7: Error: The class 'Mixed' can't be used as a mixin because it extends a class other than Object.
+// class Mixed = Object with N, M;
+//       ^^^^^
+//
+// pkg/front_end/testcases/general/mixin_inherits_non_object.dart:21:7: Error: The non-abstract class 'A' is missing implementations for these members:
+//  - N.text
+// Try to either
+//  - provide an implementation,
+//  - inherit an implementation from a superclass or mixin,
+//  - mark the class as abstract, or
+//  - provide a 'noSuchMethod' implementation.
+//
+// class A with Mixed {}
+//       ^
+// pkg/front_end/testcases/general/mixin_inherits_non_object.dart:16:14: Context: 'N.text' is defined here.
+//   String get text => 'Foo';
+//              ^^^^
+//
+import self as self;
+import "dart:core" as core;
+
+abstract class M extends core::Object /*isMixinDeclaration*/  {
+  get number() → core::int
+    return 20;
+}
+abstract class N extends core::Object /*isMixinDeclaration*/  {
+  get text() → core::String
+    return "Foo";
+}
+abstract class _Mixed&Object&N = core::Object with self::N /*isAnonymousMixin,hasConstConstructor*/  {
+  const synthetic constructor •() → self::_Mixed&Object&N
+    : super core::Object::•()
+    ;
+  mixin-super-stub get text() → core::String
+    return super.{self::N::text};
+}
+class Mixed = self::_Mixed&Object&N with self::M /*hasConstConstructor*/  {
+  const synthetic constructor •() → self::Mixed
+    : super self::_Mixed&Object&N::•()
+    ;
+  mixin-super-stub get number() → core::int
+    return super.{self::M::number};
+}
+abstract class _A&Object&Mixed = core::Object with self::Mixed /*isAnonymousMixin,hasConstConstructor*/  {
+  const synthetic constructor •() → self::_A&Object&Mixed
+    : super core::Object::•()
+    ;
+  mixin-super-stub get number() → core::int
+    return super.{self::M::number};
+}
+class A extends self::_A&Object&Mixed {
+  synthetic constructor •() → self::A
+    : super self::_A&Object&Mixed::•()
+    ;
+}
+static method main() → void async {
+  final self::A a = new self::A::•();
+  core::print(a is{ForNonNullableByDefault} self::N);
+  core::print(a is{ForNonNullableByDefault} self::M);
+}

--- a/pkg/front_end/testcases/general/mixin_inherits_non_object.dart.weak.outline.expect
+++ b/pkg/front_end/testcases/general/mixin_inherits_non_object.dart.weak.outline.expect
@@ -1,0 +1,60 @@
+library /*isNonNullableByDefault*/;
+//
+// Problems in library:
+//
+// pkg/front_end/testcases/general/mixin_inherits_non_object.dart:19:7: Error: The class 'Mixed' can't be used as a mixin because it extends a class other than Object.
+// class Mixed = Object with N, M;
+//       ^^^^^
+//
+// pkg/front_end/testcases/general/mixin_inherits_non_object.dart:21:7: Error: The non-abstract class 'A' is missing implementations for these members:
+//  - N.text
+// Try to either
+//  - provide an implementation,
+//  - inherit an implementation from a superclass or mixin,
+//  - mark the class as abstract, or
+//  - provide a 'noSuchMethod' implementation.
+//
+// class A with Mixed {}
+//       ^
+// pkg/front_end/testcases/general/mixin_inherits_non_object.dart:16:14: Context: 'N.text' is defined here.
+//   String get text => 'Foo';
+//              ^^^^
+//
+import self as self;
+import "dart:core" as core;
+
+abstract class M extends core::Object /*isMixinDeclaration*/  {
+  get number() → core::int
+    ;
+}
+abstract class N extends core::Object /*isMixinDeclaration*/  {
+  get text() → core::String
+    ;
+}
+abstract class _Mixed&Object&N = core::Object with self::N /*isAnonymousMixin,hasConstConstructor*/  {
+  const synthetic constructor •() → self::_Mixed&Object&N
+    : super core::Object::•()
+    ;
+  mixin-super-stub get text() → core::String
+    return super.{self::N::text};
+}
+class Mixed = self::_Mixed&Object&N with self::M /*hasConstConstructor*/  {
+  const synthetic constructor •() → self::Mixed
+    : super self::_Mixed&Object&N::•()
+    ;
+  mixin-super-stub get number() → core::int
+    return super.{self::M::number};
+}
+abstract class _A&Object&Mixed = core::Object with self::Mixed /*isAnonymousMixin,hasConstConstructor*/  {
+  const synthetic constructor •() → self::_A&Object&Mixed
+    : super core::Object::•()
+    ;
+  mixin-super-stub get number() → core::int
+    return super.{self::M::number};
+}
+class A extends self::_A&Object&Mixed {
+  synthetic constructor •() → self::A
+    ;
+}
+static method main() → void async 
+  ;

--- a/pkg/front_end/testcases/general/mixin_inherits_non_object.dart.weak.transformed.expect
+++ b/pkg/front_end/testcases/general/mixin_inherits_non_object.dart.weak.transformed.expect
@@ -1,0 +1,88 @@
+library /*isNonNullableByDefault*/;
+//
+// Problems in library:
+//
+// pkg/front_end/testcases/general/mixin_inherits_non_object.dart:19:7: Error: The class 'Mixed' can't be used as a mixin because it extends a class other than Object.
+// class Mixed = Object with N, M;
+//       ^^^^^
+//
+// pkg/front_end/testcases/general/mixin_inherits_non_object.dart:21:7: Error: The non-abstract class 'A' is missing implementations for these members:
+//  - N.text
+// Try to either
+//  - provide an implementation,
+//  - inherit an implementation from a superclass or mixin,
+//  - mark the class as abstract, or
+//  - provide a 'noSuchMethod' implementation.
+//
+// class A with Mixed {}
+//       ^
+// pkg/front_end/testcases/general/mixin_inherits_non_object.dart:16:14: Context: 'N.text' is defined here.
+//   String get text => 'Foo';
+//              ^^^^
+//
+import self as self;
+import "dart:core" as core;
+import "dart:async" as asy;
+
+abstract class M extends core::Object /*isMixinDeclaration*/  {
+  get number() → core::int
+    return 20;
+}
+abstract class N extends core::Object /*isMixinDeclaration*/  {
+  get text() → core::String
+    return "Foo";
+}
+abstract class _Mixed&Object&N extends core::Object implements self::N /*isAnonymousMixin,isEliminatedMixin,hasConstConstructor*/  {
+  const synthetic constructor •() → self::_Mixed&Object&N
+    : super core::Object::•()
+    ;
+  get text() → core::String
+    return "Foo";
+}
+class Mixed extends self::_Mixed&Object&N implements self::M /*isEliminatedMixin,hasConstConstructor*/  {
+  const synthetic constructor •() → self::Mixed
+    : super self::_Mixed&Object&N::•()
+    ;
+  get number() → core::int
+    return 20;
+}
+abstract class _A&Object&Mixed extends core::Object implements self::Mixed /*isAnonymousMixin,isEliminatedMixin,hasConstConstructor*/  {
+  const synthetic constructor •() → self::_A&Object&Mixed
+    : super core::Object::•()
+    ;
+  get number() → core::int
+    return 20;
+}
+class A extends self::_A&Object&Mixed {
+  synthetic constructor •() → self::A
+    : super self::_A&Object&Mixed::•()
+    ;
+}
+static method main() → void /* originally async */ {
+  final asy::_Future<dynamic> :async_future = new asy::_Future::•<dynamic>();
+  core::bool* :is_sync = false;
+  FutureOr<dynamic>? :return_value;
+  (dynamic) → dynamic :async_op_then;
+  (core::Object, core::StackTrace) → dynamic :async_op_error;
+  core::int :await_jump_var = 0;
+  dynamic :await_ctx_var;
+  function :async_op([dynamic :result, dynamic :exception, dynamic :stack_trace]) → dynamic yielding 
+    try {
+      #L1:
+      {
+        final self::A a = new self::A::•();
+        core::print(a is{ForNonNullableByDefault} self::N);
+        core::print(a is{ForNonNullableByDefault} self::M);
+      }
+      asy::_completeOnAsyncReturn(:async_future, :return_value, :is_sync);
+      return;
+    }
+    on dynamic catch(dynamic exception, core::StackTrace stack_trace) {
+      asy::_completeOnAsyncError(:async_future, exception, stack_trace, :is_sync);
+    }
+  :async_op_then = asy::_asyncThenWrapperHelper(:async_op);
+  :async_op_error = asy::_asyncErrorWrapperHelper(:async_op);
+  :async_op.call();
+  :is_sync = true;
+  return :async_future;
+}


### PR DESCRIPTION
resolve https://github.com/dart-lang/sdk/issues/45194

test result: 

```
../../a.dart:15:7: Error: The class 'Mixed' can't be used as a mixin because it extends a class other than Object.
class Mixed = Object with N, M;
      ^^^^^
../../a.dart:17:7: Error: The non-abstract class 'A' is missing implementations for these members:
 - N.text
Try to either
 - provide an implementation,
 - inherit an implementation from a superclass or mixin,
 - mark the class as abstract, or
 - provide a 'noSuchMethod' implementation.

class A with Mixed {}
      ^
../../a.dart:12:14: Context: 'N.text' is defined here.
  String get text => 'Foo';
             ^^^^
```