### PR TITLE
Add the missing space for `sdk/lib/core/num.dart`

### DIFF
--- a/sdk/lib/core/num.dart
+++ b/sdk/lib/core/num.dart
@@ -150,7 +150,7 @@ abstract class num implements Comparable<num> {
   /// print(5 % -3); // 2
   /// print(-5 % -3); // 1
   /// ```
- num operator %(num other);
+  num operator %(num other);
 
   /// Divides this number by [other].
   double operator /(num other);


### PR DESCRIPTION
This is nit-picking that `sdk/lib/core/num.dart` is missing a single space at the start of the line.

https://github.com/dart-lang/sdk/blob/6c210bbc57d89699729736a97080059636ed6cd6/sdk/lib/core/num.dart#L147-L153