### PR TITLE
Improve `String.substring` documentation

### DIFF
--- a/sdk/lib/core/string.dart
+++ b/sdk/lib/core/string.dart
@@ -315,8 +315,8 @@ abstract class String implements Comparable<String>, Pattern {
   /// string.substring(1, 4); // 'art'
   /// ```
   ///
-  /// Both [start] and [end] must not be negative or greater than [length], and
-  /// [end], if provided, must be greater or equal to [start].
+  /// Both [start] and [end] must be non-negative and no greater than [length], and
+  /// [end], if provided, must be greater than or equal to [start].
   String substring(int start, [int? end]);
 
   /// The string without any leading and trailing whitespace.

--- a/sdk/lib/core/string.dart
+++ b/sdk/lib/core/string.dart
@@ -314,6 +314,9 @@ abstract class String implements Comparable<String>, Pattern {
   /// string.substring(1);    // 'artlang'
   /// string.substring(1, 4); // 'art'
   /// ```
+  ///
+  /// Both [start] and [end] must not be negative or greater than [length], and
+  /// [end], if provided, must be greater or equal to [start].
   String substring(int start, [int? end]);
 
   /// The string without any leading and trailing whitespace.


### PR DESCRIPTION
This PR provides additional info on the `substring` method, as it will throw a `RangeError` in the following cases:

* `start` is negative;
* `end` is negative;
* `start` is greater than `length`;
* `end` is greater than `length`;
* `start` is greater than `end`.

Although some of them are a little obvious, it's better to be explicit about the expectations. One could expect that, for example, that `'abc'.substring(0, 4)` would return `'abc'` instead of throwing.