### PR TITLE
Fallback to uname for detecting ARM CPU architecture

### DIFF
--- a/build/config/linux/BUILD.gn
+++ b/build/config/linux/BUILD.gn
@@ -35,10 +35,6 @@ config("sdk") {
       ]
     }
   }
-
-  if (is_qemu) {
-    cflags += [ "-DDART_RUN_IN_QEMU_ARMv7" ]
-  }
 }
 
 config("executable_config") {

--- a/runtime/vm/cpu_arm.cc
+++ b/runtime/vm/cpu_arm.cc
@@ -20,6 +20,10 @@
 #elif defined(DART_HOST_OS_WINDOWS)
 #include <processthreadsapi.h>
 #endif
+#if !defined(DART_HOST_OS_WINDOWS)
+#include <string.h>      /* NOLINT */
+#include <sys/utsname.h> /* NOLINT */
+#endif
 #endif
 
 // ARM version differences.
@@ -145,20 +149,27 @@ void HostCPUFeatures::Init() {
   CpuInfo::Init();
   hardware_ = CpuInfo::GetCpuModel();
 
+  // QEMU may report host cpuinfo instead of emulated cpuinfo, use uname as a
+  // fallback for checking if CPU is AArch64 or ARMv7.
+  struct utsname uname_;
+  int ret_ = uname(&uname_);
+
   // Check for ARMv7, or aarch64.
   // It can be in either the Processor or Model information fields.
   if (CpuInfo::FieldContains(kCpuInfoProcessor, "aarch64") ||
       CpuInfo::FieldContains(kCpuInfoModel, "aarch64") ||
       CpuInfo::FieldContains(kCpuInfoArchitecture, "8") ||
-      CpuInfo::FieldContains(kCpuInfoArchitecture, "AArch64")) {
+      CpuInfo::FieldContains(kCpuInfoArchitecture, "AArch64") ||
+      (ret_ == 0 && (strstr(uname_.machine, "aarch64") != NULL ||
+                     strstr(uname_.machine, "arm64") != NULL ||
+                     strstr(uname_.machine, "armv8") != NULL))) {
     // pretend that this arm64 cpu is really an ARMv7
     is_arm64 = true;
   } else if (!CpuInfo::FieldContains(kCpuInfoProcessor, "ARMv7") &&
              !CpuInfo::FieldContains(kCpuInfoModel, "ARMv7") &&
-             !CpuInfo::FieldContains(kCpuInfoArchitecture, "7")) {
-#if !defined(DART_RUN_IN_QEMU_ARMv7)
+             !CpuInfo::FieldContains(kCpuInfoArchitecture, "7") &&
+             !(ret_ == 0 && strstr(uname_.machine, "armv7") != NULL)) {
     FATAL("Unrecognized ARM CPU architecture.");
-#endif
   }
 
   // Has integer division.
@@ -203,7 +214,7 @@ void HostCPUFeatures::Init() {
 
 // Use the cross-compiler's predefined macros to determine whether we should
 // use the hard or soft float ABI.
-#if defined(__ARM_PCS_VFP) || defined(DART_RUN_IN_QEMU_ARMv7)
+#if defined(__ARM_PCS_VFP)
   hardfp_supported_ = true;
 #else
   hardfp_supported_ = false;


### PR DESCRIPTION
Currently running official dart `linux/arm/v7` container image on x86_64 with QEMU results in `Unrecognized ARM CPU architecture`.

This is due to QEMU reporting host `/proc/cpuinfo` instead of the emulated architecture.

Checking `uname` in addition to `/proc/cpuinfo` would make `linux/arm/v7` build work consistently regardless of whether `--use-qemu` is supplied during SDK build time.

TEST=running the qemu bot
TEST=ran the ffi/hardfp_test.dart locally both in AOT and JIT mode.