### PR TITLE
Mention Object.hashCode in the note about LinkedHashSet in the Set documentation

### DIFF
--- a/sdk/lib/core/set.dart
+++ b/sdk/lib/core/set.dart
@@ -13,8 +13,8 @@ part of dart.core;
 /// elements are treated as being the same for any operation on the set.
 ///
 /// The default [Set] implementation, [LinkedHashSet], considers objects
-/// indistinguishable if they are equal with regard to
-/// operator [Object.==].
+/// indistinguishable if they are equal with regard to [Object.==] and
+/// [Object.hashCode].
 ///
 /// Iterating over elements of a set may be either unordered
 /// or ordered in some way. Examples:


### PR DESCRIPTION
The note about `LinkedHashSet` in the `Set` documentation is a little misleading, and it can lead developers to implement `==` without `hashCode`, only to be confused when their set doesn't work correctly.

See this [StackOverflow question](https://stackoverflow.com/questions/69664073/dart-comparison-of-objects-within-a-list/69694646#69694646), for example.

This PR mentions `Object.hashCode` along with `Object.==` in the `Set` documentation explaining `LinkedHashSet`.