### PR TITLE
docs(Duration): fix typo in `compareTo` method

### DIFF
--- a/sdk/lib/core/duration.dart
+++ b/sdk/lib/core/duration.dart
@@ -314,7 +314,7 @@ class Duration implements Comparable<Duration> {
   ///
   /// A negative [Duration] is always considered shorter than a positive one.
   ///
-  /// It is always the case that `duration1.compareTo(duration2) < 0` iff
+  /// It is always the case that `duration1.compareTo(duration2) < 0` if
   /// `(someDate + duration1).compareTo(someDate + duration2) < 0`.
   int compareTo(Duration other) => _duration.compareTo(other._duration);
 


### PR DESCRIPTION
Fixes small typo in  `compareTo` method of `Duration`.