### PR TITLE
update to_source_visitor.dart

### DIFF
--- a/pkg/analyzer/lib/src/dart/ast/to_source_visitor.dart
+++ b/pkg/analyzer/lib/src/dart/ast/to_source_visitor.dart
@@ -54,7 +54,7 @@ class ToSourceVisitor implements AstVisitor<void> {
       sink.write(', ');
       _visitNode(node.message);
     }
-    sink.write(');');
+    sink.write(')');
   }
 
   @override

--- a/pkg/analyzer/lib/src/dart/ast/to_source_visitor.dart
+++ b/pkg/analyzer/lib/src/dart/ast/to_source_visitor.dart
@@ -565,6 +565,7 @@ class ToSourceVisitor implements AstVisitor<void> {
     _visitNode(node.typeParameters);
     sink.write(' = ');
     _visitNode(node.type);
+    sink.write(';');
   }
 
   @override


### PR DESCRIPTION
GenericTypeAlias from docs 
/// A generic type alias.
///
///    functionTypeAlias ::=
///        metadata 'typedef' [SimpleIdentifier] [TypeParameterList]? = [FunctionType] ';' 
but you forgot semicolon