### PR TITLE
Fix `generate_idefiles.py` fails to work on x64 MacOS

### DIFF
--- a/tools/generate_buildfiles.py
+++ b/tools/generate_buildfiles.py
@@ -68,7 +68,7 @@ def RunHostGn(options):
         '-m',
         'all',
         '-a',
-        'all',
+        options.arch or 'all',
     ]
     if options.verbose:
         gn_command.append('-v')


### PR DESCRIPTION
Close #49982