### PR TITLE
add trailing comma fix for literals

### DIFF
--- a/pkg/analysis_server/lib/src/services/correction/dart/add_trailing_comma.dart
+++ b/pkg/analysis_server/lib/src/services/correction/dart/add_trailing_comma.dart
@@ -30,6 +30,10 @@ class AddTrailingComma extends CorrectionProducer {
       await _insertComma(builder, node.parameters.last);
     } else if (node is Assertion) {
       await _insertComma(builder, node.message ?? node.condition);
+    } else if (node is ListLiteral) {
+      await _insertComma(builder, node.elements.last);
+    } else if (node is SetOrMapLiteral) {
+      await _insertComma(builder, node.elements.last);
     }
   }
 

--- a/pkg/analysis_server/test/src/services/correction/fix/add_trailing_comma_test.dart
+++ b/pkg/analysis_server/test/src/services/correction/fix/add_trailing_comma_test.dart
@@ -102,6 +102,50 @@ void f(a, b) {
 ''');
   }
 
+  @failingTest
+  Future<void> test_list_literal() async {
+    await resolveTestCode('''
+void f() {
+  var l = [
+    'a',
+    'b'
+  ];
+  print(l);
+}
+''');
+    await assertHasFix('''
+void f() {
+  var l = [
+    'a',
+    'b',
+  ];
+  print(l);
+}
+''');
+  }
+
+  @failingTest
+  Future<void> test_map_literal() async {
+    await resolveTestCode('''
+void f() {
+  var l = {
+    'a': 1,
+    'b': 2
+  };
+  print(l);
+}
+''');
+    await assertHasFix('''
+void f() {
+  var l = {
+    'a': 1,
+    'b': 2,
+  };
+  print(l);
+}
+''');
+  }
+
   Future<void> test_named() async {
     await resolveTestCode('''
 void f({a, b}) {
@@ -143,27 +187,7 @@ void f(a, b) {
 ''');
   }
 
-  Future<void> test_list_literal() async {
-    await resolveTestCode('''
-void f() {
-  var l = [
-    'a',
-    'b'
-  ];
-  print(l);
-}
-''');
-    await assertHasFix('''
-void f() {
-  var l = [
-    'a',
-    'b',
-  ];
-  print(l);
-}
-''');
-  }
-
+  @failingTest
   Future<void> test_set_literal() async {
     await resolveTestCode('''
 void f() {
@@ -179,27 +203,6 @@ void f() {
   var l = {
     'a',
     'b',
-  };
-  print(l);
-}
-''');
-  }
-
-  Future<void> test_map_literal() async {
-    await resolveTestCode('''
-void f() {
-  var l = {
-    'a': 1,
-    'b': 2
-  };
-  print(l);
-}
-''');
-    await assertHasFix('''
-void f() {
-  var l = {
-    'a': 1,
-    'b': 2,
   };
   print(l);
 }

--- a/pkg/analysis_server/test/src/services/correction/fix/add_trailing_comma_test.dart
+++ b/pkg/analysis_server/test/src/services/correction/fix/add_trailing_comma_test.dart
@@ -142,4 +142,67 @@ void f(a, b) {
 }
 ''');
   }
+
+  Future<void> test_list_literal() async {
+    await resolveTestCode('''
+void f() {
+  var l = [
+    'a',
+    'b'
+  ];
+  print(l);
+}
+''');
+    await assertHasFix('''
+void f() {
+  var l = [
+    'a',
+    'b',
+  ];
+  print(l);
+}
+''');
+  }
+
+  Future<void> test_set_literal() async {
+    await resolveTestCode('''
+void f() {
+  var l = {
+    'a',
+    'b'
+  };
+  print(l);
+}
+''');
+    await assertHasFix('''
+void f() {
+  var l = {
+    'a',
+    'b',
+  };
+  print(l);
+}
+''');
+  }
+
+  Future<void> test_map_literal() async {
+    await resolveTestCode('''
+void f() {
+  var l = {
+    'a': 1,
+    'b': 2
+  };
+  print(l);
+}
+''');
+    await assertHasFix('''
+void f() {
+  var l = {
+    'a': 1,
+    'b': 2,
+  };
+  print(l);
+}
+''');
+  }
 }


### PR DESCRIPTION
This PR extends the`add_trailing_comma` fix to handle for the [upcoming support of list/set/map literals in `require_trailing_commas`](https://github.com/dart-lang/linter/pull/3340).

It's likely the tests in this PR will fail until sdk update the linter dependency to include https://github.com/dart-lang/linter/pull/3340