### PR TITLE
Upgrade fromEnvironment() docs to make clearer that constructor is only guaranteed to work when called as const

### DIFF
--- a/sdk/lib/core/bool.dart
+++ b/sdk/lib/core/bool.dart
@@ -19,8 +19,6 @@ class bool {
   /// In all other cases, including when there is no declaration for `name`,
   /// the result is the [defaultValue].
   ///
-  /// The value must be assigned to a constant.
-  ///
   /// The result is the same as would be returned by:
   /// ```dart
   /// (const String.fromEnvironment(name) == "true")
@@ -43,6 +41,8 @@ class bool {
   /// must be consistent across all calls to [String.fromEnvironment],
   /// [int.fromEnvironment], `bool.fromEnvironment` and [bool.hasEnvironment]
   /// in a single program.
+  /// 
+  /// The bool.fromEnvironment() constructor must be constant.
   // The .fromEnvironment() constructors are special in that we do not want
   // users to call them using "new". We prohibit that by giving them bodies
   // that throw, even though const constructors are not allowed to have bodies.

--- a/sdk/lib/core/bool.dart
+++ b/sdk/lib/core/bool.dart
@@ -41,8 +41,10 @@ class bool {
   /// must be consistent across all calls to [String.fromEnvironment],
   /// [int.fromEnvironment], `bool.fromEnvironment` and [bool.hasEnvironment]
   /// in a single program.
-  /// 
-  /// The bool.fromEnvironment() constructor must be constant.
+  ///
+  /// The `bool.fromEnvironment` constructor is only guaranteed to work when
+  /// called as  const, but may work with `new` on some specific platforms,
+  /// mainly non-AoT-compiled ones.
   // The .fromEnvironment() constructors are special in that we do not want
   // users to call them using "new". We prohibit that by giving them bodies
   // that throw, even though const constructors are not allowed to have bodies.

--- a/sdk/lib/core/bool.dart
+++ b/sdk/lib/core/bool.dart
@@ -19,6 +19,8 @@ class bool {
   /// In all other cases, including when there is no declaration for `name`,
   /// the result is the [defaultValue].
   ///
+  /// The value must be assigned to a constant.
+  ///
   /// The result is the same as would be returned by:
   /// ```dart
   /// (const String.fromEnvironment(name) == "true")

--- a/sdk/lib/core/int.dart
+++ b/sdk/lib/core/int.dart
@@ -38,7 +38,9 @@ abstract class int extends num {
   /// `int.fromEnvironment`, [bool.fromEnvironment] and [bool.hasEnvironment]
   /// in a single program.
   /// 
-  /// The int.fromEnvironment() constructor must be constant.
+  /// The `int.fromEnvironment` constructor is only guaranteed to work when
+  /// called as  const, but may work with `new` on some specific platforms,
+  /// mainly non-AoT-compiled ones.
   // The .fromEnvironment() constructors are special in that we do not want
   // users to call them using "new". We prohibit that by giving them bodies
   // that throw, even though const constructors are not allowed to have bodies.

--- a/sdk/lib/core/int.dart
+++ b/sdk/lib/core/int.dart
@@ -23,8 +23,6 @@ part of dart.core;
 abstract class int extends num {
   /// Returns the integer value of the given environment declaration [name].
   ///
-  /// The value must be assigned to a constant.
-  ///
   /// The result is the same as would be returned by:
   /// ```dart
   /// int.tryParse(const String.fromEnvironment(name, defaultValue: ""))
@@ -39,6 +37,8 @@ abstract class int extends num {
   /// must be consistent across all calls to [String.fromEnvironment],
   /// `int.fromEnvironment`, [bool.fromEnvironment] and [bool.hasEnvironment]
   /// in a single program.
+  /// 
+  /// The int.fromEnvironment() constructor must be constant.
   // The .fromEnvironment() constructors are special in that we do not want
   // users to call them using "new". We prohibit that by giving them bodies
   // that throw, even though const constructors are not allowed to have bodies.

--- a/sdk/lib/core/int.dart
+++ b/sdk/lib/core/int.dart
@@ -23,6 +23,8 @@ part of dart.core;
 abstract class int extends num {
   /// Returns the integer value of the given environment declaration [name].
   ///
+  /// The value must be assigned to a constant.
+  ///
   /// The result is the same as would be returned by:
   /// ```dart
   /// int.tryParse(const String.fromEnvironment(name, defaultValue: ""))

--- a/sdk/lib/core/string.dart
+++ b/sdk/lib/core/string.dart
@@ -151,8 +151,10 @@ abstract class String implements Comparable<String>, Pattern {
   /// must be consistent across all calls to `String.fromEnvironment`,
   /// [int.fromEnvironment], [bool.fromEnvironment] and [bool.hasEnvironment]
   /// in a single program.
-  /// 
-  /// The String.fromEnvironment() constructor must be constant.
+  ///
+  /// The `String.fromEnvironment` constructor is only guaranteed to work when
+  /// called as  const, but may work with `new` on some specific platforms,
+  /// mainly non-AoT-compiled ones.
   // The .fromEnvironment() constructors are special in that we do not want
   // users to call them using "new". We prohibit that by giving them bodies
   // that throw, even though const constructors are not allowed to have bodies.

--- a/sdk/lib/core/string.dart
+++ b/sdk/lib/core/string.dart
@@ -135,6 +135,8 @@ abstract class String implements Comparable<String>, Pattern {
   /// If [name] is not declared in the environment, the result is instead
   /// [defaultValue].
   ///
+  /// The value must be assigned to a constant.
+  ///
   /// Example of getting a value:
   /// ```dart
   /// const String.fromEnvironment("defaultFloo", defaultValue: "no floo")

--- a/sdk/lib/core/string.dart
+++ b/sdk/lib/core/string.dart
@@ -135,8 +135,6 @@ abstract class String implements Comparable<String>, Pattern {
   /// If [name] is not declared in the environment, the result is instead
   /// [defaultValue].
   ///
-  /// The value must be assigned to a constant.
-  ///
   /// Example of getting a value:
   /// ```dart
   /// const String.fromEnvironment("defaultFloo", defaultValue: "no floo")
@@ -153,6 +151,8 @@ abstract class String implements Comparable<String>, Pattern {
   /// must be consistent across all calls to `String.fromEnvironment`,
   /// [int.fromEnvironment], [bool.fromEnvironment] and [bool.hasEnvironment]
   /// in a single program.
+  /// 
+  /// The String.fromEnvironment() constructor must be constant.
   // The .fromEnvironment() constructors are special in that we do not want
   // users to call them using "new". We prohibit that by giving them bodies
   // that throw, even though const constructors are not allowed to have bodies.


### PR DESCRIPTION
This PR provides additional info on the `fromEnvironment()` constructors, as it will not work when the constructor is not constant on AOT-compiled platforms

Since `fromEnvironment()` constructors don't throw a warning when called as non-constant on AOT-compiled platforms, it makes confusing the use of dart define and lead doubts like https://twitter.com/prasadsunny1/status/1423721300149760000

