### PR TITLE
Enable Large File Support extension (LFS)

### DIFF
--- a/build/config/linux/BUILD.gn
+++ b/build/config/linux/BUILD.gn
@@ -35,6 +35,13 @@ config("sdk") {
       ]
     }
   }
+
+  # Enable Large File Support extension (LFS)
+  cflags += [
+    "-D_FILE_OFFSET_BITS=64",
+    "-D_LARGEFILE_SOURCE",
+    "-D_LARGEFILE64_SOURCE",
+  ]
 }
 
 config("executable_config") {


### PR DESCRIPTION
This PR adds flags to enable LFS to make 32-bit builds to correctly handle 64-bit inode from the ext4/xfs file systems.

Specifically, many APIs internally uses `readdir()` for listing directory, which may crash with an `EOVERFLOW`, `Value too large for defined data type`.

See https://bugs.gentoo.org/681790#c0 for some background about this issue. 

