### PR TITLE
[vm] Bug fix in dedup optimization when build deferred components.

### DIFF
--- a/runtime/tests/vm/dart/regress_49372_deferred.dart
+++ b/runtime/tests/vm/dart/regress_49372_deferred.dart
@@ -1,0 +1,12 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Regression test for https://github.com/dart-lang/sdk/issues/49372.
+// Verifies that dedup optimization doesn't merge Code from different unit.
+
+@pragma('vm:never-inline')
+int foo() => 10;
+
+@pragma('vm:never-inline')
+int bar() => foo() + 2;

--- a/runtime/tests/vm/dart/regress_49372_test.dart
+++ b/runtime/tests/vm/dart/regress_49372_test.dart
@@ -1,0 +1,21 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Regression test for https://github.com/dart-lang/sdk/issues/49372.
+// Verifies that dedup optimization doesn't merge Code from different unit.
+
+import 'package:expect/expect.dart';
+import 'regress_49372_deferred.dart' deferred as lib;
+
+@pragma('vm:never-inline')
+int foo() => 10;
+
+@pragma('vm:never-inline')
+int bar() => foo() + 7;
+
+void main() async {
+  await lib.loadLibrary();
+  Expect.equals(12, lib.bar());
+  Expect.equals(17, bar());
+}

--- a/runtime/tests/vm/dart_2/regress_49372_deferred.dart
+++ b/runtime/tests/vm/dart_2/regress_49372_deferred.dart
@@ -1,0 +1,14 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Regression test for https://github.com/dart-lang/sdk/issues/49372.
+// Verifies that dedup optimization doesn't merge Code from different unit.
+
+// @dart = 2.9
+
+@pragma('vm:never-inline')
+int foo() => 10;
+
+@pragma('vm:never-inline')
+int bar() => foo() + 2;

--- a/runtime/tests/vm/dart_2/regress_49372_test.dart
+++ b/runtime/tests/vm/dart_2/regress_49372_test.dart
@@ -1,0 +1,23 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Regression test for https://github.com/dart-lang/sdk/issues/49372.
+// Verifies that dedup optimization doesn't merge Code from different unit.
+
+// @dart = 2.9
+
+import 'package:expect/expect.dart';
+import 'regress_49372_deferred.dart' deferred as lib;
+
+@pragma('vm:never-inline')
+int foo() => 10;
+
+@pragma('vm:never-inline')
+int bar() => foo() + 7;
+
+void main() async {
+  await lib.loadLibrary();
+  Expect.equals(12, lib.bar());
+  Expect.equals(17, bar());
+}

--- a/runtime/vm/compiler/backend/flow_graph_compiler.cc
+++ b/runtime/vm/compiler/backend/flow_graph_compiler.cc
@@ -3606,49 +3606,22 @@ void FlowGraphCompiler::EmitMoveFromNative(
   }
 }
 
-// The assignment to loading units here must match that in
-// AssignLoadingUnitsCodeVisitor, which runs after compilation is done.
-static intptr_t LoadingUnitOf(Zone* zone, const Function& function) {
-  const Class& cls = Class::Handle(zone, function.Owner());
-  const Library& lib = Library::Handle(zone, cls.library());
-  const LoadingUnit& unit = LoadingUnit::Handle(zone, lib.loading_unit());
-  ASSERT(!unit.IsNull());
-  return unit.id();
-}
-
-static intptr_t LoadingUnitOf(Zone* zone, const Code& code) {
-  // No WeakSerializationReference owners here because those are only
-  // introduced during AOT serialization.
-  if (code.IsStubCode() || code.IsTypeTestStubCode()) {
-    return LoadingUnit::kRootId;
-  } else if (code.IsAllocationStubCode()) {
-    const Class& cls = Class::Cast(Object::Handle(zone, code.owner()));
-    const Library& lib = Library::Handle(zone, cls.library());
-    const LoadingUnit& unit = LoadingUnit::Handle(zone, lib.loading_unit());
-    ASSERT(!unit.IsNull());
-    return unit.id();
-  } else if (code.IsFunctionCode()) {
-    return LoadingUnitOf(zone,
-                         Function::Cast(Object::Handle(zone, code.owner())));
-  } else {
-    UNREACHABLE();
-    return LoadingUnit::kIllegalId;
-  }
-}
-
 bool FlowGraphCompiler::CanPcRelativeCall(const Function& target) const {
   return FLAG_precompiled_mode &&
-         (LoadingUnitOf(zone_, function()) == LoadingUnitOf(zone_, target));
+         (LoadingUnit::LoadingUnitOf(zone_, function()) ==
+          LoadingUnit::LoadingUnitOf(zone_, target));
 }
 
 bool FlowGraphCompiler::CanPcRelativeCall(const Code& target) const {
   return FLAG_precompiled_mode && !target.InVMIsolateHeap() &&
-         (LoadingUnitOf(zone_, function()) == LoadingUnitOf(zone_, target));
+         (LoadingUnit::LoadingUnitOf(zone_, function()) ==
+          LoadingUnit::LoadingUnitOf(zone_, target));
 }
 
 bool FlowGraphCompiler::CanPcRelativeCall(const AbstractType& target) const {
   return FLAG_precompiled_mode && !target.InVMIsolateHeap() &&
-         (LoadingUnitOf(zone_, function()) == LoadingUnit::kRootId);
+         (LoadingUnit::LoadingUnitOf(zone_, function()) ==
+          LoadingUnit::LoadingUnit::kRootId);
 }
 
 #undef __

