### PR TITLE
[analysis_server_client] make dartBinary as parameter for Server.start

### DIFF
--- a/pkg/analysis_server_client/lib/server.dart
+++ b/pkg/analysis_server_client/lib/server.dart
@@ -99,11 +99,12 @@ class Server extends ServerBase {
     bool suppressAnalytics = true,
     bool useAnalysisHighlight2 = false,
     bool enableAsserts = false,
+    String? dartBinary,
   }) async {
     if (_process != null) {
       throw Exception('Process already started');
     }
-    var dartBinary = Platform.executable;
+    dartBinary ??= Platform.executable;
 
     // The integration tests run 3x faster when run from snapshots
     // (you need to run test.py with --use-sdk).


### PR DESCRIPTION
Platform.executable != dartBinary for compiled executables.

This change allows package users to provide the path for the dartBinary if their app will be compiled.