### PR TITLE
feat: support dSYM symbolication in native_stack_traces

### DIFF
--- a/pkg/native_stack_traces/bin/decode.dart
+++ b/pkg/native_stack_traces/bin/decode.dart
@@ -162,7 +162,9 @@ Dwarf? _loadFromFile(String? original, Function(String) usageError) {
     return null;
   }
   final filename = path.canonicalize(path.normalize(original));
-  if (!io.File(filename).existsSync()) {
+  if (filename.endsWith('dSYM')
+      ? !io.Directory(filename).existsSync()
+      : !io.File(filename).existsSync()) {
     usageError('debug file "$original" does not exist');
     return null;
   }
@@ -207,7 +209,7 @@ void find(ArgResults options) {
     return usageError('need both VM start and isolate start');
   }
 
-  var vmStart = dwarf.vmStartAddress;
+  late final int vmStart;
   if (options['vm_start'] != null) {
     final address = tryParseIntAddress(options['vm_start']);
     if (address == null) {
@@ -215,9 +217,11 @@ void find(ArgResults options) {
           '${options['vm_start']}');
     }
     vmStart = address;
+  } else {
+    vmStart = dwarf.vmStartAddress;
   }
 
-  var isolateStart = dwarf.isolateStartAddress;
+  late final int isolateStart;
   if (options['isolate_start'] != null) {
     final address = tryParseIntAddress(options['isolate_start']);
     if (address == null) {
@@ -225,6 +229,8 @@ void find(ArgResults options) {
           '${options['isolate_start']}');
     }
     isolateStart = address;
+  } else {
+    isolateStart = dwarf.isolateStartAddress;
   }
 
   final header = StackTraceHeader(isolateStart, vmStart);


### PR DESCRIPTION
This is part of #43612 - enabling Flutter users to `split-debug-info` into `dSYM` and symbolize it back, using `flutter symbolize` or directly using the CLI tool in `native_stack_traces`.

The general approach taken was proposed by @mraleph in this comment: https://github.com/dart-lang/sdk/issues/43612#issuecomment-842164854

There are quite a few open questions here as well as in the Flutter tooling, but I'd like to get the feedback on this. There are two main pain points in this PR
1. the current implementation in `dwarf.dart` only supports ELF format - that doesn't match the dwarf file contained in a dSYM container and it is beyond me to implement the dwarf parsing so the proposed solution uses a CLI tool `atos` get symbol names for individual addresses. This, however, loses the option to load the dwarf from a Uint8List, which is currently done by the `flutter` tool to allow unit testing.
2. So far I couldn't figure out a way to extract the following addresses from dSYM and they're required to properly call `atos`... any ideas? Currently they're parsed from the given stack trace (the second line already was before this PR).
    ```
    isolate_dso_base: 116904000, vm_dso_base: 116904000
    isolate_instructions: 11690f6d0, vm_instructions: 11690aee0
    ```
    
Additionally, I haven't seen any tests for the existing CLI tool. Hopefully, the CI will give me some feedback here.