### PR TITLE
[analyzer] change type alias cycle focus on typedef name.

### DIFF
--- a/pkg/analyzer/lib/src/generated/error_verifier.dart
+++ b/pkg/analyzer/lib/src/generated/error_verifier.dart
@@ -3962,13 +3962,13 @@ class ErrorVerifier extends RecursiveAstVisitor<void>
   ///
   /// See [CompileTimeErrorCode.TYPE_ALIAS_CANNOT_REFERENCE_ITSELF].
   void _checkForTypeAliasCannotReferenceItself(
-    AstNode node,
+    TypeAlias node,
     TypeAliasElementImpl element,
   ) {
     if (element.hasSelfReference) {
       errorReporter.reportErrorForNode(
         CompileTimeErrorCode.TYPE_ALIAS_CANNOT_REFERENCE_ITSELF,
-        node,
+        node.name,
       );
     }
   }

--- a/pkg/analyzer/test/src/diagnostics/not_instantiated_bound_test.dart
+++ b/pkg/analyzer/test/src/diagnostics/not_instantiated_bound_test.dart
@@ -116,7 +116,7 @@ typedef F(C value);
 class C<T extends F> {}
 class D<T extends C> {}
 ''', [
-      error(CompileTimeErrorCode.TYPE_ALIAS_CANNOT_REFERENCE_ITSELF, 0, 19),
+      error(CompileTimeErrorCode.TYPE_ALIAS_CANNOT_REFERENCE_ITSELF, 8, 1),
       error(CompileTimeErrorCode.NOT_INSTANTIATED_BOUND, 38, 1),
       error(CompileTimeErrorCode.NOT_INSTANTIATED_BOUND, 62, 1),
     ]);

--- a/pkg/analyzer/test/src/diagnostics/type_alias_cannot_reference_itself_test.dart
+++ b/pkg/analyzer/test/src/diagnostics/type_alias_cannot_reference_itself_test.dart
@@ -19,7 +19,7 @@ class TypeAliasCannotReferenceItselfTest extends PubPackageResolutionTest {
     await assertErrorsInCode('''
 typedef A<T extends A<int>>();
 ''', [
-      error(CompileTimeErrorCode.TYPE_ALIAS_CANNOT_REFERENCE_ITSELF, 0, 30),
+      error(CompileTimeErrorCode.TYPE_ALIAS_CANNOT_REFERENCE_ITSELF, 8, 1),
     ]);
   }
 
@@ -27,7 +27,7 @@ typedef A<T extends A<int>>();
     await assertErrorsInCode('''
 typedef A(A b());
 ''', [
-      error(CompileTimeErrorCode.TYPE_ALIAS_CANNOT_REFERENCE_ITSELF, 0, 17),
+      error(CompileTimeErrorCode.TYPE_ALIAS_CANNOT_REFERENCE_ITSELF, 8, 1),
     ]);
   }
 
@@ -40,8 +40,8 @@ main() {
   foo(null);
 }
 ''', [
-      error(CompileTimeErrorCode.TYPE_ALIAS_CANNOT_REFERENCE_ITSELF, 0, 37),
-      error(CompileTimeErrorCode.TYPE_ALIAS_CANNOT_REFERENCE_ITSELF, 38, 37),
+      error(CompileTimeErrorCode.TYPE_ALIAS_CANNOT_REFERENCE_ITSELF, 8, 1),
+      error(CompileTimeErrorCode.TYPE_ALIAS_CANNOT_REFERENCE_ITSELF, 46, 1),
     ]);
   }
 
@@ -49,7 +49,7 @@ main() {
     await assertErrorsInCode('''
 typedef A<T extends A<int>> = void Function();
 ''', [
-      error(CompileTimeErrorCode.TYPE_ALIAS_CANNOT_REFERENCE_ITSELF, 0, 46),
+      error(CompileTimeErrorCode.TYPE_ALIAS_CANNOT_REFERENCE_ITSELF, 8, 1),
     ]);
   }
 
