### PR TITLE
fix(docs): corrects common typos in project documentation

### DIFF
--- a/build/README.dart.md
+++ b/build/README.dart.md
@@ -4,4 +4,4 @@ The snapshot was taken with a recursive copy `cp -R` of the directory from
 the flutter repository.
 
 The contents has now diverged significantly from Flutter, and is maintained
-independantly by the Dart team. It is used to support the GN build system.
+independently by the Dart team. It is used to support the GN build system.

--- a/pkg/analysis_server/tool/lsp_spec/lsp_specification.md
+++ b/pkg/analysis_server/tool/lsp_spec/lsp_specification.md
@@ -729,7 +729,7 @@ export interface ChangeAnnotation {
 }
 ```
 
-Usually clients provide options to group the changes along the annotations they are associated with. To support this in the protocol an edit or resource operation refers to a change annotation using an identifier and not the change annotation literal directly. This allows servers to use the identical annotation across multiple edits or resource operations which then allows clients to group the operations under that change annotation. The actual change annotations together with their identifers are managed by the workspace edit via the new property `changeAnnotations`.
+Usually clients provide options to group the changes along the annotations they are associated with. To support this in the protocol an edit or resource operation refers to a change annotation using an identifier and not the change annotation literal directly. This allows servers to use the identical annotation across multiple edits or resource operations which then allows clients to group the operations under that change annotation. The actual change annotations together with their identifiers are managed by the workspace edit via the new property `changeAnnotations`.
 
 ```typescript
 

--- a/pkg/dartdev/doc/dart-fix.md
+++ b/pkg/dartdev/doc/dart-fix.md
@@ -9,7 +9,7 @@ used to batch apply fixes for analysis issues.
 
 `dart fix` runs over your project looking for analysis issues. For each issue it
 checks whether there is an automated fix that can be applied. These fixes are
-generaly either in response to a lint or hint in your code, or part of upgrading
+generally either in response to a lint or hint in your code, or part of upgrading
 your source to newer package APIs.
 
 For the first type of change, the fixes are generally in response to the set of

--- a/pkg/js/proposal.md
+++ b/pkg/js/proposal.md
@@ -283,7 +283,7 @@ JavaScript API may have a name that is not legal in Dart, or its name may have
 different visibility, such as names starting with underscore.
 
 Renames are made possible by taking advantage of the static type of the
-reciever. This is similar to static calls and extension methods.
+receiver. This is similar to static calls and extension methods.
 
 ```dart
 UserInfo user = someExpression;
@@ -789,7 +789,7 @@ main() {
 
 The last check is an example of one consequence of the looser checking. 
 Conceptually we have a `JSAny` type. This type only exists in runtime, and does
-not require a representation, since it results from the absense of type
+not require a representation, since it results from the absence of type
 information. This is discussed later when we look at the type system.
 
 Besides JS Arrays, Dart generic functions and methods can also be called from
@@ -1222,7 +1222,7 @@ the direction we need go. Implementing interfaces can be useful however.
 
 ### JS Proxy
 
-One question that comes up occassionally is how to use JS Proxy from Dart.
+One question that comes up occasionally is how to use JS Proxy from Dart.
 We can expose JSProxy from "package:js":
 
 ```dart

