### PR TITLE
Fixing broken URL in the analyzer package

### DIFF
--- a/pkg/analyzer/lib/dart/element/element.dart
+++ b/pkg/analyzer/lib/dart/element/element.dart
@@ -5,7 +5,7 @@
 /// Defines the element model. The element model describes the semantic (as
 /// opposed to syntactic) structure of Dart code. The syntactic structure of the
 /// code is modeled by the [AST
-/// structure](../analyzer.dart.ast.ast/analyzer.dart.ast.ast-library.html).
+/// structure](../dart_ast_ast/dart_ast_ast-library.html).
 ///
 /// The element model consists of two closely related kinds of objects: elements
 /// (instances of a subclass of [Element]) and types. This library defines the


### PR DESCRIPTION
The URL is broken as it can be seen here at the end of the first paragraph:

- https://pub.dev/documentation/analyzer/latest/dart_element_element/dart_element_element-library.html  

The broken URL before the fix was:
 - https://pub.dev/documentation/analyzer/latest/analyzer.dart.ast.ast/analyzer.dart.ast.ast-library.html 

After the fix, it should be: 
- https://pub.dev/documentation/analyzer/latest/dart_ast_ast/dart_ast_ast-library.html