### PR TITLE
Deleted repetition "/// (We return the string)" from the Documentation of DartObject.toSymbolValue

### DIFF
--- a/pkg/analyzer/lib/dart/constant/value.dart
+++ b/pkg/analyzer/lib/dart/constant/value.dart
@@ -136,7 +136,6 @@ abstract class DartObject {
   /// or `null` if
   /// * this object is not of type 'Symbol', or
   /// * the value of the object being represented is `null`.
-  /// (We return the string
   String? toSymbolValue();
 
   /// Return the representation of the type corresponding to the value of the


### PR DESCRIPTION
…n of DartObject.toSymbolValue

Deleted "/// (We return the string)" from the documentation of `DartObject.toSymbolValue` because it is a repetition of the first sentence and it seems to be a residue of a internal temporary description. If the "/// (We return the string" was meant to stay here, then the closing ")" is missing.