### PR TITLE
[VM] trigger message notify callback for each non-service message that came in while message handler was paused.

### DIFF
--- a/runtime/vm/isolate.cc
+++ b/runtime/vm/isolate.cc
@@ -3572,6 +3572,8 @@ void Isolate::PauseEventHandler() {
                1, std::memory_order_acq_rel) > 0) {
       saved_notify_callback(Api::CastIsolate(this));
     }
+  } else {
+    wake_pause_event_handler_count_.store(0);
   }
   set_message_notify_callback(saved_notify_callback);
   Dart_ExitScope();

--- a/runtime/vm/isolate.cc
+++ b/runtime/vm/isolate.cc
@@ -3502,13 +3502,11 @@ InstancePtr Isolate::LookupServiceExtensionHandler(const String& name) {
 
 void Isolate::WakePauseEventHandler(Dart_Isolate isolate) {
   Isolate* iso = reinterpret_cast<Isolate*>(isolate);
-
   MonitorLocker ml(iso->pause_loop_monitor_);
   ml.Notify();
 
   Dart_MessageNotifyCallback current_notify_callback =
       iso->message_notify_callback();
-
   // It is possible that WakePauseEventHandler was replaced by original callback
   // while waiting for pause_loop_monitor_. In that case PauseEventHandler
   // is no longer running and the original callback needs to be invoked instead

--- a/runtime/vm/isolate.h
+++ b/runtime/vm/isolate.h
@@ -1712,6 +1712,8 @@ class Isolate : public BaseIsolate, public IntrusiveDListEntry<Isolate> {
 
   std::unique_ptr<VirtualMemory> regexp_backtracking_stack_cache_ = nullptr;
 
+  std::atomic<intptr_t> wake_pause_event_handler_count_;
+
   static Dart_IsolateGroupCreateCallback create_group_callback_;
   static Dart_InitializeIsolateCallback initialize_callback_;
   static Dart_IsolateShutdownCallback shutdown_callback_;

--- a/runtime/vm/isolate.h
+++ b/runtime/vm/isolate.h
@@ -1712,7 +1712,7 @@ class Isolate : public BaseIsolate, public IntrusiveDListEntry<Isolate> {
 
   std::unique_ptr<VirtualMemory> regexp_backtracking_stack_cache_ = nullptr;
 
-  std::atomic<intptr_t> wake_pause_event_handler_count_;
+  intptr_t wake_pause_event_handler_count_;
 
   static Dart_IsolateGroupCreateCallback create_group_callback_;
   static Dart_InitializeIsolateCallback initialize_callback_;


### PR DESCRIPTION
Fixes https://github.com/dart-lang/sdk/issues/37312

This is necessary because notify callback invocation results in one call to `Dart_HandleMessage`, which only removes a single message from the queue. 

Tested: Manually through FFI (Dart_PostCObject) while stopping on breakpoint. Without the change messages get stuck in the queue and then permanently delayed.