### PR TITLE
[VM - FFI] Optimize `Pointer<T>.asTypedList()`

### DIFF
--- a/benchmarks/FfiAsTypedList/dart/FfiAsTypedList.dart
+++ b/benchmarks/FfiAsTypedList/dart/FfiAsTypedList.dart
@@ -1,0 +1,49 @@
+// Copyright (c) 2021, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Micro-benchmark for creating TypeData lists from Pointers.
+//
+// The FfiMemory benchmark tests accessing memory through TypedData.
+
+import 'dart:ffi';
+
+import 'package:benchmark_harness/benchmark_harness.dart';
+import 'package:ffi/ffi.dart';
+
+//
+// Benchmark fixture.
+//
+
+// Number of repeats: 1000
+const N = 1000;
+
+class FromPointerInt8 extends BenchmarkBase {
+  Pointer<Int8> pointer = nullptr;
+  FromPointerInt8() : super('FfiAsTypedList.FromPointerInt8');
+
+  @override
+  void setup() => pointer = calloc(1);
+  @override
+  void teardown() => calloc.free(pointer);
+
+  @override
+  void run() {
+    for (var i = 0; i < N; i++) {
+      pointer.asTypedList(1);
+    }
+  }
+}
+
+//
+// Main driver.
+//
+
+void main() {
+  final benchmarks = [
+    () => FromPointerInt8(),
+  ];
+  for (final benchmark in benchmarks) {
+    benchmark().report();
+  }
+}

--- a/benchmarks/FfiAsTypedList/dart2/FfiAsTypedList.dart
+++ b/benchmarks/FfiAsTypedList/dart2/FfiAsTypedList.dart
@@ -1,0 +1,51 @@
+// Copyright (c) 2021, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Micro-benchmark for creating TypeData lists from Pointers.
+//
+// The FfiMemory benchmark tests accessing memory through TypedData.
+
+// @dart=2.9
+
+import 'dart:ffi';
+
+import 'package:benchmark_harness/benchmark_harness.dart';
+import 'package:ffi/ffi.dart';
+
+//
+// Benchmark fixture.
+//
+
+// Number of repeats: 1000
+const N = 1000;
+
+class FromPointerInt8 extends BenchmarkBase {
+  Pointer<Int8> pointer = nullptr;
+  FromPointerInt8() : super('FfiAsTypedList.FromPointerInt8');
+
+  @override
+  void setup() => pointer = calloc(1);
+  @override
+  void teardown() => calloc.free(pointer);
+
+  @override
+  void run() {
+    for (var i = 0; i < N; i++) {
+      pointer.asTypedList(1);
+    }
+  }
+}
+
+//
+// Main driver.
+//
+
+void main() {
+  final benchmarks = [
+    () => FromPointerInt8(),
+  ];
+  for (final benchmark in benchmarks) {
+    benchmark().report();
+  }
+}

