### PR TITLE
Correcting misnamed variable in doc comments

### DIFF
--- a/sdk/lib/core/list.dart
+++ b/sdk/lib/core/list.dart
@@ -137,7 +137,7 @@ abstract class List<E> implements EfficientLengthIterable<E> {
   /// ```dart
   /// List<dynamic> dynList = ...some JSON value...;
   /// List<Map<String, dynamic>> fooList =
-  ///     List.from(dynList.where((x) => x is Map && map["kind"] == "foo"));
+  ///     List.from(dynList.where((x) => x is Map && x["kind"] == "foo"));
   /// ```
   ///
   /// This constructor creates a growable list when [growable] is true;


### PR DESCRIPTION
Unless I'm missing something, the map that is being referenced here is `x` from the function argument. It looks like calling it `map` was just a typo. Alternatively rename `x` to `map`.