### PR TITLE
Fix build script host arch detection on M1

### DIFF
--- a/tools/utils.py
+++ b/tools/utils.py
@@ -154,10 +154,10 @@ def GuessArchitecture():
     os_id = platform.machine()
     if os_id.startswith('armv6'):
         return 'armv6'
+    elif os_id.startswith('arm64') or os_id.startswith('aarch64'):
+        return 'arm64'
     elif os_id.startswith('arm'):
         return 'arm'
-    elif os_id.startswith('aarch64'):
-        return 'arm64'
     elif '64' in os_id:
         return 'x64'
     elif (not os_id) or (not re.match('(x|i[3-6])86', os_id) is None):


### PR DESCRIPTION
This fixes host architecture guessing on M1.

Since arm64 and aarch64 are synonymous branches for those are merged.