### PR TITLE
Document same-library access for protected members

### DIFF
--- a/pkg/meta/lib/meta.dart
+++ b/pkg/meta/lib/meta.dart
@@ -209,9 +209,9 @@ const _OptionalTypeArgs optionalTypeArgs = _OptionalTypeArgs();
 /// field) `m` in a class `C`. If the annotation is on a field it applies to the
 /// getter, and setter if appropriate, that are induced by the field. Indicates
 /// that `m` should only be invoked from instance methods of `C` or classes that
-/// extend, implement or mix in `C`, either directly or indirectly. Additionally
-/// indicates that `m` should only be invoked on `this`, whether explicitly or
-/// implicitly.
+/// extend, implement or mix in `C`, either directly or indirectly or from within
+/// the same library that `m` is declared in. Additionally indicates that `m`
+/// should only be invoked on `this`, whether explicitly or implicitly.
 ///
 /// Tools, such as the analyzer, can provide feedback if
 ///

--- a/pkg/meta/lib/meta.dart
+++ b/pkg/meta/lib/meta.dart
@@ -211,7 +211,8 @@ const _OptionalTypeArgs optionalTypeArgs = _OptionalTypeArgs();
 /// that `m` should only be invoked from instance methods of `C` or classes that
 /// extend, implement or mix in `C`, either directly or indirectly or from within
 /// the same library that `m` is declared in. Additionally indicates that `m`
-/// should only be invoked on `this`, whether explicitly or implicitly.
+/// should only be invoked on `this` from outside of the library that it is
+/// declared in, whether explicitly or implicitly.
 ///
 /// Tools, such as the analyzer, can provide feedback if
 ///

--- a/pkg/meta/lib/meta.dart
+++ b/pkg/meta/lib/meta.dart
@@ -211,8 +211,8 @@ const _OptionalTypeArgs optionalTypeArgs = _OptionalTypeArgs();
 /// that `m` should only be invoked from instance methods of `C` or classes that
 /// extend, implement or mix in `C`, either directly or indirectly or from within
 /// the same library that `m` is declared in. Additionally indicates that `m`
-/// should only be invoked on `this` from outside of the library that it is
-/// declared in, whether explicitly or implicitly.
+/// should only be invoked on `this` (when outside of the library that it is
+/// declared in), whether explicitly or implicitly.
 ///
 /// Tools, such as the analyzer, can provide feedback if
 ///


### PR DESCRIPTION
I noticed that in the Flutter framework, `@protected` members are called from outside of instance methods. @Hixie responded:

> protected allows access from the same file

I think this should be documented.