--- a/runtime/vm/object.h
+++ b/runtime/vm/object.h
@@ -7432,6 +7432,10 @@ class LoadingUnit : public Object {
     return RoundedAllocationSize(sizeof(UntaggedLoadingUnit));
   }
 
+  static intptr_t LoadingUnitOf(Zone* zone, const Function& function);
+  static intptr_t LoadingUnitOf(Zone* zone, const Code& code);
+  static intptr_t LoadingUnitOf(const Code& code);
+
   LoadingUnitPtr parent() const;
   void set_parent(const LoadingUnit& value) const;
 

--- a/runtime/vm/program_visitor.cc
+++ b/runtime/vm/program_visitor.cc
@@ -1214,7 +1214,11 @@ class CodeKeyValueTrait {
     if (pair->UncheckedEntryPointOffset() != key->UncheckedEntryPointOffset()) {
       return false;
     }
-    return Instructions::Equals(pair->instructions(), key->instructions());
+    if (!Instructions::Equals(pair->instructions(), key->instructions())) {
+      return false;
+    }
+    return LoadingUnit::LoadingUnitOf(*pair) ==
+           LoadingUnit::LoadingUnitOf(*key);
   }
 };
 #endif

--- a/runtime/vm/reusable_handles.h
+++ b/runtime/vm/reusable_handles.h
@@ -96,6 +96,8 @@ REUSABLE_HANDLE_LIST(REUSABLE_SCOPE)
   ReusableInstanceHandleScope reused_instance_handle(thread);
 #define REUSABLE_LIBRARY_HANDLESCOPE(thread)                                   \
   ReusableLibraryHandleScope reused_library_handle(thread);
+#define REUSABLE_LOADING_UNIT_HANDLESCOPE(thread)                              \
+  ReusableLoadingUnitHandleScope reused_loading_unit_handle(thread);
 #define REUSABLE_OBJECT_HANDLESCOPE(thread)                                    \
   ReusableObjectHandleScope reused_object_handle(thread);
 #define REUSABLE_PC_DESCRIPTORS_HANDLESCOPE(thread)                            \

--- a/runtime/vm/thread.h
+++ b/runtime/vm/thread.h
@@ -84,6 +84,7 @@ class Thread;
   V(GrowableObjectArray)                                                       \
   V(Instance)                                                                  \
   V(Library)                                                                   \
+  V(LoadingUnit)                                                               \
   V(Object)                                                                    \
   V(PcDescriptors)                                                             \
   V(Smi)                                                                       \


### PR DESCRIPTION
`Dedup optimization` will remove duplicated Code object and keep one instance.
When building deferred components, the only Code object (e.x. as callee B) maybe
exist in different loading unit from the caller A. This will cause a rellocation
bug if A->B was a relative call.

Add a flag to indicate building with deferred components.
When working with dedup and deferred components, assignUnit first and
Code object from different unit is unequal.

Issues: https://github.com/dart-lang/sdk/issues/49372

Signed-off-by: fangzheyuan <fangzheyuan@bytedance.com>