### PR TITLE
[analyzer] add getter/setter conflict search in lexical scope lookup.

### DIFF
--- a/pkg/analyzer/lib/error/error.dart
+++ b/pkg/analyzer/lib/error/error.dart
@@ -430,6 +430,7 @@ const List<ErrorCode> errorCodeValues = [
   CompileTimeErrorCode.UNDEFINED_EXTENSION_SETTER,
   CompileTimeErrorCode.UNDEFINED_FUNCTION,
   CompileTimeErrorCode.UNDEFINED_GETTER,
+  CompileTimeErrorCode.UNDEFINED_TOP_LEVEL_GETTER,
   CompileTimeErrorCode.UNDEFINED_IDENTIFIER,
   CompileTimeErrorCode.UNDEFINED_IDENTIFIER_AWAIT,
   CompileTimeErrorCode.UNDEFINED_METHOD,

--- a/pkg/analyzer/lib/src/dart/resolver/simple_identifier_resolver.dart
+++ b/pkg/analyzer/lib/src/dart/resolver/simple_identifier_resolver.dart
@@ -175,6 +175,19 @@ class SimpleIdentifierResolver {
 
     var element = hasRead ? result.readElement : result.writeElement;
 
+    // search for property writer.
+    var writerResult = _resolver.lexicalLookup(node: node, setter: true);
+    if (writerResult.requested is PropertyAccessorElement) {
+      // verify var of searched writer has getter.
+      var val = (writerResult.requested as PropertyAccessorElement).variable;
+      var getter = val.getter;
+      if (getter == null && val is TopLevelVariableElement) {
+        _errorReporter.reportErrorForNode(
+            CompileTimeErrorCode.UNDEFINED_TOP_LEVEL_GETTER, node,
+            [node.name]);
+      }
+    }
+
     var enclosingClass = _resolver.enclosingClass;
     if (_isFactoryConstructorReturnType(node) &&
         !identical(element, enclosingClass)) {

--- a/pkg/analyzer/lib/src/dart/resolver/simple_identifier_resolver.dart
+++ b/pkg/analyzer/lib/src/dart/resolver/simple_identifier_resolver.dart
@@ -184,7 +184,7 @@ class SimpleIdentifierResolver {
       if (getter == null && val is TopLevelVariableElement) {
         _errorReporter.reportErrorForNode(
             CompileTimeErrorCode.UNDEFINED_TOP_LEVEL_GETTER, node,
-            [node.name]);
+            [node.name, result.readElement, val.setter]);
       }
     }
 

--- a/pkg/analyzer/lib/src/error/codes.dart
+++ b/pkg/analyzer/lib/src/error/codes.dart
@@ -12618,6 +12618,10 @@ class CompileTimeErrorCode extends AnalyzerErrorCode {
           "defining a getter or field named '{0}'.",
       hasPublishedDocs: true);
 
+  static const CompileTimeErrorCode UNDEFINED_TOP_LEVEL_GETTER = CompileTimeErrorCode(
+      'UNDEFINED_TOP_LEVEL_GETTER',
+      "Getter not found: '{0}'.");
+
   /**
    * Parameters:
    * 0: the name of the identifier

--- a/pkg/analyzer/lib/src/error/codes.dart
+++ b/pkg/analyzer/lib/src/error/codes.dart
@@ -12618,9 +12618,16 @@ class CompileTimeErrorCode extends AnalyzerErrorCode {
           "defining a getter or field named '{0}'.",
       hasPublishedDocs: true);
 
+  /**
+   * Parameters:
+   * 0: the name of the getter
+   * 1: the name of the inherited getter
+   * 2: the name of the top-level setter
+   */
   static const CompileTimeErrorCode UNDEFINED_TOP_LEVEL_GETTER = CompileTimeErrorCode(
       'UNDEFINED_TOP_LEVEL_GETTER',
-      "Getter not found: '{0}'.");
+      "'{0}' can't be used as a getter because inherited getter `{1}` has"
+          " been hidden by top-level setter `{2}`");
 
   /**
    * Parameters:

--- a/pkg/analyzer/test/src/diagnostics/invalid_top_level_getter.dart
+++ b/pkg/analyzer/test/src/diagnostics/invalid_top_level_getter.dart
@@ -1,0 +1,34 @@
+// Copyright (c) 2021, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/src/error/codes.dart';
+import 'package:test_reflective_loader/test_reflective_loader.dart';
+
+import '../dart/resolution/context_collection_resolution.dart';
+
+main() {
+  defineReflectiveSuite(() {
+    defineReflectiveTests(InvalidTopLevelGetterTest);
+  });
+}
+
+@reflectiveTest
+class InvalidTopLevelGetterTest extends PubPackageResolutionTest {
+  test_top_level_getter() async {
+    await assertErrorsInCode(
+        '''
+set m(_) {}
+
+class A {
+  int get m => 0;
+}
+
+class B extends A {
+  void userOfM() => print(m);
+}
+''', [
+      error(CompileTimeErrorCode.UNDEFINED_TOP_LEVEL_GETTER, 90, 1),
+    ]);
+  }
+}

--- a/pkg/analyzer/test/src/diagnostics/test_all.dart
+++ b/pkg/analyzer/test/src/diagnostics/test_all.dart
@@ -346,6 +346,8 @@ import 'invalid_use_of_visible_for_testing_member_test.dart'
     as invalid_use_of_visible_for_testing_member;
 import 'invalid_visibility_annotation_test.dart'
     as invalid_visibility_annotation;
+import 'invalid_top_level_getter.dart'
+    as invalid_top_level_getter;
 import 'invocation_of_extension_without_call_test.dart'
     as invocation_of_extension_without_call;
 import 'invocation_of_non_function_expression_test.dart'
@@ -912,6 +914,7 @@ main() {
     invalid_use_of_visible_for_template_member.main();
     invalid_use_of_visible_for_testing_member.main();
     invalid_visibility_annotation.main();
+    invalid_top_level_getter.main();
     invocation_of_extension_without_call.main();
     invocation_of_non_function_expression.main();
     label_in_outer_scope.main();


### PR DESCRIPTION
resolve https://github.com/dart-lang/sdk/issues/45467