### PR TITLE
Enable print_ssa_liveranges

### DIFF
--- a/runtime/vm/compiler/backend/linearscan.cc
+++ b/runtime/vm/compiler/backend/linearscan.cc
@@ -463,7 +463,7 @@ void LiveRange::Print() {
   THR_Print("  live range v%" Pd " [%" Pd ", %" Pd ") in ", vreg(), Start(),
             End());
   assigned_location().Print();
-  if (spill_slot_.HasStackIndex()) {
+  if (spill_slot_.HasStackIndex() && spill_slot_.base_reg() == FPREG) {
     const intptr_t stack_slot =
         -compiler::target::frame_layout.VariableIndexForFrameSlot(
             spill_slot_.stack_index());

--- a/runtime/vm/compiler/backend/linearscan.cc
+++ b/runtime/vm/compiler/backend/linearscan.cc
@@ -463,11 +463,8 @@ void LiveRange::Print() {
   THR_Print("  live range v%" Pd " [%" Pd ", %" Pd ") in ", vreg(), Start(),
             End());
   assigned_location().Print();
-  if (spill_slot_.HasStackIndex() && spill_slot_.base_reg() == FPREG) {
-    const intptr_t stack_slot =
-        -compiler::target::frame_layout.VariableIndexForFrameSlot(
-            spill_slot_.stack_index());
-    THR_Print(" allocated spill slot: %" Pd "", stack_slot);
+  if (!spill_slot_.IsInvalid() && !spill_slot_.IsConstant()) {
+    THR_Print(" assigned spill slot: %s", spill_slot_.ToCString());
   }
   THR_Print("\n");
 


### PR DESCRIPTION
Assert when print_ssa_liveranges flag is set.
Check two conditions to print spill slot.
- HasStackIndex
- FP base register