### PR TITLE
vm math patch: use a singleton for Random.secure

### DIFF
--- a/sdk/lib/_internal/vm/lib/math_patch.dart
+++ b/sdk/lib/_internal/vm/lib/math_patch.dart
@@ -206,6 +206,8 @@ external double _log(double x);
 // TODO(iposva): Handle patch methods within a patch class correctly.
 @patch
 class Random {
+  static late final Random _secureRandom = _SecureRandom();
+
   @patch
   factory Random([int? seed]) {
     var state = _Random._setupSeed((seed == null) ? _Random._nextSeed() : seed);
@@ -218,9 +220,7 @@ class Random {
   }
 
   @patch
-  factory Random.secure() {
-    return new _SecureRandom();
-  }
+  factory Random.secure() => _secureRandom;
 }
 
 class _Random implements Random {


### PR DESCRIPTION
Seems to be zero upside to creating a new instance every time

Change-Id: I8cf372f654225ee5f599fd0c36019607c1186fc9
