### PR TITLE
Bump emsdk revision (fix build for Windows on Arm)

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -195,7 +195,7 @@ vars = {
 
   # Emscripten is used in dart2wasm tests.
   "download_emscripten": False,
-  "emsdk_rev": "d0291b3216fbc9765d9cfc1a2103316b32a555c6",
+  "emsdk_rev": "e41b8c68a248da5f18ebd03bd0420953945d52ff",
   "emsdk_ver": "3.1.3",
 }
 


### PR DESCRIPTION
3.1.22 -> 3.1.24

Needed to fix compilation issue for Windows on Arm. Since introduction of emsdk dependency, build for Windows on Arm is broken, since 'emcc' is not found where it should be.

emsdk does not support this architecture, and an error was emitted when downloading or installing any toolchain. Waiting for native support, a simple fallback to x64 version was added to emsdk (from 3.1.24). https://github.com/emscripten-core/emsdk/commit/35358657b4763f18b6a49ddc326f8f7053ed7f49

Note: emsdk_ver is not important here, as it's the target toolchain downloaded.