### PR TITLE
Update precompiler_trace.dart

### DIFF
--- a/pkg/vm_snapshot_analysis/lib/precompiler_trace.dart
+++ b/pkg/vm_snapshot_analysis/lib/precompiler_trace.dart
@@ -39,7 +39,7 @@ class CallGraphNode {
   /// Dominator of this node.
   ///
   /// Computed by [CallGraph.computeDominators].
-  late CallGraphNode dominator;
+  CallGraphNode? dominator;
 
   /// Nodes dominated by this node.
   ///


### PR DESCRIPTION
 `CallGraphNode.dominator` should be nullable, not late, as it is expected for root node of a CallGraph to have a null dominator.

When it is non-nullable, devTools to fails convert to null-safe version of vm_snapshot_analysis: https://github.com/flutter/devtools/runs/4974867863?check_suite_focus=true