@@ -57,7 +57,7 @@ typedef A<T extends A<int>> = void Function();
     await assertErrorsInCode(r'''
 typedef F<X extends F<X>> = F Function();
 ''', [
-      error(CompileTimeErrorCode.TYPE_ALIAS_CANNOT_REFERENCE_ITSELF, 0, 41),
+      error(CompileTimeErrorCode.TYPE_ALIAS_CANNOT_REFERENCE_ITSELF, 8, 1),
     ]);
   }
 
@@ -70,8 +70,8 @@ main() {
   foo(null);
 }
 ''', [
-      error(CompileTimeErrorCode.TYPE_ALIAS_CANNOT_REFERENCE_ITSELF, 0, 26),
-      error(CompileTimeErrorCode.TYPE_ALIAS_CANNOT_REFERENCE_ITSELF, 27, 26),
+      error(CompileTimeErrorCode.TYPE_ALIAS_CANNOT_REFERENCE_ITSELF, 13, 1),
+      error(CompileTimeErrorCode.TYPE_ALIAS_CANNOT_REFERENCE_ITSELF, 40, 1),
     ]);
   }
 
@@ -93,8 +93,8 @@ typedef D F();
 typedef T1 = T2;
 typedef T2 = T1;
 ''', [
-      error(CompileTimeErrorCode.TYPE_ALIAS_CANNOT_REFERENCE_ITSELF, 0, 16),
-      error(CompileTimeErrorCode.TYPE_ALIAS_CANNOT_REFERENCE_ITSELF, 17, 16),
+      error(CompileTimeErrorCode.TYPE_ALIAS_CANNOT_REFERENCE_ITSELF, 8, 2),
+      error(CompileTimeErrorCode.TYPE_ALIAS_CANNOT_REFERENCE_ITSELF, 25, 2),
     ]);
   }
 
@@ -102,7 +102,7 @@ typedef T2 = T1;
     await assertErrorsInCode('''
 typedef T = void Function(T);
 ''', [
-      error(CompileTimeErrorCode.TYPE_ALIAS_CANNOT_REFERENCE_ITSELF, 0, 29),
+      error(CompileTimeErrorCode.TYPE_ALIAS_CANNOT_REFERENCE_ITSELF, 8, 1),
     ]);
   }
 
@@ -110,7 +110,7 @@ typedef T = void Function(T);
     await assertErrorsInCode('''
 typedef T = T;
 ''', [
-      error(CompileTimeErrorCode.TYPE_ALIAS_CANNOT_REFERENCE_ITSELF, 0, 14),
+      error(CompileTimeErrorCode.TYPE_ALIAS_CANNOT_REFERENCE_ITSELF, 8, 1),
     ]);
   }
 
@@ -118,7 +118,7 @@ typedef T = T;
     await assertErrorsInCode('''
 typedef T = T?;
 ''', [
-      error(CompileTimeErrorCode.TYPE_ALIAS_CANNOT_REFERENCE_ITSELF, 0, 15),
+      error(CompileTimeErrorCode.TYPE_ALIAS_CANNOT_REFERENCE_ITSELF, 8, 1),
     ]);
   }
 
@@ -126,7 +126,7 @@ typedef T = T?;
     await assertErrorsInCode('''
 typedef T = List<T>;
 ''', [
-      error(CompileTimeErrorCode.TYPE_ALIAS_CANNOT_REFERENCE_ITSELF, 0, 20),
+      error(CompileTimeErrorCode.TYPE_ALIAS_CANNOT_REFERENCE_ITSELF, 8, 1),
     ]);
   }
 
