### PR TITLE
fix https://github.com/dart-lang/sdk/issues/46764

### DIFF
--- a/pkg/analyzer/lib/src/summary2/bundle_reader.dart
+++ b/pkg/analyzer/lib/src/summary2/bundle_reader.dart
@@ -423,7 +423,7 @@ class LibraryReader {
   final Uint32List _classMembersLengths;
   int _classMembersLengthsIndex = 0;
 
-  late List<Reference> exports;
+  List<Reference>? exports;
 
   LibraryReader._({
     required LinkedElementFactory elementFactory,

--- a/pkg/analyzer/lib/src/summary2/linked_element_factory.dart
+++ b/pkg/analyzer/lib/src/summary2/linked_element_factory.dart
@@ -157,7 +157,7 @@ class LinkedElementFactory {
     var library = libraryReaders[uriStr];
     if (library == null) return const [];
 
-    return library.exports;
+    return library.exports ?? [];
   }
 
   bool hasLibrary(String uriStr) {


### PR DESCRIPTION
https://github.com/dart-lang/sdk/issues/46764

Late Initialization Error: Field 'exports' has not been initialized.#0 LibraryReader.exports