### PR TITLE
Docs: Update broken link for Random.secure

### DIFF
--- a/sdk/lib/math/random.dart
+++ b/sdk/lib/math/random.dart
@@ -9,7 +9,7 @@ part of dart.math;
 /// The default implementation supplies a stream of pseudo-random bits that are
 /// not suitable for cryptographic purposes.
 ///
-/// Use the [Random.secure]() constructor for cryptographic purposes.
+/// Use the [Random.secure] constructor for cryptographic purposes.
 ///
 /// To create a non-negative random integer uniformly distributed in the range
 /// from 0, inclusive, to max, exclusive, use [nextInt(int max)].


### PR DESCRIPTION
This PR fixes the broken link for `Random.secure()` doc under the `Random()` documentation section
Refer: https://api.flutter.dev/flutter/dart-math/Random-class.html