### PR TITLE
[io/http] Add a HTTP Client parameter on WebSocket.connect to allow a custom HTTP Client for web socket connections.

### DIFF
--- a/sdk/lib/_http/websocket.dart
+++ b/sdk/lib/_http/websocket.dart
@@ -375,8 +375,9 @@ abstract class WebSocket
           {Iterable<String>? protocols,
           Map<String, dynamic>? headers,
           CompressionOptions compression =
-              CompressionOptions.compressionDefault}) =>
-      _WebSocketImpl.connect(url, protocols, headers, compression: compression);
+              CompressionOptions.compressionDefault,
+      HttpClient? customClient}) =>
+      _WebSocketImpl.connect(url, protocols, headers, compression: compression, customClient: customClient;
 
   @Deprecated('This constructor will be removed in Dart 2.0. Use `implements`'
       ' instead of `extends` if implementing this abstract class.')

--- a/sdk/lib/_http/websocket.dart
+++ b/sdk/lib/_http/websocket.dart
@@ -376,8 +376,9 @@ abstract class WebSocket
           Map<String, dynamic>? headers,
           CompressionOptions compression =
               CompressionOptions.compressionDefault,
-      HttpClient? customClient}) =>
-      _WebSocketImpl.connect(url, protocols, headers, compression: compression, customClient: customClient;
+          HttpClient? customClient}) =>
+      _WebSocketImpl.connect(url, protocols, headers,
+          compression: compression, customClient: customClient);
 
   @Deprecated('This constructor will be removed in Dart 2.0. Use `implements`'
       ' instead of `extends` if implementing this abstract class.')

