### PR TITLE
Update CSS lib version dep

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -91,7 +91,7 @@ vars = {
   "collection_rev": "a4c941ab94044d118b2086a3f261c30377604127",
   "convert_rev": "e063fdca4bebffecbb5e6aa5525995120982d9ce",
   "crypto_rev": "b5024e4de2b1c474dd558bef593ddbf0bfade152",
-  "csslib_rev": "6f35da3d93eb56eb25925779d235858d4090ce6f",
+  "csslib_rev": "02abc1ddf93092efef2be365300f15504d23cd23",
 
   # Note: Updates to dart_style have to be coordinated with the infrastructure
   # team so that the internal formatter `tools/sdks/dart-sdk/bin/dart format`


### PR DESCRIPTION
This is needed internally to get a change to global-context rename which was requested by the CSS team at Google.