### PR TITLE
Fix isAfter method code example on DateTime class

### DIFF
--- a/sdk/lib/core/date_time.dart
+++ b/sdk/lib/core/date_time.dart
@@ -432,8 +432,8 @@ class DateTime implements Comparable<DateTime> {
   /// assert(later.isAfter(now.toUtc()));
   /// assert(later.toUtc().isAfter(now));
   ///
-  /// assert(!now.toUtc().isBefore(now));
-  /// assert(!now.isBefore(now.toUtc()));
+  /// assert(!now.toUtc().isAfter(now));
+  /// assert(!now.isAfter(now.toUtc()));
   /// ```
   external bool isAfter(DateTime other);
 


### PR DESCRIPTION
The code example looks similar as [isBefore method](https://github.com/dart-lang/sdk/blob/b8d040e5239e02b945b529347d0b980fc8a26db2/sdk/lib/core/date_time.dart#L405-L417) except in this change.