@@ -134,7 +134,7 @@ typedef T = List<T>;
     await assertErrorsInCode('''
 typedef T<X extends T<Never>> = List<X>;
 ''', [
-      error(CompileTimeErrorCode.TYPE_ALIAS_CANNOT_REFERENCE_ITSELF, 0, 40),
+      error(CompileTimeErrorCode.TYPE_ALIAS_CANNOT_REFERENCE_ITSELF, 8, 1),
     ]);
   }
 
@@ -142,7 +142,7 @@ typedef T<X extends T<Never>> = List<X>;
     await assertErrorsInCode('''
 typedef A({A a});
 ''', [
-      error(CompileTimeErrorCode.TYPE_ALIAS_CANNOT_REFERENCE_ITSELF, 0, 17),
+      error(CompileTimeErrorCode.TYPE_ALIAS_CANNOT_REFERENCE_ITSELF, 8, 1),
     ]);
   }
 
@@ -150,7 +150,7 @@ typedef A({A a});
     await assertErrorsInCode('''
 typedef A([A a]);
 ''', [
-      error(CompileTimeErrorCode.TYPE_ALIAS_CANNOT_REFERENCE_ITSELF, 0, 17),
+      error(CompileTimeErrorCode.TYPE_ALIAS_CANNOT_REFERENCE_ITSELF, 8, 1),
     ]);
   }
 
@@ -158,7 +158,7 @@ typedef A([A a]);
     await assertErrorsInCode('''
 typedef A(A a);
 ''', [
-      error(CompileTimeErrorCode.TYPE_ALIAS_CANNOT_REFERENCE_ITSELF, 0, 15),
+      error(CompileTimeErrorCode.TYPE_ALIAS_CANNOT_REFERENCE_ITSELF, 8, 1),
     ]);
   }
 
@@ -166,7 +166,7 @@ typedef A(A a);
     await assertErrorsInCode('''
 typedef A(List<A> a);
 ''', [
-      error(CompileTimeErrorCode.TYPE_ALIAS_CANNOT_REFERENCE_ITSELF, 0, 21),
+      error(CompileTimeErrorCode.TYPE_ALIAS_CANNOT_REFERENCE_ITSELF, 8, 1),
     ]);
   }
 
@@ -194,7 +194,7 @@ class C {
     await assertErrorsInCode('''
 typedef A A();
 ''', [
-      error(CompileTimeErrorCode.TYPE_ALIAS_CANNOT_REFERENCE_ITSELF, 0, 14),
+      error(CompileTimeErrorCode.TYPE_ALIAS_CANNOT_REFERENCE_ITSELF, 10, 1),
     ]);
   }
 
