### PR TITLE
add UNDEFINED_EXTENSION_GETTER to bulk fix

### DIFF
--- a/pkg/analysis_server/lib/src/services/correction/bulk_fix_processor.dart
+++ b/pkg/analysis_server/lib/src/services/correction/bulk_fix_processor.dart
@@ -78,6 +78,9 @@ class BulkFixProcessor {
     CompileTimeErrorCode.UNDEFINED_CLASS: [
       DataDriven.new,
     ],
+    CompileTimeErrorCode.UNDEFINED_EXTENSION_GETTER: [
+      DataDriven.new,
+    ],
     CompileTimeErrorCode.UNDEFINED_FUNCTION: [
       DataDriven.new,
     ],


### PR DESCRIPTION
Following up on #49164 this PR allows rename in extensions via `dart fix`