### PR TITLE
Leave `dependencies:` node uncommented

### DIFF
--- a/pkg/dartdev/lib/src/templates/console.dart
+++ b/pkg/dartdev/lib/src/templates/console.dart
@@ -44,7 +44,8 @@ version: 1.0.0
 environment:
   ${common.sdkConstraint}
 
-# dependencies:
+dependencies:
+# Add regular dependencies here, for example:
 #   path: ^1.8.0
 
 dev_dependencies:


### PR DESCRIPTION
Ideally we'd leave the `dependencies:` node itself uncommented, even if the content beneath it is commented out. If the node is commented, then VSCode's "Dart: Add Dependency" command gets confused, and adds a new node at the bottom, rather than uncommenting the `dependencies:` node. 

This change should be benign, and removes the need for Dart-Code to introduce logic to uncomment the parent node. For finesse, this also adds an explanatory comment to indicate that `path:` is an example.