@@ -203,8 +203,21 @@ typedef A A();
 typedef B A();
 typedef A B();
 ''', [
-      error(CompileTimeErrorCode.TYPE_ALIAS_CANNOT_REFERENCE_ITSELF, 0, 14),
-      error(CompileTimeErrorCode.TYPE_ALIAS_CANNOT_REFERENCE_ITSELF, 15, 14),
+      error(CompileTimeErrorCode.TYPE_ALIAS_CANNOT_REFERENCE_ITSELF, 10, 1),
+      error(CompileTimeErrorCode.TYPE_ALIAS_CANNOT_REFERENCE_ITSELF, 25, 1),
+    ]);
+  }
+  test_typedef_reference_itself() async {
+    await assertErrorsInCode('''
+/**
+ * This is a test
+ */
+
+typedef FUNC1<T> = void Function<T1 extends FUNC1<T>>();
+
+main() {}    
+''', [
+      error(CompileTimeErrorCode.TYPE_ALIAS_CANNOT_REFERENCE_ITSELF, 35, 5),
     ]);
   }
 }

--- a/tests/language/function/type_alias6_test.dart
+++ b/tests/language/function/type_alias6_test.dart
@@ -6,7 +6,7 @@
 import "package:expect/expect.dart";
 
 typedef F(List<F> x);
-// [error line 8, column 1, length 21]
+// [error line 8, column 9, length 1]
 // [analyzer] COMPILE_TIME_ERROR.TYPE_ALIAS_CANNOT_REFERENCE_ITSELF
 //      ^
 // [cfe] The typedef 'F' has a reference to itself.

--- a/tests/language/function/type_alias9_test.dart
+++ b/tests/language/function/type_alias9_test.dart
@@ -4,12 +4,12 @@
 // Dart test for legally self referencing function type alias.
 
 typedef void F(List<G> l);
-// [error line 6, column 1, length 26]
+// [error line 6, column 14, length 1]
 // [analyzer] COMPILE_TIME_ERROR.TYPE_ALIAS_CANNOT_REFERENCE_ITSELF
 //           ^
 // [cfe] The typedef 'F' has a reference to itself.
 typedef void G(List<F> l);
-// [error line 11, column 1, length 26]
+// [error line 11, column 14, length 1]
 // [analyzer] COMPILE_TIME_ERROR.TYPE_ALIAS_CANNOT_REFERENCE_ITSELF
 
 main() {

--- a/tests/language/regress/regress33479_test.dart
+++ b/tests/language/regress/regress33479_test.dart
@@ -3,7 +3,11 @@ class Hest<TypeX extends Fisk> {}
 // [analyzer] COMPILE_TIME_ERROR.NOT_INSTANTIATED_BOUND
 
 typedef Fisk = void Function // don't merge lines
+<<<<<<< HEAD
 // [error line 5, column 1, length 346]
+=======
+// [error line 7, column 9, length 4]
+>>>>>>> bugfix: update test fix
 // [analyzer] COMPILE_TIME_ERROR.TYPE_ALIAS_CANNOT_REFERENCE_ITSELF
 //      ^
 // [cfe] Generic type 'Fisk' can't be used without type arguments in the bounds of its own type variables. It is referenced indirectly through 'Hest'.

--- a/tests/language/typedef/cyclic2_test.dart
+++ b/tests/language/typedef/cyclic2_test.dart
@@ -6,60 +6,60 @@
 
 // A body dependency, cycle length 1.
 typedef F1<X> = F1<X> Function();
-// [error line 8, column 1, length 33]
+// [error line 8, column 9, length 2]
 // [analyzer] COMPILE_TIME_ERROR.TYPE_ALIAS_CANNOT_REFERENCE_ITSELF
 //      ^^
 // [cfe] The typedef 'F1' has a reference to itself.
 
 // A body dependency (in a bound), cycle length 1.
 typedef F2<X> = Function<Y extends F2<X>>(Y);
-// [error line 15, column 1, length 45]
+// [error line 15, column 9, length 2]
 // [analyzer] COMPILE_TIME_ERROR.TYPE_ALIAS_CANNOT_REFERENCE_ITSELF
 //      ^^
 // [cfe] The typedef 'F2' has a reference to itself.
 
 // A bound dependency, cycle length 1.
 typedef F3<X extends F3<X>> = Function(X);
-// [error line 22, column 1, length 42]
+// [error line 22, column 9, length 2]
 // [analyzer] COMPILE_TIME_ERROR.TYPE_ALIAS_CANNOT_REFERENCE_ITSELF
 //      ^^
 // [cfe] The typedef 'F3' has a reference to itself.
 
 // A body dependency, cycle length 2.
 typedef F4a<X> = F4b<X> Function();
-// [error line 29, column 1, length 35]
+// [error line 29, column 9, length 3]
 // [analyzer] COMPILE_TIME_ERROR.TYPE_ALIAS_CANNOT_REFERENCE_ITSELF
 //      ^^^
 // [cfe] The typedef 'F4a' has a reference to itself.
 
 typedef F4b<X> = F4a<X> Function();
-// [error line 35, column 1, length 35]
+// [error line 35, column 9, length 3]
 // [analyzer] COMPILE_TIME_ERROR.TYPE_ALIAS_CANNOT_REFERENCE_ITSELF
 //      ^^^
 // [cfe] The typedef 'F4b' has a reference to itself.
 
 // A body dependency (in a bound), cycle length 2.
 typedef F5a<X> = Function<Y extends F5b<X>>(Y);
-// [error line 42, column 1, length 47]
+// [error line 42, column 9, length 3]
 // [analyzer] COMPILE_TIME_ERROR.TYPE_ALIAS_CANNOT_REFERENCE_ITSELF
 //      ^^^
 // [cfe] The typedef 'F5a' has a reference to itself.
 
 typedef F5b<X> = Function<Y extends F5a<X>>(Y);
-// [error line 48, column 1, length 47]
+// [error line 48, column 9, length 3]
 // [analyzer] COMPILE_TIME_ERROR.TYPE_ALIAS_CANNOT_REFERENCE_ITSELF
 //      ^^^
 // [cfe] The typedef 'F5b' has a reference to itself.
 
 // A bound dependency, cycle length 2.
 typedef F6a<X extends F6b<X>> = Function(X);
-// [error line 55, column 1, length 44]
+// [error line 55, column 9, length 3]
 // [analyzer] COMPILE_TIME_ERROR.TYPE_ALIAS_CANNOT_REFERENCE_ITSELF
 //      ^^^
 // [cfe] The typedef 'F6a' has a reference to itself.
 
 typedef F6b<X extends F6a<X>> = Function(X);
-// [error line 61, column 1, length 44]
+// [error line 61, column 9, length 3]
 // [analyzer] COMPILE_TIME_ERROR.TYPE_ALIAS_CANNOT_REFERENCE_ITSELF
 //      ^^^
 // [cfe] The typedef 'F6b' has a reference to itself.

--- a/tests/language_2/function/type_alias6_test.dart
+++ b/tests/language_2/function/type_alias6_test.dart
@@ -8,7 +8,7 @@
 import "package:expect/expect.dart";
 
 typedef F(List<F> x);
-// [error line 10, column 1, length 21]
+// [error line 8, column 9, length 1]
 // [analyzer] COMPILE_TIME_ERROR.TYPE_ALIAS_CANNOT_REFERENCE_ITSELF
 //      ^
 // [cfe] The typedef 'F' has a reference to itself.

--- a/tests/language_2/function/type_alias9_test.dart
+++ b/tests/language_2/function/type_alias9_test.dart
@@ -6,12 +6,12 @@
 // @dart = 2.9
 
 typedef void F(List<G> l);
-// [error line 8, column 1, length 26]
+// [error line 6, column 14, length 1]
 // [analyzer] COMPILE_TIME_ERROR.TYPE_ALIAS_CANNOT_REFERENCE_ITSELF
 //           ^
 // [cfe] The typedef 'F' has a reference to itself.
 typedef void G(List<F> l);
-// [error line 13, column 1, length 26]
+// [error line 11, column 14, length 1]
 // [analyzer] COMPILE_TIME_ERROR.TYPE_ALIAS_CANNOT_REFERENCE_ITSELF
 
 main() {

--- a/tests/language_2/regress/regress33479_test.dart
+++ b/tests/language_2/regress/regress33479_test.dart
@@ -7,7 +7,7 @@ class Hest<TypeX extends Fisk> {}
 // [analyzer] COMPILE_TIME_ERROR.NOT_INSTANTIATED_BOUND
 
 typedef Fisk = void Function // don't merge lines
-// [error line 9, column 1, length 346]
+// [error line 7, column 9, length 4]
 // [analyzer] COMPILE_TIME_ERROR.TYPE_ALIAS_CANNOT_REFERENCE_ITSELF
 //      ^
 // [cfe] Generic type 'Fisk' can't be used without type arguments in the bounds of its own type variables. It is referenced indirectly through 'Hest'.


### PR DESCRIPTION
try to fix : https://github.com/dart-lang/sdk/issues/45786