--- a/sdk/lib/_http/websocket_impl.dart
+++ b/sdk/lib/_http/websocket_impl.dart
@@ -995,15 +995,15 @@ class _WebSocketImpl extends Stream with _ServiceObject implements WebSocket {
   Timer? _closeTimer;
   _WebSocketPerMessageDeflate? _deflate;
 
-  static final HttpClient _httpClient = new HttpClient();
+  static HttpClient _httpClient = new HttpClient();
 
   static Future<WebSocket> connect(
       String url, Iterable<String>? protocols, Map<String, dynamic>? headers,
-      {CompressionOptions compression =
-          CompressionOptions.compressionDefault}) {
-    Uri uri = Uri.parse(url);
-    if (uri.scheme != "ws" && uri.scheme != "wss") {
-      throw new WebSocketException("Unsupported URL scheme '${uri.scheme}'");
+      {CompressionOptions compression = CompressionOptions.compressionDefault,
+      HttpClient customClient}) {
+    //overriding _httpClient if user specifies a custom http client.
+    if (customClient != null) {
+      _httpClient = customClient..userAgent ??= _httpClient.userAgent;
     }
 
     Random random = new Random();

--- a/sdk/lib/_http/websocket_impl.dart
+++ b/sdk/lib/_http/websocket_impl.dart
@@ -1022,8 +1022,6 @@ class _WebSocketImpl extends Stream with _ServiceObject implements WebSocket {
         path: uri.path,
         query: uri.query,
         fragment: uri.fragment);
-        // Use Custom HTTP Client first is it exists, else
-        // default to static client
     return (customClient ?? _httpClient).openUrl("GET", uri).then((request) {
       if (uri.userInfo != null && !uri.userInfo.isEmpty) {
         // If the URL contains user information use that for basic

--- a/sdk/lib/_http/websocket_impl.dart
+++ b/sdk/lib/_http/websocket_impl.dart
@@ -1005,6 +1005,10 @@ class _WebSocketImpl extends Stream with _ServiceObject implements WebSocket {
     if (customClient != null) {
       _httpClient = customClient..userAgent ??= _httpClient.userAgent;
     }
+    Uri uri = Uri.parse(url);
+    if (uri.scheme != "ws" && uri.scheme != "wss") {
+      throw new WebSocketException("Unsupported URL scheme '${uri.scheme}'");
+    }
 
     Random random = new Random();
     // Generate 16 random bytes.

--- a/tests/standalone/io/web_socket_error_test.dart
+++ b/tests/standalone/io/web_socket_error_test.dart
@@ -48,9 +48,9 @@ class SecurityConfiguration {
       : HttpServer.bind(HOST_NAME, 0, backlog: backlog);
 
   Future<WebSocket> createClient(int port) => secure
-      ? WebSocket.connect('${secure ? "wss" : "ws"}://$HOST_NAME:$port/')
-      : WebSocket.connect('${secure ? "wss" : "ws"}://$HOST_NAME:$port/',
-          customClient: HttpClient(context: clientContext));
+      ? WebSocket.connect('${secure ? "wss" : "ws"}://$HOST_NAME:$port/',
+          customClient: HttpClient(context: clientContext))
+      : WebSocket.connect('${secure ? "wss" : "ws"}://$HOST_NAME:$port/');
 
   void testForceCloseServerEnd(int totalConnections) {
     createServer().then((server) {

--- a/tests/standalone/io/web_socket_error_test.dart
+++ b/tests/standalone/io/web_socket_error_test.dart
@@ -47,9 +47,10 @@ class SecurityConfiguration {
       ? HttpServer.bindSecure(HOST_NAME, 0, serverContext, backlog: backlog)
       : HttpServer.bind(HOST_NAME, 0, backlog: backlog);
 
-  Future<WebSocket> createClient(int port) =>
-      // TODO(whesse): Add a client context argument to WebSocket.connect.
-      WebSocket.connect('${secure ? "wss" : "ws"}://$HOST_NAME:$port/');
+  Future<WebSocket> createClient(int port) => secure
+      ? WebSocket.connect('${secure ? "wss" : "ws"}://$HOST_NAME:$port/')
+      : WebSocket.connect('${secure ? "wss" : "ws"}://$HOST_NAME:$port/',
+          customClient: HttpClient(context: clientContext));
 
   void testForceCloseServerEnd(int totalConnections) {
     createServer().then((server) {
@@ -94,7 +95,6 @@ class SecurityConfiguration {
 main() {
   asyncStart();
   new SecurityConfiguration(secure: false).runTests();
-  // TODO(whesse): WebSocket.connect needs an optional context: parameter
-  // new SecurityConfiguration(secure: true).runTests();
+  new SecurityConfiguration(secure: true).runTests();
   asyncEnd();
 }

--- a/tests/standalone/io/web_socket_error_test.dart
+++ b/tests/standalone/io/web_socket_error_test.dart
@@ -47,10 +47,9 @@ class SecurityConfiguration {
       ? HttpServer.bindSecure(HOST_NAME, 0, serverContext, backlog: backlog)
       : HttpServer.bind(HOST_NAME, 0, backlog: backlog);
 
-  Future<WebSocket> createClient(int port) => secure
-      ? WebSocket.connect('${secure ? "wss" : "ws"}://$HOST_NAME:$port/',
-          customClient: HttpClient(context: clientContext))
-      : WebSocket.connect('${secure ? "wss" : "ws"}://$HOST_NAME:$port/');
+  Future<WebSocket> createClient(int port) =>
+      WebSocket.connect('${secure ? "wss" : "ws"}://$HOST_NAME:$port/',
+          customClient: secure ? HttpClient(context: clientContext) : null);
 
   void testForceCloseServerEnd(int totalConnections) {
     createServer().then((server) {

--- a/tests/standalone/io/web_socket_test.dart
+++ b/tests/standalone/io/web_socket_test.dart
@@ -43,7 +43,9 @@ class SecurityConfiguration {
       : HttpServer.bind(HOST_NAME, 0, backlog: backlog);
 
   Future<WebSocket> createClient(int port,
-          {String? user, Map<String, Object>? headers, String? customUserAgent}) =>
+          {String? user,
+          Map<String, Object>? headers,
+          String? customUserAgent}) =>
       WebSocket.connect(
           '${secure ? "wss" : "ws"}://${user is Null ? "" : "$user@"}$HOST_NAME:$port/',
           headers: headers,

--- a/tests/standalone/io/web_socket_test.dart
+++ b/tests/standalone/io/web_socket_test.dart
@@ -13,10 +13,8 @@ import "dart:io";
 import "dart:typed_data";
 
 import "package:async_helper/async_helper.dart";
-import "package:convert/convert.dart";
 import "package:crypto/crypto.dart";
 import "package:expect/expect.dart";
-import "package:path/path.dart";
 
 const WEB_SOCKET_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
 
@@ -45,7 +43,7 @@ class SecurityConfiguration {
       : HttpServer.bind(HOST_NAME, 0, backlog: backlog);
 
   Future<WebSocket> createClient(int port,
-          {String user, Map<String, Object> headers, String customUserAgent}) =>
+          {String? user, Map<String, Object>? headers, String? customUserAgent}) =>
       WebSocket.connect(
           '${secure ? "wss" : "ws"}://${user is Null ? "" : "$user@"}$HOST_NAME:$port/',
           headers: headers,
@@ -492,7 +490,7 @@ class SecurityConfiguration {
         'My-Header': 'my-value',
         'My-Header-Multiple': ['my-value-1', 'my-value-2']
       };
-      createClient(server.port).then((websocket) {
+      createClient(server.port, headers: headers).then((websocket) {
         return websocket.listen((message) {
           Expect.equals("Hello", message);
           websocket.close();
@@ -525,7 +523,7 @@ class SecurityConfiguration {
         });
       });
 
-      createClient(server.port).then((websocket) {
+      createClient(server.port, user: userInfo).then((websocket) {
         return websocket.listen((message) {
           Expect.equals("Hello", message);
           websocket.close();

--- a/tests/standalone/io/web_socket_test.dart
+++ b/tests/standalone/io/web_socket_test.dart
@@ -44,11 +44,11 @@ class SecurityConfiguration {
       ? HttpServer.bindSecure(HOST_NAME, 0, serverContext, backlog: backlog)
       : HttpServer.bind(HOST_NAME, 0, backlog: backlog);
 
-  Future<WebSocket> createClient(int port, {HttpClient? customClient}) => secure
-      ? WebSocket.connect('${secure ? "wss" : "ws"}://$HOST_NAME:$port/',
-          customClient: customClient ?? HttpClient(context: clientContext))
-      : WebSocket.connect('${secure ? "wss" : "ws"}://$HOST_NAME:$port/',
-          customClient: customClient);
+  Future<WebSocket> createClient(int port, {HttpClient? customClient}) =>
+      WebSocket.connect('${secure ? "wss" : "ws"}://$HOST_NAME:$port/',
+          customClient: customClient ?? secure
+              ? HttpClient(context: clientContext)
+              : null);
 
   checkCloseStatus(webSocket, closeStatus, closeReason) {
     Expect.equals(

--- a/tests/standalone/io/web_socket_test.dart
+++ b/tests/standalone/io/web_socket_test.dart
@@ -44,9 +44,10 @@ class SecurityConfiguration {
       ? HttpServer.bindSecure(HOST_NAME, 0, serverContext, backlog: backlog)
       : HttpServer.bind(HOST_NAME, 0, backlog: backlog);
 
-  Future<WebSocket> createClient(int port, {HttpClient? customClient}) =>
-      // TODO(whesse): Add client context argument to WebSocket.connect
-      WebSocket.connect('${secure ? "wss" : "ws"}://$HOST_NAME:$port/',
+  Future<WebSocket> createClient(int port, {HttpClient? customClient}) => secure
+      ? WebSocket.connect('${secure ? "wss" : "ws"}://$HOST_NAME:$port/',
+          customClient: customClient ?? HttpClient(context: clientContext))
+      : WebSocket.connect('${secure ? "wss" : "ws"}://$HOST_NAME:$port/',
           customClient: customClient);
 
   checkCloseStatus(webSocket, closeStatus, closeReason) {
@@ -564,7 +565,8 @@ class SecurityConfiguration {
         webSocket.close();
         asyncEnd();
       });
-      var client = HttpClient()..userAgent = 'New User Agent';
+      var client = HttpClient(context: secure ? clientContext : null)
+        ..userAgent = 'New User Agent';
       WebSocket.userAgent = 'Default User Agent';
       createClient(server.port, customClient: client).then((webSocket) {
         webSocket.close();
@@ -606,6 +608,5 @@ class SecurityConfiguration {
 
 main() {
   new SecurityConfiguration(secure: false).runTests();
-  // TODO(whesse): Make WebSocket.connect() take an optional context: parameter.
-  // new SecurityConfiguration(secure: true).runTests();
+  new SecurityConfiguration(secure: true).runTests();
 }

--- a/tests/standalone/io/web_socket_test.dart
+++ b/tests/standalone/io/web_socket_test.dart
@@ -560,12 +560,12 @@ class SecurityConfiguration {
     asyncStart();
     createServer().then((server) {
       server.transform(new WebSocketTransformer()).listen((webSocket) {
-        Expect.equals('Default User Agent', WebSocket.userAgent);
+        Expect.equals('Custom User Agent', WebSocket.userAgent);
         server.close();
         webSocket.close();
         asyncEnd();
       });
-      WebSocket.userAgent = 'Default User Agent';
+      WebSocket.userAgent = 'Custom User Agent';
       createClient(server.port, customUserAgent: 'New User Agent').then((webSocket) {
         webSocket.close();
       });

--- a/tests/standalone/io/web_socket_test.dart
+++ b/tests/standalone/io/web_socket_test.dart
@@ -44,10 +44,10 @@ class SecurityConfiguration {
       ? HttpServer.bindSecure(HOST_NAME, 0, serverContext, backlog: backlog)
       : HttpServer.bind(HOST_NAME, 0, backlog: backlog);
 
-  Future<WebSocket> createClient(int port, {HttpClient? customClient}) =>
+  Future<WebSocket> createClient(int port, {String? customUserAgent}) =>
       WebSocket.connect('${secure ? "wss" : "ws"}://$HOST_NAME:$port/',
-          customClient: customClient ?? secure
-              ? HttpClient(context: clientContext)
+          customClient: secure
+              ? (HttpClient(context: clientContext)..userAgent = customUserAgent)
               : null);
 
   checkCloseStatus(webSocket, closeStatus, closeReason) {
@@ -565,10 +565,8 @@ class SecurityConfiguration {
         webSocket.close();
         asyncEnd();
       });
-      var client = HttpClient(context: secure ? clientContext : null)
-        ..userAgent = 'New User Agent';
       WebSocket.userAgent = 'Default User Agent';
-      createClient(server.port, customClient: client).then((webSocket) {
+      createClient(server.port, customUserAgent: 'New User Agent').then((webSocket) {
         webSocket.close();
       });
     });

--- a/tests/standalone_2/io/web_socket_test.dart
+++ b/tests/standalone_2/io/web_socket_test.dart
@@ -46,9 +46,10 @@ class SecurityConfiguration {
       ? HttpServer.bindSecure(HOST_NAME, 0, serverContext, backlog: backlog)
       : HttpServer.bind(HOST_NAME, 0, backlog: backlog);
 
-  Future<WebSocket> createClient(int port, {HttpClient customClient}) =>
-      // TODO(whesse): Add client context argument to WebSocket.connect
-      WebSocket.connect('${secure ? "wss" : "ws"}://$HOST_NAME:$port/',
+  Future<WebSocket> createClient(int port, {HttpClient customClient}) => secure
+      ? WebSocket.connect('${secure ? "wss" : "ws"}://$HOST_NAME:$port/',
+          customClient: customClient ?? HttpClient(context: clientContext))
+      : WebSocket.connect('${secure ? "wss" : "ws"}://$HOST_NAME:$port/',
           customClient: customClient);
 
   checkCloseStatus(webSocket, closeStatus, closeReason) {
@@ -566,7 +567,8 @@ class SecurityConfiguration {
         webSocket.close();
         asyncEnd();
       });
-      var client = HttpClient()..userAgent = 'New User Agent';
+      var client = HttpClient(context: secure ? clientContext : null)
+        ..userAgent = 'New User Agent';
       WebSocket.userAgent = 'Default User Agent';
       createClient(server.port, customClient: client).then((webSocket) {
         webSocket.close();
@@ -608,6 +610,5 @@ class SecurityConfiguration {
 
 main() {
   new SecurityConfiguration(secure: false).runTests();
-  // TODO(whesse): Make WebSocket.connect() take an optional context: parameter.
-  // new SecurityConfiguration(secure: true).runTests();
+  new SecurityConfiguration(secure: true).runTests();
 }

--- a/tests/standalone_2/io/web_socket_test.dart
+++ b/tests/standalone_2/io/web_socket_test.dart
@@ -15,10 +15,8 @@ import "dart:io";
 import "dart:typed_data";
 
 import "package:async_helper/async_helper.dart";
-import "package:convert/convert.dart";
 import "package:crypto/crypto.dart";
 import "package:expect/expect.dart";
-import "package:path/path.dart";
 
 const WEB_SOCKET_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
 

--- a/tests/standalone_2/io/web_socket_test.dart
+++ b/tests/standalone_2/io/web_socket_test.dart
@@ -46,11 +46,11 @@ class SecurityConfiguration {
       ? HttpServer.bindSecure(HOST_NAME, 0, serverContext, backlog: backlog)
       : HttpServer.bind(HOST_NAME, 0, backlog: backlog);
 
-  Future<WebSocket> createClient(int port, {HttpClient customClient}) => secure
-      ? WebSocket.connect('${secure ? "wss" : "ws"}://$HOST_NAME:$port/',
-          customClient: customClient ?? HttpClient(context: clientContext))
-      : WebSocket.connect('${secure ? "wss" : "ws"}://$HOST_NAME:$port/',
-          customClient: customClient);
+  Future<WebSocket> createClient(int port, {HttpClient customClient}) =>
+      WebSocket.connect('${secure ? "wss" : "ws"}://$HOST_NAME:$port/',
+          customClient: customClient ?? secure
+              ? HttpClient(context: clientContext)
+              : null);
 
   checkCloseStatus(webSocket, closeStatus, closeReason) {
     Expect.equals(

--- a/tests/standalone_2/io/web_socket_test.dart
+++ b/tests/standalone_2/io/web_socket_test.dart
@@ -46,10 +46,10 @@ class SecurityConfiguration {
       ? HttpServer.bindSecure(HOST_NAME, 0, serverContext, backlog: backlog)
       : HttpServer.bind(HOST_NAME, 0, backlog: backlog);
 
-  Future<WebSocket> createClient(int port, {HttpClient customClient}) =>
+  Future<WebSocket> createClient(int port, {String customUserAgent}) =>
       WebSocket.connect('${secure ? "wss" : "ws"}://$HOST_NAME:$port/',
-          customClient: customClient ?? secure
-              ? HttpClient(context: clientContext)
+          customClient: secure
+              ? (HttpClient(context: clientContext)..userAgent = customUserAgent)
               : null);
 
   checkCloseStatus(webSocket, closeStatus, closeReason) {
@@ -567,10 +567,8 @@ class SecurityConfiguration {
         webSocket.close();
         asyncEnd();
       });
-      var client = HttpClient(context: secure ? clientContext : null)
-        ..userAgent = 'New User Agent';
       WebSocket.userAgent = 'Default User Agent';
-      createClient(server.port, customClient: client).then((webSocket) {
+      createClient(server.port, customUserAgent: 'New User Agent').then((webSocket) {
         webSocket.close();
       });
     });

--- a/tests/standalone_2/io/web_socket_test.dart
+++ b/tests/standalone_2/io/web_socket_test.dart
@@ -46,10 +46,14 @@ class SecurityConfiguration {
       ? HttpServer.bindSecure(HOST_NAME, 0, serverContext, backlog: backlog)
       : HttpServer.bind(HOST_NAME, 0, backlog: backlog);
 
-  Future<WebSocket> createClient(int port, {String customUserAgent}) =>
-      WebSocket.connect('${secure ? "wss" : "ws"}://$HOST_NAME:$port/',
+  Future<WebSocket> createClient(int port,
+          {String user, Map<String, Object> headers, String customUserAgent}) =>
+      WebSocket.connect(
+          '${secure ? "wss" : "ws"}://${user is Null ? "" : "$user@"}$HOST_NAME:$port/',
+          headers: headers,
           customClient: secure
-              ? (HttpClient(context: clientContext)..userAgent = customUserAgent)
+              ? (HttpClient(context: clientContext)
+                ..userAgent = customUserAgent)
               : null);
 
   checkCloseStatus(webSocket, closeStatus, closeReason) {
@@ -308,7 +312,7 @@ class SecurityConfiguration {
         asyncEnd();
       });
 
-      HttpClient client = new HttpClient();
+      final client = HttpClient(context: secure ? clientContext : null);
       client
           .postUrl(Uri.parse(
               "${secure ? 'https:' : 'http:'}//$HOST_NAME:${server.port}/"))
@@ -405,12 +409,12 @@ class SecurityConfiguration {
       var baseWsUrl = '$wsProtocol://$HOST_NAME:${server.port}/';
       var httpProtocol = '${secure ? "https" : "http"}';
       var baseHttpUrl = '$httpProtocol://$HOST_NAME:${server.port}/';
-      HttpClient client = new HttpClient();
+      final client = HttpClient(context: secure ? clientContext : null);
 
       for (int i = 0; i < connections; i++) {
         var completer = new Completer();
         futures.add(completer.future);
-        WebSocket.connect('${baseWsUrl}').then((websocket) {
+        createClient(server.port).then((websocket) {
           websocket.listen((_) {
             websocket.close();
           }, onDone: completer.complete);
@@ -460,9 +464,7 @@ class SecurityConfiguration {
         });
       });
 
-      var url = '${secure ? "wss" : "ws"}://$HOST_NAME:${server.port}/';
-
-      WebSocket.connect(url).then((websocket) {
+      createClient(server.port).then((websocket) {
         return websocket.listen((message) {
           Expect.equals("Hello", message);
           websocket.close();
@@ -488,12 +490,11 @@ class SecurityConfiguration {
         });
       });
 
-      var url = '${secure ? "wss" : "ws"}://$HOST_NAME:${server.port}/';
       var headers = {
         'My-Header': 'my-value',
         'My-Header-Multiple': ['my-value-1', 'my-value-2']
       };
-      WebSocket.connect(url, headers: headers).then((websocket) {
+      createClient(server.port, headers: headers).then((websocket) {
         return websocket.listen((message) {
           Expect.equals("Hello", message);
           websocket.close();
@@ -526,9 +527,7 @@ class SecurityConfiguration {
         });
       });
 
-      var url =
-          '${secure ? "wss" : "ws"}://$userInfo@$HOST_NAME:${server.port}/';
-      WebSocket.connect(url).then((websocket) {
+      createClient(server.port, user: userInfo).then((websocket) {
         return websocket.listen((message) {
           Expect.equals("Hello", message);
           websocket.close();
@@ -567,8 +566,10 @@ class SecurityConfiguration {
         webSocket.close();
         asyncEnd();
       });
+      // Next line should take no effect on custom user agent value provided
       WebSocket.userAgent = 'Custom User Agent';
-      createClient(server.port, customUserAgent: 'New User Agent').then((webSocket) {
+      createClient(server.port, customUserAgent: 'New User Agent')
+          .then((webSocket) {
         webSocket.close();
       });
     });

--- a/tests/standalone_2/io/web_socket_test.dart
+++ b/tests/standalone_2/io/web_socket_test.dart
@@ -46,9 +46,10 @@ class SecurityConfiguration {
       ? HttpServer.bindSecure(HOST_NAME, 0, serverContext, backlog: backlog)
       : HttpServer.bind(HOST_NAME, 0, backlog: backlog);
 
-  Future<WebSocket> createClient(int port) =>
+  Future<WebSocket> createClient(int port, {HttpClient customClient}) =>
       // TODO(whesse): Add client context argument to WebSocket.connect
-      WebSocket.connect('${secure ? "wss" : "ws"}://$HOST_NAME:$port/');
+      WebSocket.connect('${secure ? "wss" : "ws"}://$HOST_NAME:$port/',
+          customClient: customClient);
 
   checkCloseStatus(webSocket, closeStatus, closeReason) {
     Expect.equals(
@@ -556,6 +557,23 @@ class SecurityConfiguration {
     });
   }
 
+  void testStaticClientUserAgentStaysTheSame() {
+    asyncStart();
+    createServer().then((server) {
+      server.transform(new WebSocketTransformer()).listen((webSocket) {
+        Expect.equals('Default User Agent', WebSocket.userAgent);
+        server.close();
+        webSocket.close();
+        asyncEnd();
+      });
+      var client = HttpClient()..userAgent = 'New User Agent';
+      WebSocket.userAgent = 'Default User Agent';
+      createClient(server.port, customClient: client).then((webSocket) {
+        webSocket.close();
+      });
+    });
+  }
+
   void runTests() {
     testRequestResponseClientCloses(2, null, null, 1);
     testRequestResponseClientCloses(2, 3001, null, 2);
@@ -584,6 +602,7 @@ class SecurityConfiguration {
     testAdditionalHeaders();
     testBasicAuthentication();
     testShouldSetUserAgent();
+    testStaticClientUserAgentStaysTheSame();
   }
 }
 

--- a/tests/standalone_2/io/web_socket_test.dart
+++ b/tests/standalone_2/io/web_socket_test.dart
@@ -562,12 +562,12 @@ class SecurityConfiguration {
     asyncStart();
     createServer().then((server) {
       server.transform(new WebSocketTransformer()).listen((webSocket) {
-        Expect.equals('Default User Agent', WebSocket.userAgent);
+        Expect.equals('Custom User Agent', WebSocket.userAgent);
         server.close();
         webSocket.close();
         asyncEnd();
       });
-      WebSocket.userAgent = 'Default User Agent';
+      WebSocket.userAgent = 'Custom User Agent';
       createClient(server.port, customUserAgent: 'New User Agent').then((webSocket) {
         webSocket.close();
       });


### PR DESCRIPTION
The WebSocket abstract class was changed to allow an optional parameter called customClient that takes in a HTTPClient and passes it to the WebSocket Implementation.
The WebSocket implementation takes the customClient, checks if its null, if its not null, it uses the customClient in place of the static HTTPClient that the WebSocket Implementation offers.
This custom client does not override the static HTTPClient, so all previous functionality remains the same when the customClient is not present.

TEST=testStaticClientUserAgentStaysTheSame() in web_socket_test.dart in standalone_2/standalone
TEST=new SecurityConfiguration(secure: true).runTests(); in web_socket_error_test.dart and web_socket_test.dart in standalone_2/standalone

Bug: https://github.com/dart-lang/sdk/issues/34284