### PR TITLE
[analyzer] Fix null check operator

### DIFF
--- a/pkg/analyzer/lib/src/summary2/linked_element_factory.dart
+++ b/pkg/analyzer/lib/src/summary2/linked_element_factory.dart
@@ -416,7 +416,8 @@ class LinkedElementFactory {
 
   bool isLibraryUri(String uriStr) {
     var libraryContext = libraryReaders[uriStr];
-    return libraryContext?.hasPartOfDirective ?? false;
+    var hasPartOfDirective = libraryContext?.hasPartOfDirective ?? false;
+    return !hasPartOfDirective;
   }
 
   LibraryElementImpl? libraryOfUri(String uriStr) {

--- a/pkg/analyzer/lib/src/summary2/linked_element_factory.dart
+++ b/pkg/analyzer/lib/src/summary2/linked_element_factory.dart
@@ -415,8 +415,8 @@ class LinkedElementFactory {
   }
 
   bool isLibraryUri(String uriStr) {
-    var libraryContext = libraryReaders[uriStr]!;
-    return !libraryContext.hasPartOfDirective;
+    var libraryContext = libraryReaders[uriStr];
+    return libraryContext?.hasPartOfDirective ?? false;
   }
 
   LibraryElementImpl? libraryOfUri(String uriStr) {


### PR DESCRIPTION
This PR fixed the null check operator error.

Reference
https://github.com/mobxjs/mobx.dart/issues/659

Error
```bash
Null check operator used on a null value
#0      LinkedElementFactory.isLibraryUri (package:analyzer/src/summary2/linked_element_factory.dart:418:48)
#1      LibraryContext.isLibraryUri (package:analyzer/src/dart/analysis/library_context.dart:95:27)
#2      LibraryAnalyzer._isLibrarySource (package:analyzer/src/dart/analysis/library_analyzer.dart:511:25)
#3      LibraryAnalyzer._resolveDirectives (package:analyzer/src/dart/analysis/library_analyzer.dart:552:36)
#4      LibraryAnalyzer.analyzeSync (package:analyzer/src/dart/analysis/library_analyzer.dart:128:5)
#5      LibraryAnalyzer.analyze (package:analyzer/src/dart/analysis/library_analyzer.dart:105:12)
#6      AnalysisDriver._computeAnalysisResult.<anonymous closure> (package:analyzer/src/dart/analysis/driver.dart:1590:63)
#7      PerformanceLog.run (package:analyzer/src/dart/analysis/performance_logger.dart:32:15)
#8      AnalysisDriver._computeAnalysisResult (package:analyzer/src/dart/analysis/driver.dart:1565:20)
#9      AnalysisDriver._computeErrors (package:analyzer/src/dart/analysis/driver.dart:1644:26)
#10     AnalysisDriver.performWork (package:analyzer/src/dart/analysis/driver.dart:1266:20)
#11     AnalysisDriverScheduler._run (package:analyzer/src/dart/analysis/driver.dart:2296:24)
<asynchronous suspension>

```