### PR TITLE
[vm] Prevent empty range in coverage output

### DIFF
--- a/runtime/vm/source_report.cc
+++ b/runtime/vm/source_report.cc
@@ -607,12 +607,12 @@ void SourceReport::VisitLibrary(JSONArray* jsarr, const Library& lib) {
         Error& err = Error::Handle(cls.EnsureIsFinalized(thread()));
         if (!err.IsNull()) {
           // Emit an uncompiled range for this class with error information.
-          JSONObject range(jsarr);
           script = cls.script();
           const intptr_t script_index = GetScriptIndex(script);
           if (script_index < 0) {
             continue;
           }
+          JSONObject range(jsarr);
           range.AddProperty("scriptIndex", script_index);
           range.AddProperty("startPos", cls.token_pos());
           range.AddProperty("endPos", cls.end_token_pos());
@@ -624,12 +624,12 @@ void SourceReport::VisitLibrary(JSONArray* jsarr, const Library& lib) {
       } else {
         cls.EnsureDeclarationLoaded();
         // Emit one range for the whole uncompiled class.
-        JSONObject range(jsarr);
         script = cls.script();
         const intptr_t script_index = GetScriptIndex(script);
         if (script_index < 0) {
           continue;
         }
+        JSONObject range(jsarr);
         range.AddProperty("scriptIndex", script_index);
         range.AddProperty("startPos", cls.token_pos());
         range.AddProperty("endPos", cls.end_token_pos());


### PR DESCRIPTION
Remove empty coverage in case of non-null library_filters