### PR TITLE
Do not try to handle non ZX_PKT_TYPE_SIGNAL_ONE incorrectly

### DIFF
--- a/runtime/bin/eventhandler_fuchsia.cc
+++ b/runtime/bin/eventhandler_fuchsia.cc
@@ -60,13 +60,6 @@
                      __LINE__, ##__VA_ARGS__);                                 \
     errno = err;                                                               \
   }
-#define LOG_WARN(msg, ...)                                                      \
-  {                                                                            \
-    int err = errno;                                                           \
-    Syslog::PrintErr("Dart EventHandler WARNING: %s:%d: " msg, __FILE__,         \
-                     __LINE__, ##__VA_ARGS__);                                 \
-    errno = err;                                                               \
-  }
 #if defined(EVENTHANDLER_LOG_INFO)
 #define LOG_INFO(msg, ...)                                                     \
   Syslog::Print("Dart EventHandler INFO: %s:%d: " msg, __FILE__, __LINE__,     \
@@ -561,7 +554,7 @@ void EventHandlerImplementation::HandlePacket(zx_port_packet_t* pkt) {
   }
 
   if (pkt->type != ZX_PKT_TYPE_SIGNAL_ONE) {
-    LOG_WARN("HandlePacket: Got unexpected packet type: key=%x\n", pkt->type);
+    LOG_ERR("HandlePacket: Got unexpected packet type: key=%x\n", pkt->type);
     return;
   }
   

--- a/runtime/bin/eventhandler_fuchsia.cc
+++ b/runtime/bin/eventhandler_fuchsia.cc
@@ -60,6 +60,13 @@
                      __LINE__, ##__VA_ARGS__);                                 \
     errno = err;                                                               \
   }
+#define LOG_WARN(msg, ...)                                                      \
+  {                                                                            \
+    int err = errno;                                                           \
+    Syslog::PrintErr("Dart EventHandler WARNING: %s:%d: " msg, __FILE__,         \
+                     __LINE__, ##__VA_ARGS__);                                 \
+    errno = err;                                                               \
+  }
 #if defined(EVENTHANDLER_LOG_INFO)
 #define LOG_INFO(msg, ...)                                                     \
   Syslog::Print("Dart EventHandler INFO: %s:%d: " msg, __FILE__, __LINE__,     \
@@ -555,27 +562,33 @@ void EventHandlerImplementation::HandlePacket(zx_port_packet_t* pkt) {
            pkt->signal.observed);
   LOG_INFO("HandlePacket: Got event packet: count = %ld\n", pkt->signal.count);
 
-  DescriptorInfo* di = reinterpret_cast<DescriptorInfo*>(pkt->key);
-  zx_signals_t observed = pkt->signal.observed;
-  const intptr_t old_mask = di->Mask();
-  const uint32_t epoll_event = di->io_handle()->WaitEnd(observed);
-  intptr_t event_mask = IOHandle::EpollEventsToMask(epoll_event);
-  if ((event_mask & (1 << kErrorEvent)) != 0) {
-    di->NotifyAllDartPorts(event_mask);
-  } else if (event_mask != 0) {
-    event_mask = di->io_handle()->ToggleEvents(event_mask);
-    if (event_mask != 0) {
-      Dart_Port port = di->NextNotifyDartPort(event_mask);
-      ASSERT(port != 0);
-      bool success = DartUtils::PostInt32(port, event_mask);
-      if (!success) {
-        // This can happen if e.g. the isolate that owns the port has died
-        // for some reason.
-        LOG_INFO("Failed to post event to port %ld\n", port);
+  if (pkt->type == ZX_PKT_TYPE_SIGNAL_ONE) {
+    ZX_ASSERT(pkt->key != 0);
+    DescriptorInfo* di = reinterpret_cast<DescriptorInfo*>(pkt->key);
+    zx_signals_t observed = pkt->signal.observed;
+    const intptr_t old_mask = di->Mask();
+    const uint32_t epoll_event = di->io_handle()->WaitEnd(observed);
+    intptr_t event_mask = IOHandle::EpollEventsToMask(epoll_event);
+    if ((event_mask & (1 << kErrorEvent)) != 0) {
+      di->NotifyAllDartPorts(event_mask);
+    } else if (event_mask != 0) {
+      event_mask = di->io_handle()->ToggleEvents(event_mask);
+      if (event_mask != 0) {
+        Dart_Port port = di->NextNotifyDartPort(event_mask);
+        ASSERT(port != 0);
+        bool success = DartUtils::PostInt32(port, event_mask);
+        if (!success) {
+          // This can happen if e.g. the isolate that owns the port has died
+          // for some reason.
+          LOG_INFO("Failed to post event to port %ld\n", port);
+        }
       }
     }
+    UpdatePort(old_mask, di);
+    return;
   }
-  UpdatePort(old_mask, di);
+
+  LOG_WARN("HandlePacket: Got unexpected packet type: key=%x\n", pkt->type);
 }
 
 int64_t EventHandlerImplementation::GetTimeout() const {

--- a/runtime/bin/eventhandler_fuchsia.cc
+++ b/runtime/bin/eventhandler_fuchsia.cc
@@ -17,6 +17,7 @@
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include <zircon/assert.h>
 #include <zircon/status.h>
 #include <zircon/syscalls.h>
 #include <zircon/syscalls/object.h>


### PR DESCRIPTION
Do not try to handle non ZX_PKT_TYPE_SIGNAL_ONE packets as ZX_PKT_TYPE_SIGNAL_ONE packets.  Doing so causes exceptions when reading from the union in zx_port_packet_t.

Warn when we get a packet type we don't expect, so we can decide if we want to handle it.

Also asserts that `pkt->key != 0`, to detect such errors.

Tested: by building for fuchsia and testing on Nest Hub device.

BUG: b/253491057