### PR TITLE
Removed `Finalizer`s from the unsupported features by dart:ffi

### DIFF
--- a/samples/ffi/sqlite/docs/sqlite-tutorial.md
+++ b/samples/ffi/sqlite/docs/sqlite-tutorial.md
@@ -219,7 +219,6 @@ Features which we did not use in this tutorial:
 Features which `dart:ffi` does not support yet:
 
 * Callbacks from C back into Dart.
-* Finalizers
 * C++ Exceptions (Not on roadmap yet.)
 
 Platform limitations:


### PR DESCRIPTION
As dart:ffi now supports `Finalizer`s, they should be removed from the unsupported features list.