### PR TITLE
expose onUploadProgress on HttpRequest dart:html

### DIFF
--- a/sdk/lib/html/dart2js/html_dart2js.dart
+++ b/sdk/lib/html/dart2js/html_dart2js.dart
@@ -18134,14 +18134,17 @@ class HttpRequest extends HttpRequestEventTarget {
    *
    * See also: [authorization headers](http://en.wikipedia.org/wiki/Basic_access_authentication).
    */
-  static Future<HttpRequest> request(String url,
-      {String? method,
-      bool? withCredentials,
-      String? responseType,
-      String? mimeType,
-      Map<String, String>? requestHeaders,
-      sendData,
-      void onProgress(ProgressEvent e)?}) {
+  static Future<HttpRequest> request(
+    String url, {
+    String? method,
+    bool? withCredentials,
+    String? responseType,
+    String? mimeType,
+    Map<String, String>? requestHeaders,
+    sendData,
+    void onProgress(ProgressEvent e)?,
+    void onUploadProgress(ProgressEvent e)?,
+  }) {
     var completer = new Completer<HttpRequest>();
 
     var xhr = new HttpRequest();
@@ -18170,6 +18173,10 @@ class HttpRequest extends HttpRequestEventTarget {
 
     if (onProgress != null) {
       xhr.onProgress.listen(onProgress);
+    }
+
+    if (onUploadProgress != null) {
+      xhr.upload.onProgress.listen(onUploadProgress);
     }
 
     xhr.onLoad.listen((e) {

--- a/tests/lib/html/xhr_test.dart
+++ b/tests/lib/html/xhr_test.dart
@@ -99,6 +99,16 @@ Future testRequestOnProgress() async {
   validate200Response(xhr);
 }
 
+Future testRequestOnUploadProgress() async {
+  var progressCalled = false;
+  var xhr = await HttpRequest.request(url, onUploadProgress: (_) {
+    progressCalled = true;
+  });
+  expect(xhr.readyState, HttpRequest.DONE);
+  expect(progressCalled, HttpRequest.supportsProgressEvent);
+  validate200Response(xhr);
+}
+
 Future testRequestWithCredentialsNoFile() async {
   try {
     await HttpRequest.request('NonExistingFile', withCredentials: true);

--- a/tests/lib_2/html/xhr_test.dart
+++ b/tests/lib_2/html/xhr_test.dart
@@ -101,6 +101,16 @@ Future testRequestOnProgress() async {
   validate200Response(xhr);
 }
 
+Future testRequestOnUploadProgress() async {
+  var progressCalled = false;
+  var xhr = await HttpRequest.request(url, onUploadProgress: (_) {
+    progressCalled = true;
+  });
+  expect(xhr.readyState, HttpRequest.DONE);
+  expect(progressCalled, HttpRequest.supportsProgressEvent);
+  validate200Response(xhr);
+}
+
 Future testRequestWithCredentialsNoFile() async {
   try {
     await HttpRequest.request('NonExistingFile', withCredentials: true);


### PR DESCRIPTION
Context:
I am using HttpRequest in `dart:html` to upload file. 
All is ok when I use HttpRequest with `onProgress` on Flutter `2.0.5` but when I upgraded Flutter `2.2.0`, the `onProgress` is not called then I read the document and know the way use [xhr.upload.onprogress](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/upload) to get the upload progress and it works.