### PR TITLE
Build fixes for Windows on Arm

### DIFF
--- a/build/vs_toolchain.py
+++ b/build/vs_toolchain.py
@@ -443,13 +443,15 @@ def _CopyDebugger(target_dir, target_cpu):
                         ('api-ms-win-eventing-provider-l1-1-0.dll', False)])
   for debug_file, is_optional in debug_files:
     full_path = os.path.join(win_sdk_dir, 'Debuggers', target_cpu, debug_file)
+    ignore_missing = os.environ.get('IGNORE_MISSING_DEBUG_DLL')
     if not os.path.exists(full_path):
-      if is_optional:
+      if is_optional or ignore_missing:
         continue
       else:
         raise Exception('%s not found in "%s"\r\nYou must install '
                         'Windows 10 SDK version 10.0.20348.0 including the '
-                        '"Debugging Tools for Windows" feature.' %
+                        '"Debugging Tools for Windows" feature.'
+                        'You can set IGNORE_MISSING_DEBUG_DLL to bypass this.' %
                         (debug_file, full_path))
     target_path = os.path.join(target_dir, debug_file)
     _CopyRuntimeImpl(target_path, full_path)

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -176,7 +176,7 @@ def HostArchitectures():
             # X64 Macs no longer support IA32.
             return ['x64']
     else:
-        if m in ['aarch64', 'arm64', 'arm64e']:
+        if m in ['aarch64', 'arm64', 'arm64e', 'ARM64']:
             return ['arm64']
         if m in ['armv7l']:
             return ['arm']


### PR DESCRIPTION
As part of Linaro [Windows on Arm project](https://www.linaro.org/windows-on-arm/), we are helping to enable some projects for this new platform.
Dart/Flutter is on our list, and we are willing to make it work for this platform. Luckily, a lot of work has already been done by Dart community (thanks!), and only a few bits are missing.

This PR fixes build of dart-sdk for windows on arm (natively) when using a "vanilla" visual studio installation.
After contacting @rmacnak-google (who ported for this platform), it seems build was not tried out of google infrastructure, which seems to have some custom setup.

```python3 ./tools/build.py --arch arm64 --mode release```, now results in a working build.

Please see individual commits for details.