--- a/runtime/tools/ffi/sdk_lib_ffi_generator.dart
+++ b/runtime/tools/ffi/sdk_lib_ffi_generator.dart
@@ -223,7 +223,13 @@ void generatePatchExtension(
       ? ""
       : """
   @patch
-  $typedListType asTypedList(int elements) => _asExternalTypedData(this, elements);
+  $typedListType asTypedList(int length) {
+    ArgumentError.checkNotNull(this, "Pointer<$nativeType>");
+    ArgumentError.checkNotNull(length, "length");
+    _checkExternalTypedDataLength(length, $elementSize);
+    _checkPointerAlignment(address, $elementSize);
+    return _asExternalTypedData$nativeType(this, length);
+  }
 """;
 
   if (container == "Pointer") {

--- a/runtime/vm/bootstrap_natives.h
+++ b/runtime/vm/bootstrap_natives.h
@@ -400,7 +400,16 @@ namespace dart {
   V(Ffi_dl_lookup, 2)                                                          \
   V(Ffi_dl_getHandle, 1)                                                       \
   V(Ffi_dl_providesSymbol, 2)                                                  \
-  V(Ffi_asExternalTypedData, 2)                                                \
+  V(Ffi_asExternalTypedDataInt8, 2)                                            \
+  V(Ffi_asExternalTypedDataInt16, 2)                                           \
+  V(Ffi_asExternalTypedDataInt32, 2)                                           \
+  V(Ffi_asExternalTypedDataInt64, 2)                                           \
+  V(Ffi_asExternalTypedDataUint8, 2)                                           \
+  V(Ffi_asExternalTypedDataUint16, 2)                                          \
+  V(Ffi_asExternalTypedDataUint32, 2)                                          \
+  V(Ffi_asExternalTypedDataUint64, 2)                                          \
+  V(Ffi_asExternalTypedDataFloat, 2)                                           \
+  V(Ffi_asExternalTypedDataDouble, 2)                                          \
   V(Ffi_dl_processLibrary, 0)                                                  \
   V(Ffi_dl_executableLibrary, 0)                                               \
   V(Ffi_GetFfiNativeResolver, 0)                                               \

--- a/runtime/vm/class_id.h
+++ b/runtime/vm/class_id.h
@@ -140,7 +140,7 @@ typedef uint16_t ClassIdTagType;
   V(Int32x4Array)                                                              \
   V(Float64x2Array)
 
-#define CLASS_LIST_FFI_NUMERIC(V)                                              \
+#define CLASS_LIST_FFI_NUMERIC_FIXED_SIZE(V)                                   \
   V(Int8)                                                                      \
   V(Int16)                                                                     \
   V(Int32)                                                                     \
@@ -149,9 +149,12 @@ typedef uint16_t ClassIdTagType;
   V(Uint16)                                                                    \
   V(Uint32)                                                                    \
   V(Uint64)                                                                    \
-  V(IntPtr)                                                                    \
   V(Float)                                                                     \
   V(Double)
+
+#define CLASS_LIST_FFI_NUMERIC(V)                                              \
+  CLASS_LIST_FFI_NUMERIC_FIXED_SIZE(V)                                         \
+  V(IntPtr)
 
 #define CLASS_LIST_FFI_TYPE_MARKER(V)                                          \
   CLASS_LIST_FFI_NUMERIC(V)                                                    \

--- a/runtime/vm/compiler/ffi/recognized_method.cc
+++ b/runtime/vm/compiler/ffi/recognized_method.cc
@@ -45,6 +45,33 @@ classid_t ElementTypedDataCid(classid_t class_id) {
   }
 }
 
+classid_t ElementExternalTypedDataCid(classid_t class_id) {
+  switch (class_id) {
+    case kFfiInt8Cid:
+      return kExternalTypedDataInt8ArrayCid;
+    case kFfiUint8Cid:
+      return kExternalTypedDataUint8ArrayCid;
+    case kFfiInt16Cid:
+      return kExternalTypedDataInt16ArrayCid;
+    case kFfiUint16Cid:
+      return kExternalTypedDataUint16ArrayCid;
+    case kFfiInt32Cid:
+      return kExternalTypedDataInt32ArrayCid;
+    case kFfiUint32Cid:
+      return kExternalTypedDataUint32ArrayCid;
+    case kFfiInt64Cid:
+      return kExternalTypedDataInt64ArrayCid;
+    case kFfiUint64Cid:
+      return kExternalTypedDataUint64ArrayCid;
+    case kFfiFloatCid:
+      return kExternalTypedDataFloat32ArrayCid;
+    case kFfiDoubleCid:
+      return kExternalTypedDataFloat64ArrayCid;
+    default:
+      UNREACHABLE();
+  }
+}
+
 classid_t RecognizedMethodTypeArgCid(MethodRecognizer::Kind kind) {
   switch (kind) {
 #define LOAD_STORE(type)                                                       \
@@ -62,6 +89,11 @@ classid_t RecognizedMethodTypeArgCid(MethodRecognizer::Kind kind) {
     case MethodRecognizer::kFfiLoadPointer:
     case MethodRecognizer::kFfiStorePointer:
       return kPointerCid;
+#define AS_EXTERNAL_TYPED_DATA(type)                                           \
+  case MethodRecognizer::kFfiAsExternalTypedData##type:                        \
+    return kFfi##type##Cid;
+    CLASS_LIST_FFI_NUMERIC_FIXED_SIZE(AS_EXTERNAL_TYPED_DATA)
+#undef AS_EXTERNAL_TYPED_DATA
     default:
       UNREACHABLE();
   }

--- a/runtime/vm/compiler/ffi/recognized_method.h
+++ b/runtime/vm/compiler/ffi/recognized_method.h
@@ -23,6 +23,10 @@ namespace ffi {
 // TypedData class id for a NativeType type, except for Void and NativeFunction.
 classid_t ElementTypedDataCid(classid_t class_id);
 
+// ExternalTypedData class id for a NativeType type, except for Void,
+// NativeFunction, IntPtr and Pointer.
+classid_t ElementExternalTypedDataCid(classid_t class_id);
+
 // Returns the kFFi<type>Cid for the recognized load/store method [kind].
 classid_t RecognizedMethodTypeArgCid(MethodRecognizer::Kind kind);
 

--- a/runtime/vm/compiler/recognized_methods_list.h
+++ b/runtime/vm/compiler/recognized_methods_list.h
@@ -221,6 +221,16 @@ namespace dart {
   V(::, _storePointer, FfiStorePointer, 0xea6b7751)                            \
   V(::, _fromAddress, FfiFromAddress, 0xfd8cb1cc)                              \
   V(Pointer, get:address, FfiGetAddress, 0x7cde87be)                           \
+  V(::, _asExternalTypedDataInt8, FfiAsExternalTypedDataInt8, 0x768a0698)      \
+  V(::, _asExternalTypedDataInt16, FfiAsExternalTypedDataInt16, 0xd09cf9c6)    \
+  V(::, _asExternalTypedDataInt32, FfiAsExternalTypedDataInt32, 0x38248946)    \
+  V(::, _asExternalTypedDataInt64, FfiAsExternalTypedDataInt64, 0xafaa47fb)    \
+  V(::, _asExternalTypedDataUint8, FfiAsExternalTypedDataUint8, 0x35228834)    \
+  V(::, _asExternalTypedDataUint16, FfiAsExternalTypedDataUint16, 0x89a51e3a)  \
+  V(::, _asExternalTypedDataUint32, FfiAsExternalTypedDataUint32, 0xd272dc41)  \
+  V(::, _asExternalTypedDataUint64, FfiAsExternalTypedDataUint64, 0x06be71c5)  \
+  V(::, _asExternalTypedDataFloat, FfiAsExternalTypedDataFloat, 0x6f465e0c)    \
+  V(::, _asExternalTypedDataDouble, FfiAsExternalTypedDataDouble, 0x40cdd9e1)  \
   V(::, _getNativeField, GetNativeField, 0xa0139b85)                           \
   V(::, reachabilityFence, ReachabilityFence, 0x619235c1)                      \
   V(_Utf8Decoder, _scan, Utf8DecoderScan, 0x1dcaf73d)                          \

--- a/runtime/vm/object.h
+++ b/runtime/vm/object.h
@@ -3177,8 +3177,8 @@ class Function : public Object {
   // run.
   bool ForceOptimize() const {
     return IsFfiFromAddress() || IsFfiGetAddress() || IsFfiLoad() ||
-           IsFfiStore() || IsFfiTrampoline() || IsTypedDataViewFactory() ||
-           IsUtf8Scan() || IsGetNativeField();
+           IsFfiStore() || IsFfiTrampoline() || IsFfiAsExternalTypedData() ||
+           IsTypedDataViewFactory() || IsUtf8Scan() || IsGetNativeField();
   }
 
   bool CanBeInlined() const;
@@ -3508,6 +3508,12 @@ class Function : public Object {
   bool IsFfiGetAddress() const {
     const auto kind = recognized_kind();
     return kind == MethodRecognizer::kFfiGetAddress;
+  }
+
+  bool IsFfiAsExternalTypedData() const {
+    const auto kind = recognized_kind();
+    return MethodRecognizer::kFfiAsExternalTypedDataInt8 <= kind &&
+           kind <= MethodRecognizer::kFfiAsExternalTypedDataDouble;
   }
 
   bool IsGetNativeField() const {

--- a/tools/bots/try_benchmarks.sh
+++ b/tools/bots/try_benchmarks.sh
@@ -188,6 +188,8 @@ EOF
     out/ReleaseIA32/dart --sound-null-safety benchmarks/NativeCall/dart/NativeCall.dart
     out/ReleaseIA32/dart benchmarks/FfiBoringssl/dart2/FfiBoringssl.dart
     out/ReleaseIA32/dart --sound-null-safety benchmarks/FfiBoringssl/dart/FfiBoringssl.dart
+    out/ReleaseIA32/dart benchmarks/FfiAsTypedList/dart2/FfiAsTypedList.dart
+    out/ReleaseIA32/dart --sound-null-safety benchmarks/FfiAsTypedList/dart/FfiAsTypedList.dart
     out/ReleaseIA32/dart benchmarks/FfiCall/dart2/FfiCall.dart
     out/ReleaseIA32/dart --sound-null-safety benchmarks/FfiCall/dart/FfiCall.dart
     out/ReleaseIA32/dart benchmarks/FfiMemory/dart2/FfiMemory.dart


### PR DESCRIPTION
This change refactors `_asExternalTypedData` into multiple functions,
which are data type specific, e.g `_asExternalTypedDataInt8`.
These functions are implemented as recognized methods.
Argument checks have previously been performed in the removed
runtime entry implementation of `_asExternalTypedData.` These are
now handled in Dart.

Closes https://github.com/dart-lang/sdk/issues/39843