--- a/pkg/kernel/binary.md
+++ b/pkg/kernel/binary.md
@@ -36,7 +36,7 @@ type UInt7 extends UInt {
 
 type UInt14 extends UInt {
   Byte byte1(10xxxxxx); // most significant byte, discard the high bit
-  Byte byte2(xxxxxxxx); // least signficant byte
+  Byte byte2(xxxxxxxx); // least significant byte
 }
 
 type UInt30 extends UInt {

--- a/pkg/scrape/README.md
+++ b/pkg/scrape/README.md
@@ -63,7 +63,7 @@ analysis over some code. It has a few methods you call on it to set up an
 analysis:
 
 *   `addHistogram()` registers a new named histogram. This is the main way you
-    count occurences of datapoints you care about in the code you are analyzing.
+    count occurrences of datapoints you care about in the code you are analyzing.
     Each histogram is a named collection of datapoints. When the analysis
     completes, scrape prints out each histogram, buckets the datapoints, and
     shows how many of each datapoint occurred.

--- a/runtime/docs/gc.md
+++ b/runtime/docs/gc.md
@@ -4,13 +4,13 @@ The Dart VM has a generational garbage collector with two generations. The new g
 
 ## Object representation
 
-Object pointers refer either to immediate objects or heap objects, distinguished by a tag in the low bits of the pointer. The Dart VM has only one kind of immediate object, Smis (small integers), whose pointers have a tag of 0. Heap objects have a pointer tag of 1. The upper bits of a Smi pointer are its value, and the upper bits of a heap object pointer are the most signficant bits of its address (the least significant bit is always 0 because heap objects always have greater than 2-byte alignment).
+Object pointers refer either to immediate objects or heap objects, distinguished by a tag in the low bits of the pointer. The Dart VM has only one kind of immediate object, Smis (small integers), whose pointers have a tag of 0. Heap objects have a pointer tag of 1. The upper bits of a Smi pointer are its value, and the upper bits of a heap object pointer are the most significant bits of its address (the least significant bit is always 0 because heap objects always have greater than 2-byte alignment).
 
 A tag of 0 allows many operations to be performed on Smis without untagging and retagging. It also allows hiding aligned addresses to the C heap from the GC.
 
 A tag of 1 has no penalty on heap object access because removing the tag can be folded into the offset used by load and store instructions.
 
-Heap objects are always allocated in double-word increments. Objects in old-space are kept at double-word alignment (address % double-word == 0), and objects in new-space are kept offset from double-word alignment (address % double-word == word). This allows checking an object's age without comparing to a boundry address, avoiding restrictions on heap placement and avoiding loading the boundry from thread-local storage. Additionally, the scavenger can quickly skip over both immediates and old objects with a single branch.
+Heap objects are always allocated in double-word increments. Objects in old-space are kept at double-word alignment (address % double-word == 0), and objects in new-space are kept offset from double-word alignment (address % double-word == word). This allows checking an object's age without comparing to a boundary address, avoiding restrictions on heap placement and avoiding loading the boundary from thread-local storage. Additionally, the scavenger can quickly skip over both immediates and old objects with a single branch.
 
 | Pointer    | Referent                                |
 | ---        | ---                                     |
@@ -29,7 +29,7 @@ The Dart VM's GC is precise and moving.
 
 A GC is said to be "precise" if when a collection happens it knows exactly what is and is not a pointer into the heap. For example, in compiled Dart code the VM tracks which stack slots contain object pointers and which contain unboxed values. This is opposed to a "conservative" collector that considers any pointer-sized value might be a pointer into the heap, though it might just be an unboxed value.
 
-In a "moving" GC, the address of an object might change, requiring pointers to that object to be updated. In the Dart VM, objects can move during a scavenge or a compaction. A moving GC must be a precise GC: if a conservative GC updates a value that is not guarenteed to be a pointer, it will corrupt execution when the value was not in fact a pointer.
+In a "moving" GC, the address of an object might change, requiring pointers to that object to be updated. In the Dart VM, objects can move during a scavenge or a compaction. A moving GC must be a precise GC: if a conservative GC updates a value that is not guaranteed to be a pointer, it will corrupt execution when the value was not in fact a pointer.
 
 The VM does not know which stack slots, globals or object fields in foreign languages contain pointers into the Dart heap, including the VM's own runtime implemented in C++. For the GC to remain precise, foreign languages reference Dart objects indirectly through "handles". Handles can be thought of as pointers to pointers. They are allocated from the VM, and the GC will visit (and possibly update) the pointers contained in handles during collections.
 
@@ -154,7 +154,7 @@ For old-space objects created after marking started, the marker may see uninitia
 
 New-space objects and roots are only visited during a safepoint, and safepoints establish synchronization.
 
-When the mutator's mark block becomes full, it transfered to the marker by an acquire-release operation, so the marker will see the stores into the block.
+When the mutator's mark block becomes full, it transferred to the marker by an acquire-release operation, so the marker will see the stores into the block.
 
 ## Write barrier elimination
 

--- a/runtime/vm/service/service.md
+++ b/runtime/vm/service/service.md
@@ -3806,7 +3806,7 @@ The _Success_ type is used to indicate that an operation completed successfully.
 
 ```
 class Timeline extends Response {
-  // A list of timeline events. No order is guarenteed for these events; in particular, these events may be unordered with respect to their timestamps.
+  // A list of timeline events. No order is guaranteed for these events; in particular, these events may be unordered with respect to their timestamps.
   TimelineEvent[] traceEvents;
 
   // The start of the period of time in which traceEvents were collected.


### PR DESCRIPTION
Scope of changes is restricted to markdown docs only. Changes made in agreement with Standard American English.