### PR TITLE
Spelling runtime vm compiler

### DIFF
--- a/runtime/vm/compiler/aot/precompiler.cc
+++ b/runtime/vm/compiler/aot/precompiler.cc
@@ -3767,7 +3767,7 @@ Obfuscator::Obfuscator(Thread* thread, const String& private_key)
   }
   auto zone = thread->zone();
 
-  // Create ObfuscationState from ObjectStore::obfusction_map().
+  // Create ObfuscationState from ObjectStore::obfuscation_map().
   ObjectStore* store = isolate_group->object_store();
   Array& obfuscation_state = Array::Handle(zone, store->obfuscation_map());
 

--- a/runtime/vm/compiler/aot/precompiler.cc
+++ b/runtime/vm/compiler/aot/precompiler.cc
@@ -2468,7 +2468,7 @@ static bool IsUserDefinedClass(Zone* zone,
 }
 
 /// Updates |visited| weak table with information about whether object
-/// (transitevly) references constants of user-defined classes: |kDrop|
+/// (transitively) references constants of user-defined classes: |kDrop|
 /// indicates it does, |kRetain| - does not.
 class ConstantInstanceVisitor {
  public:

--- a/runtime/vm/compiler/aot/precompiler.h
+++ b/runtime/vm/compiler/aot/precompiler.h
@@ -612,7 +612,7 @@ class Obfuscator : public ValueObject {
     String& renamed_;
   };
 
-  // Current obfucation state or NULL if obfuscation is not enabled.
+  // Current obfuscation state or NULL if obfuscation is not enabled.
   ObfuscationState* state_;
 };
 #else

--- a/runtime/vm/compiler/assembler/assembler_arm.h
+++ b/runtime/vm/compiler/assembler/assembler_arm.h
@@ -1599,7 +1599,7 @@ class Assembler : public AssemblerBase {
   // beginning of the branch instruction.
   //
   // Use this function for testing whether [distance] can be encoded using the
-  // 24-bit offets in the branch instructions, which are multiples of 4.
+  // 24-bit offsets in the branch instructions, which are multiples of 4.
   static bool CanEncodeBranchDistance(int32_t distance) {
     ASSERT(Utils::IsAligned(distance, 4));
     // The distance is off by 8 due to the way the ARM CPUs read PC.

--- a/runtime/vm/compiler/assembler/disassembler_arm.cc
+++ b/runtime/vm/compiler/assembler/disassembler_arm.cc
@@ -941,11 +941,11 @@ void ARMDecoder::DecodeType3(Instr* instr) {
       }
       // Check differences between A8.8.{165,248} and FormatRegister.
       static_assert(kDivRdShift == kRnShift,
-                    "div 'rd does not corresspond to 'rn");
+                    "div 'rd does not correspond to 'rn");
       static_assert(kDivRmShift == kRsShift,
-                    "div 'rm does not corresspond to 'rs");
+                    "div 'rm does not correspond to 'rs");
       static_assert(kDivRnShift == kRmShift,
-                    "div 'rn does not corresspond to 'rm");
+                    "div 'rn does not correspond to 'rm");
       if (instr->IsDivUnsigned()) {
         Format(instr, "udiv'cond 'rn, 'rs, 'rm");
       } else {

--- a/runtime/vm/compiler/assembler/disassembler_x86.cc
+++ b/runtime/vm/compiler/assembler/disassembler_x86.cc
@@ -1939,7 +1939,7 @@ int DisassemblerX64::InstructionDecode(uword pc) {
         break;
 
       // These encodings for inc and dec are IA32 only, but we don't get here
-      // on X64 - the REX prefix recoginizer catches them earlier.
+      // on X64 - the REX prefix recognizer catches them earlier.
       case 0x40:
       case 0x41:
       case 0x42:

--- a/runtime/vm/compiler/backend/constant_propagator.cc
+++ b/runtime/vm/compiler/backend/constant_propagator.cc
@@ -369,7 +369,7 @@ void ConstantPropagator::VisitPhi(PhiInstr* instr) {
                  info->visit_count);
     NOT_IN_PRODUCT(
         FlowGraphPrinter::PrintGraph("Constant Propagation", graph_));
-    FATAL("Aborting due to non-covergence.");
+    FATAL("Aborting due to non-convergence.");
   }
 
   // Compute the join over all the reachable predecessor values.

--- a/runtime/vm/compiler/backend/flow_graph.cc
+++ b/runtime/vm/compiler/backend/flow_graph.cc
@@ -1643,7 +1643,7 @@ void FlowGraph::ValidatePhis() {
           if (phi == nullptr && !IsImmortalVariable(j)) {
             // We have no phi node for the this variable.
             // Double check we do not have a different value in our env.
-            // If we do, we would have needed a phi-node in the successsor.
+            // If we do, we would have needed a phi-node in the successor.
             ASSERT(last_instruction->env() != nullptr);
             Definition* current_definition =
                 last_instruction->env()->ValueAt(j)->definition();

--- a/runtime/vm/compiler/backend/flow_graph_compiler.cc
+++ b/runtime/vm/compiler/backend/flow_graph_compiler.cc
@@ -3570,7 +3570,7 @@ void FlowGraphCompiler::EmitNativeMove(
     return;
   }
 
-  // Solve descrepancies between container size and payload size.
+  // Solve discrepancies between container size and payload size.
   if (src_payload_type.IsInt() && dst_payload_type.IsInt() &&
       (src_payload_size != src_container_size ||
        dst_payload_size != dst_container_size)) {

--- a/runtime/vm/compiler/backend/flow_graph_compiler.h
+++ b/runtime/vm/compiler/backend/flow_graph_compiler.h
@@ -570,7 +570,7 @@ class FlowGraphCompiler : public ValueObject {
     return used_static_fields_;
   }
 
-  // Constructor is lighweight, major initialization work should occur here.
+  // Constructor is lightweight, major initialization work should occur here.
   // This makes it easier to measure time spent in the compiler.
   void InitCompiler();
 

--- a/runtime/vm/compiler/backend/il.cc
+++ b/runtime/vm/compiler/backend/il.cc
@@ -2558,7 +2558,7 @@ Definition* Definition::Canonicalize(FlowGraph* flow_graph) {
 }
 
 Definition* RedefinitionInstr::Canonicalize(FlowGraph* flow_graph) {
-  // Must not remove Redifinitions without uses until LICM, even though
+  // Must not remove Redefinitions without uses until LICM, even though
   // Redefinition might not have any uses itself it can still be dominating
   // uses of the value it redefines and must serve as a barrier for those
   // uses. RenameUsesDominatedByRedefinitions would normalize the graph and

--- a/runtime/vm/compiler/backend/il.cc
+++ b/runtime/vm/compiler/backend/il.cc
@@ -6905,7 +6905,7 @@ void FfiCallInstr::EmitParamMoves(FlowGraphCompiler* compiler,
                    compiler::FieldAddress(
                        temp0, compiler::target::PointerBase::data_offset()));
 
-      // Copy chuncks.
+      // Copy chunks.
       const intptr_t sp_offset =
           marshaller_.PassByPointerStackOffset(arg_index);
       // Struct size is rounded up to a multiple of target::kWordSize.

--- a/runtime/vm/compiler/backend/il.cc
+++ b/runtime/vm/compiler/backend/il.cc
@@ -3316,7 +3316,7 @@ Definition* IntConverterInstr::Canonicalize(FlowGraph* flow_graph) {
   UnboxInt64Instr* unbox_defn = value()->definition()->AsUnboxInt64();
   if (unbox_defn != NULL && (from() == kUnboxedInt64) &&
       (to() == kUnboxedInt32) && unbox_defn->HasOnlyInputUse(value())) {
-    // TODO(vegorov): there is a duplication of code between UnboxedIntCoverter
+    // TODO(vegorov): there is a duplication of code between UnboxedIntConverter
     // and code path that unboxes Mint into Int32. We should just schedule
     // these instructions close to each other instead of fusing them.
     Definition* replacement =

--- a/runtime/vm/compiler/backend/il.cc
+++ b/runtime/vm/compiler/backend/il.cc
@@ -3936,7 +3936,7 @@ const CallTargets* CallTargets::CreateAndExpand(Zone* zone,
     // into a suffix that consists purely of abstract classes to
     // shorten the range.
     // However such spreading is beneficial when it allows to
-    // merge to consequtive ranges.
+    // merge to consecutive ranges.
     intptr_t cid_end_including_abstract = target_info->cid_end;
     for (int i = target_info->cid_end + 1; i < upper_limit_cid; i++) {
       bool class_is_abstract = false;

--- a/runtime/vm/compiler/backend/il.h
+++ b/runtime/vm/compiler/backend/il.h
@@ -2105,7 +2105,7 @@ class TargetEntryInstr : public BlockEntryInstr {
 // Represents an entrypoint to a function which callers can invoke (i.e. not
 // used for OSR entries).
 //
-// The flow graph builder might decide to create create multiple entrypoints
+// The flow graph builder might decide to create multiple entrypoints
 // (e.g. checked/unchecked entrypoints) and will attach those to the
 // [GraphEntryInstr].
 //

--- a/runtime/vm/compiler/backend/il.h
+++ b/runtime/vm/compiler/backend/il.h
@@ -6658,7 +6658,7 @@ class RecordCoverageInstr : public TemplateInstruction<0, NoThrow> {
   DISALLOW_COPY_AND_ASSIGN(RecordCoverageInstr);
 };
 
-// Note overrideable, built-in: value ? false : true.
+// Note overridable, built-in: value ? false : true.
 class BooleanNegateInstr : public TemplateDefinition<1, NoThrow> {
  public:
   explicit BooleanNegateInstr(Value* value) { SetInputAt(0, value); }

--- a/runtime/vm/compiler/backend/il.h
+++ b/runtime/vm/compiler/backend/il.h
@@ -2977,7 +2977,7 @@ class StoreIndexedUnsafeInstr : public TemplateInstruction<2, NoThrow> {
 //
 // Currently this instruction uses pinpoints the register to be FP.
 //
-// This lowlevel instruction is non-inlinable since it makes assumptons about
+// This lowlevel instruction is non-inlinable since it makes assumptions about
 // the frame.  This is asserted via `inliner.cc::CalleeGraphValidator`.
 class LoadIndexedUnsafeInstr : public TemplateDefinition<1, NoThrow> {
  public:
@@ -3116,7 +3116,7 @@ class MemoryCopyInstr : public TemplateInstruction<5, NoThrow> {
 // usual location (stack or LR).  The arguments descriptor supplied by the
 // original caller will be put into ARGS_DESC_REG.
 //
-// This lowlevel instruction is non-inlinable since it makes assumptons about
+// This lowlevel instruction is non-inlinable since it makes assumptions about
 // the frame.  This is asserted via `inliner.cc::CalleeGraphValidator`.
 class TailCallInstr : public TemplateInstruction<1, Throws, Pure> {
  public:

--- a/runtime/vm/compiler/backend/il.h
+++ b/runtime/vm/compiler/backend/il.h
@@ -3491,7 +3491,7 @@ class GotoInstr : public TemplateInstruction<0, NoThrow> {
 // The FlowGraphCompiler will - as a post-processing step - invoke
 // [ComputeOffsetTable] of all [IndirectGotoInstr]s. In there we initialize a
 // TypedDataInt32Array containing offsets of all [IndirectEntryInstr]s (the
-// offests are relative to start of the instruction payload).
+// offsets are relative to start of the instruction payload).
 //
 //  => See `FlowGraphCompiler::CompileGraph()`
 //  => See `IndirectGotoInstr::ComputeOffsetTable`

--- a/runtime/vm/compiler/backend/il.h
+++ b/runtime/vm/compiler/backend/il.h
@@ -10345,7 +10345,7 @@ class LoadThreadInstr : public TemplateDefinition<0, NoThrow, Pure> {
 // All SIMD intrinsics and recognized methods are represented via instances
 // of SimdOpInstr, a particular type of SimdOp is selected by SimdOpInstr::Kind.
 //
-// Defines below are used to contruct SIMD_OP_LIST - a list of all SIMD
+// Defines below are used to construct SIMD_OP_LIST - a list of all SIMD
 // operations. SIMD_OP_LIST contains information such as arity, input types and
 // output type for each SIMD op and is used to derive things like input
 // and output representations, type of return value, etc.

--- a/runtime/vm/compiler/backend/il.h
+++ b/runtime/vm/compiler/backend/il.h
@@ -1029,7 +1029,7 @@ class Instruction : public ZoneAllocated {
 
   virtual bool ComputeCanDeoptimizeAfterCall() const {
     // TODO(dartbug.com/45213): Incrementally migrate IR instructions from using
-    // [ComputeCanDeoptimze] to either [ComputeCanDeoptimizeAfterCall] if they
+    // [ComputeCanDeoptimize] to either [ComputeCanDeoptimizeAfterCall] if they
     // can only lazy deoptimize.
     return false;
   }

--- a/runtime/vm/compiler/backend/il.h
+++ b/runtime/vm/compiler/backend/il.h
@@ -4676,7 +4676,7 @@ class PolymorphicInstanceCallInstr : public InstanceCallBaseInstr {
 
   virtual intptr_t CallCount() const;
 
-  // If this polymophic call site was created to cover the remaining cids after
+  // If this polymorphic call site was created to cover the remaining cids after
   // inlining then we need to keep track of the total number of calls including
   // the ones that we inlined. This is different from the CallCount above:  Eg
   // if there were 100 calls originally, distributed across three class-ids in

--- a/runtime/vm/compiler/backend/inliner.cc
+++ b/runtime/vm/compiler/backend/inliner.cc
@@ -1519,7 +1519,7 @@ class CallSiteInliner : public ValueObject {
   }
 
   void PrintInlinedInfoFor(const Function& caller, intptr_t depth) {
-    // Prevent duplicate printing as inlined_info aggregates all inlinining.
+    // Prevent duplicate printing as inlined_info aggregates all inlining.
     GrowableArray<intptr_t> call_instructions_printed;
     // Print those that were inlined.
     for (intptr_t i = 0; i < inlined_info_.length(); i++) {

--- a/runtime/vm/compiler/backend/loops.cc
+++ b/runtime/vm/compiler/backend/loops.cc
@@ -445,7 +445,7 @@ void InductionVarAnalysis::ClassifyControl(LoopInfo* loop) {
     // conditions like i <= U as upperbound or i >= L as lowerbound since this
     // could loop forever when U is kMaxInt64 or L is kMinInt64 under Dart's
     // 64-bit arithmetic wrap-around. Non-unit strides could overshoot the
-    // bound due to aritmetic wrap-around.
+    // bound due to arithmetic wrap-around.
     switch (cmp) {
       case Token::kLT:
         // Accept i < U (i++).

--- a/runtime/vm/compiler/backend/loops.cc
+++ b/runtime/vm/compiler/backend/loops.cc
@@ -65,7 +65,7 @@ class InductionVarAnalysis : public ValueObject {
   void ClassifyControl(LoopInfo* loop);
 
   // Transfer methods. Compute how induction of the operands, if any,
-  // tranfers over the operation performed by the given definition.
+  // transfers over the operation performed by the given definition.
   InductionVar* TransferPhi(LoopInfo* loop, Definition* def, intptr_t idx = -1);
   InductionVar* TransferDef(LoopInfo* loop, Definition* def);
   InductionVar* TransferBinary(LoopInfo* loop, Definition* def);

--- a/runtime/vm/compiler/backend/loops.h
+++ b/runtime/vm/compiler/backend/loops.h
@@ -288,7 +288,7 @@ class LoopInfo : public ZoneAllocated {
   // Header of loop.
   BlockEntryInstr* header_;
 
-  // Compact represention of every block in the loop,
+  // Compact representation of every block in the loop,
   // indexed by its "preorder_number".
   BitVector* blocks_;
 

--- a/runtime/vm/compiler/backend/loops.h
+++ b/runtime/vm/compiler/backend/loops.h
@@ -72,7 +72,7 @@ class InductionVar : public ZoneAllocated {
     }
   }
 
-  // Returns true if the other induction is structually equivalent.
+  // Returns true if the other induction is structurally equivalent.
   bool IsEqual(const InductionVar* other) const {
     ASSERT(other != nullptr);
     if (kind_ == other->kind_) {

--- a/runtime/vm/compiler/backend/range_analysis.cc
+++ b/runtime/vm/compiler/backend/range_analysis.cc
@@ -1367,7 +1367,7 @@ void RangeAnalysis::MarkUnreachableBlocks() {
     if (Range::IsUnknown(constraints_[i]->range())) {
       TargetEntryInstr* target = constraints_[i]->target();
       if (target == NULL) {
-        // TODO(vegorov): replace Constraint with an uncoditional
+        // TODO(vegorov): replace Constraint with an unconditional
         // deoptimization and kill all dominated dead code.
         continue;
       }

--- a/runtime/vm/compiler/backend/redundancy_elimination.cc
+++ b/runtime/vm/compiler/backend/redundancy_elimination.cc
@@ -169,7 +169,7 @@ class Place : public ValueObject {
     // nullptr instance.
     kStaticField,
 
-    // Instance field location. It is reprensented by a pair of instance
+    // Instance field location. It is represented by a pair of instance
     // and a Slot.
     kInstanceField,
 

--- a/runtime/vm/compiler/backend/redundancy_elimination.cc
+++ b/runtime/vm/compiler/backend/redundancy_elimination.cc
@@ -792,7 +792,7 @@ class AliasedSet : public ZoneAllocated {
 
   const PhiPlaceMoves* phi_moves() const { return phi_moves_; }
 
-  void RollbackAliasedIdentites() {
+  void RollbackAliasedIdentities() {
     for (intptr_t i = 0; i < identity_rollback_.length(); ++i) {
       identity_rollback_[i]->SetIdentity(AliasIdentity::Unknown());
     }
@@ -1783,7 +1783,7 @@ class LoadOptimizer : public ValueObject {
     }
   }
 
-  ~LoadOptimizer() { aliased_set_->RollbackAliasedIdentites(); }
+  ~LoadOptimizer() { aliased_set_->RollbackAliasedIdentities(); }
 
   Zone* zone() const { return graph_->zone(); }
 

--- a/runtime/vm/compiler/backend/redundancy_elimination.cc
+++ b/runtime/vm/compiler/backend/redundancy_elimination.cc
@@ -949,7 +949,7 @@ class AliasedSet : public ZoneAllocated {
   }
 
   // When computing kill sets we let less generic alias insert its
-  // representatives into more generic alias'es kill set. For example
+  // representatives into more generic aliases kill set. For example
   // when visiting alias X[*] instead of searching for all aliases X[C]
   // and inserting their representatives into kill set for X[*] we update
   // kill set for X[*] each time we visit new X[C] for some C.

--- a/runtime/vm/compiler/backend/redundancy_elimination.cc
+++ b/runtime/vm/compiler/backend/redundancy_elimination.cc
@@ -3310,7 +3310,7 @@ enum SafeUseCheck { kOptimisticCheck, kStrictCheck };
 //     - strict, when only marked allocations are assumed to be allocation
 //       sinking candidates.
 //
-// Fix-point algorithm in CollectCandiates first collects a set of allocations
+// Fix-point algorithm in CollectCandidates first collects a set of allocations
 // optimistically and then checks each collected candidate strictly and unmarks
 // invalid candidates transitively until only strictly valid ones remain.
 static bool IsSafeUse(Value* use, SafeUseCheck check_type) {

--- a/runtime/vm/compiler/backend/redundancy_elimination.cc
+++ b/runtime/vm/compiler/backend/redundancy_elimination.cc
@@ -142,7 +142,7 @@ class CSEInstructionSet : public ValueObject {
 //     of the data type. Obviously X[C|S] and X[K|U] alias if and only if either
 //     C = RoundDown(K, S) or K = RoundDown(C, U).
 //     Note that not all accesses to typed data are aligned: e.g. ByteData
-//     allows unanaligned access through it's get*/set* methods.
+//     allows unaligned access through it's get*/set* methods.
 //     Check in Place::SetIndex ensures that we never create a place X[C|S]
 //     such that C is not aligned by S.
 //

--- a/runtime/vm/compiler/backend/type_propagator.cc
+++ b/runtime/vm/compiler/backend/type_propagator.cc
@@ -1016,7 +1016,7 @@ CompileType* Value::Type() {
 
 void Value::SetReachingType(CompileType* type) {
   // If [type] is owned but not by the definition which flows into this use
-  // then we need to disconect the type from original owner by cloning it.
+  // then we need to disconnect the type from original owner by cloning it.
   // This is done to prevent situations when [type] is updated by its owner
   // but [owner] is no longer connected to this use through def-use chain
   // and as a result type propagator does not recompute type of the current

--- a/runtime/vm/compiler/backend/type_propagator.cc
+++ b/runtime/vm/compiler/backend/type_propagator.cc
@@ -913,7 +913,7 @@ static bool CanPotentiallyBeSmi(const AbstractType& type, bool recurse) {
     return !recurse || CanPotentiallyBeSmi(AbstractType::Handle(param.bound()),
                                            /*recurse=*/false);
   } else if (type.HasTypeClass()) {
-    // If this is an unstantiated type then it can only potentially be a super
+    // If this is an uninstantiated type then it can only potentially be a super
     // type of a Smi if it is either FutureOr<...> or Comparable<...>.
     // In which case we need to look at the type argument to determine whether
     // this location can contain a smi.

--- a/runtime/vm/compiler/compiler_pass.cc
+++ b/runtime/vm/compiler/compiler_pass.cc
@@ -461,7 +461,7 @@ COMPILER_PASS(OptimisticallySpecializeSmiPhis, {
 
 COMPILER_PASS(WidenSmiToInt32, {
   // Where beneficial convert Smi operations into Int32 operations.
-  // Only meanigful for 32bit platforms right now.
+  // Only meaningful for 32bit platforms right now.
   flow_graph->WidenSmiToInt32();
 });
 

--- a/runtime/vm/compiler/ffi/native_calling_convention.cc
+++ b/runtime/vm/compiler/ffi/native_calling_convention.cc
@@ -258,12 +258,12 @@ class ArgumentAllocator : public ValueObject {
 #endif  // defined(TARGET_ARCH_IA32)
 
 #if defined(TARGET_ARCH_ARM)
-  // Transfer homogenuous floats in FPU registers, and allocate the rest
+  // Transfer homogeneous floats in FPU registers, and allocate the rest
   // in 4 or 8 size chunks in registers and stack.
   const NativeLocation& AllocateCompound(
       const NativeCompoundType& payload_type) {
     const auto& compound_type = payload_type.AsCompound();
-    if (compound_type.ContainsHomogenuousFloats() && !SoftFpAbi() &&
+    if (compound_type.ContainsHomogeneousFloats() && !SoftFpAbi() &&
         compound_type.NumPrimitiveMembersRecursive() <= 4) {
       const auto& elem_type = compound_type.FirstPrimitiveMember();
       const intptr_t size = compound_type.SizeInBytes();
@@ -329,7 +329,7 @@ class ArgumentAllocator : public ValueObject {
       const NativeCompoundType& payload_type) {
     const auto& compound_type = payload_type.AsCompound();
     const intptr_t size = compound_type.SizeInBytes();
-    if (compound_type.ContainsHomogenuousFloats() &&
+    if (compound_type.ContainsHomogeneousFloats() &&
         compound_type.NumPrimitiveMembersRecursive() <= 4) {
       const auto& elem_type = compound_type.FirstPrimitiveMember();
       const intptr_t elem_size = elem_type.SizeInBytes();
@@ -754,7 +754,7 @@ static const NativeLocation& CompoundResultLocation(
     Zone* zone,
     const NativeCompoundType& payload_type) {
   const intptr_t num_members = payload_type.NumPrimitiveMembersRecursive();
-  if (payload_type.ContainsHomogenuousFloats() && !SoftFpAbi() &&
+  if (payload_type.ContainsHomogeneousFloats() && !SoftFpAbi() &&
       num_members <= 4) {
     NativeLocations& multiple_locations =
         *new (zone) NativeLocations(zone, num_members);

--- a/runtime/vm/compiler/ffi/native_calling_convention.cc
+++ b/runtime/vm/compiler/ffi/native_calling_convention.cc
@@ -748,7 +748,7 @@ static const NativeLocation& CompoundResultLocation(
 
 #if defined(TARGET_ARCH_ARM)
 // Arm passes homogenous float return values in FPU registers and small
-// composities in a single integer register. The rest is stored into the
+// composites in a single integer register. The rest is stored into the
 // location passed in by pointer.
 static const NativeLocation& CompoundResultLocation(
     Zone* zone,

--- a/runtime/vm/compiler/ffi/native_calling_convention_test.cc
+++ b/runtime/vm/compiler/ffi/native_calling_convention_test.cc
@@ -304,7 +304,7 @@ UNIT_TEST_CASE_WITH_ZONE(NativeCallingConvention_union16bytesHomogenousx10) {
   const auto& union_type = NativeUnionType::FromNativeTypes(Z, member_types);
 
   EXPECT_EQ(16, union_type.SizeInBytes());
-  EXPECT(union_type.ContainsHomogenuousFloats());
+  EXPECT(union_type.ContainsHomogeneousFloats());
 
   auto& arguments = *new (Z) NativeTypes(Z, 13);
   arguments.Add(&union_type);

--- a/runtime/vm/compiler/ffi/native_type.cc
+++ b/runtime/vm/compiler/ffi/native_type.cc
@@ -162,7 +162,7 @@ intptr_t NativePrimitiveType::AlignmentInBytesField() const {
   }
 }
 
-static bool ContainsHomogenuousFloatsInternal(const NativeTypes& types);
+static bool ContainsHomogeneousFloatsInternal(const NativeTypes& types);
 
 // Keep consistent with
 // pkg/vm/lib/transformations/ffi_definitions.dart:StructLayout:_calculateLayout.
@@ -190,7 +190,7 @@ NativeStructType& NativeStructType::FromNativeTypes(Zone* zone,
   // However, homogenous structs are treated differently. They are aligned to
   // their member alignment. (Which is 4 in case of a homogenous float).
   // Source: manual testing.
-  if (!ContainsHomogenuousFloatsInternal(members)) {
+  if (!ContainsHomogeneousFloatsInternal(members)) {
     alignment_stack = compiler::target::kWordSize;
   }
 #endif
@@ -977,7 +977,7 @@ bool NativeUnionType::ContainsUnalignedMembers(intptr_t offset) const {
   return false;
 }
 
-static void ContainsHomogenuousFloatsRecursive(const NativeTypes& types,
+static void ContainsHomogeneousFloatsRecursive(const NativeTypes& types,
                                                bool* only_float,
                                                bool* only_double) {
   for (intptr_t i = 0; i < types.length(); i++) {
@@ -990,21 +990,21 @@ static void ContainsHomogenuousFloatsRecursive(const NativeTypes& types,
       *only_double = *only_double && (type == kDouble);
     }
     if (member_type.IsCompound()) {
-      ContainsHomogenuousFloatsRecursive(member_type.AsCompound().members(),
+      ContainsHomogeneousFloatsRecursive(member_type.AsCompound().members(),
                                          only_float, only_double);
     }
   }
 }
 
-static bool ContainsHomogenuousFloatsInternal(const NativeTypes& types) {
+static bool ContainsHomogeneousFloatsInternal(const NativeTypes& types) {
   bool only_float = true;
   bool only_double = true;
-  ContainsHomogenuousFloatsRecursive(types, &only_float, &only_double);
+  ContainsHomogeneousFloatsRecursive(types, &only_float, &only_double);
   return (only_double || only_float) && types.length() > 0;
 }
 
-bool NativeCompoundType::ContainsHomogenuousFloats() const {
-  return ContainsHomogenuousFloatsInternal(this->members());
+bool NativeCompoundType::ContainsHomogeneousFloats() const {
+  return ContainsHomogeneousFloatsInternal(this->members());
 }
 
 const NativeType& NativeType::WidenTo4Bytes(Zone* zone) const {

--- a/runtime/vm/compiler/ffi/native_type.h
+++ b/runtime/vm/compiler/ffi/native_type.h
@@ -141,7 +141,7 @@ class NativeType : public ZoneAllocated {
   virtual intptr_t NumPrimitiveMembersRecursive() const = 0;
   virtual const NativePrimitiveType& FirstPrimitiveMember() const = 0;
 
-  // Returns the number of primitive members when this aggregrate is flattened
+  // Returns the number of primitive members when this aggregate is flattened
   // out, and sets the out-parameters to the first two such primitive members.
   virtual intptr_t PrimitivePairMembers(
       const NativePrimitiveType** first,

--- a/runtime/vm/compiler/ffi/native_type.h
+++ b/runtime/vm/compiler/ffi/native_type.h
@@ -89,7 +89,7 @@ class NativeType : public ZoneAllocated {
   // Does not take into account padding required if repeating.
   virtual intptr_t SizeInBytes() const = 0;
 
-  // The alignment in bytes of this represntation on the stack.
+  // The alignment in bytes of this representation on the stack.
   virtual intptr_t AlignmentInBytesStack() const = 0;
 
   // The alignment in bytes of this representation as member of a composite.

--- a/runtime/vm/compiler/ffi/native_type.h
+++ b/runtime/vm/compiler/ffi/native_type.h
@@ -312,7 +312,7 @@ class NativeCompoundType : public NativeType {
   //
   // Useful for determining whether struct is passed in FP registers in hardfp
   // and arm64.
-  bool ContainsHomogenuousFloats() const;
+  bool ContainsHomogeneousFloats() const;
 
   virtual intptr_t NumPrimitiveMembersRecursive() const = 0;
   virtual const NativePrimitiveType& FirstPrimitiveMember() const;

--- a/runtime/vm/compiler/ffi/native_type.h
+++ b/runtime/vm/compiler/ffi/native_type.h
@@ -295,7 +295,7 @@ class NativeCompoundType : public NativeType {
 #if !defined(DART_PRECOMPILED_RUNTIME)
   virtual bool ContainsOnlyFloats(Range range) const = 0;
 
-  // Returns how many word-sized chuncks _only_ contain floats.
+  // Returns how many word-sized chunks _only_ contain floats.
   //
   // Useful for determining whether struct is passed in FP registers on x64.
   intptr_t NumberOfWordSizeChunksOnlyFloat() const;

--- a/runtime/vm/compiler/ffi/native_type_test.cc
+++ b/runtime/vm/compiler/ffi/native_type_test.cc
@@ -70,7 +70,7 @@ UNIT_TEST_CASE_WITH_ZONE(NativeCompoundType_int8x10) {
 
   const auto& struct_type = RunStructTest(Z, "struct_int8x10", members);
 
-  EXPECT(!struct_type.ContainsHomogenuousFloats());
+  EXPECT(!struct_type.ContainsHomogeneousFloats());
   EXPECT(!struct_type.ContainsOnlyFloats(Range::StartAndEnd(0, 8)));
   EXPECT_EQ(0, struct_type.NumberOfWordSizeChunksOnlyFloat());
   EXPECT_EQ(
@@ -94,7 +94,7 @@ UNIT_TEST_CASE_WITH_ZONE(NativeCompoundType_floatx4) {
   //
   // On Arm64 iOS stack alignment of homogenous floats is not word size see
   // runtime/vm/compiler/ffi/unit_tests/struct_floatx4/arm64_ios.expect.
-  EXPECT(struct_type.ContainsHomogenuousFloats());
+  EXPECT(struct_type.ContainsHomogeneousFloats());
 
   // On x64, 8-byte parts of the chunks contain only floats and will be passed
   // in FPU registers.
@@ -164,7 +164,7 @@ UNIT_TEST_CASE_WITH_ZONE(NativeCompoundType_int8array) {
   const auto& struct_type = RunStructTest(Z, "struct_int8array", members);
 
   EXPECT_EQ(8, struct_type.SizeInBytes());
-  EXPECT(!struct_type.ContainsHomogenuousFloats());
+  EXPECT(!struct_type.ContainsHomogeneousFloats());
   EXPECT(!struct_type.ContainsOnlyFloats(Range::StartAndEnd(0, 8)));
   EXPECT_EQ(0, struct_type.NumberOfWordSizeChunksOnlyFloat());
   EXPECT_EQ(
@@ -191,7 +191,7 @@ UNIT_TEST_CASE_WITH_ZONE(NativeCompoundType_floatarray) {
   const auto& struct_type = RunStructTest(Z, "struct_floatarray", members);
 
   EXPECT_EQ(16, struct_type.SizeInBytes());
-  EXPECT(struct_type.ContainsHomogenuousFloats());
+  EXPECT(struct_type.ContainsHomogeneousFloats());
   EXPECT(struct_type.ContainsOnlyFloats(Range::StartAndEnd(0, 8)));
   EXPECT_EQ(16 / compiler::target::kWordSize,
             struct_type.NumberOfWordSizeChunksOnlyFloat());
@@ -310,7 +310,7 @@ UNIT_TEST_CASE_WITH_ZONE(NativeCompoundType_union_primitive_members) {
 
   EXPECT_EQ(4, union_type.NumPrimitiveMembersRecursive());
   EXPECT(union_type.FirstPrimitiveMember().Equals(float_type));
-  EXPECT(union_type.ContainsHomogenuousFloats());
+  EXPECT(union_type.ContainsHomogeneousFloats());
 
   EXPECT(!union_type.ContainsUnalignedMembers());
 }

--- a/runtime/vm/compiler/ffi/range.h
+++ b/runtime/vm/compiler/ffi/range.h
@@ -52,7 +52,7 @@ class Range {
     return Contains(other.start_) && Contains(other.end_inclusive());
   }
 
-  // Returns true iff [this] is completey after [other].
+  // Returns true iff [this] is completely after [other].
   bool After(const Range& other) const {
     return other.end_exclusive_ <= start_;
   }

--- a/runtime/vm/compiler/frontend/base_flow_graph_builder.h
+++ b/runtime/vm/compiler/frontend/base_flow_graph_builder.h
@@ -247,7 +247,7 @@ class BaseFlowGraphBuilder {
   // Note: SSA construction currently does not support inserting Phi functions
   // for expression stack locations - only real local variables are supported.
   // This means that you can't use MakeTemporary in a way that would require
-  // a Phi in SSA form. For example example below will be miscompiled or
+  // a Phi in SSA form. For example, the example below will be miscompiled or
   // will crash debug VM with assertion when building SSA for optimizing
   // compiler:
   //

--- a/runtime/vm/compiler/frontend/base_flow_graph_builder.h
+++ b/runtime/vm/compiler/frontend/base_flow_graph_builder.h
@@ -387,7 +387,7 @@ class BaseFlowGraphBuilder {
   // NoSuchMethod message).
   // Sets 'receiver' to 'null' after the check if 'clear_the_temp'.
   // Note that this does _not_ use the result of the CheckNullInstr, so it does
-  // not create a data depedency and might break with code motion.
+  // not create a data dependency and might break with code motion.
   Fragment CheckNull(TokenPosition position,
                      LocalVariable* receiver,
                      const String& function_name,

--- a/runtime/vm/compiler/frontend/kernel_binary_flowgraph.cc
+++ b/runtime/vm/compiler/frontend/kernel_binary_flowgraph.cc
@@ -4632,7 +4632,7 @@ Fragment StreamingFlowGraphBuilder::BuildAssertStatement(
 
 Fragment StreamingFlowGraphBuilder::BuildLabeledStatement(
     TokenPosition* position) {
-  // There can be serveral cases:
+  // There can be several cases:
   //
   //   * the body contains a break
   //   * the body doesn't contain a break

--- a/runtime/vm/compiler/frontend/kernel_to_il.cc
+++ b/runtime/vm/compiler/frontend/kernel_to_il.cc
@@ -4345,7 +4345,7 @@ Fragment FlowGraphBuilder::PopFromStackToTypedDataBase(
                                          /*index_unboxed=*/false);
     offset_in_bytes += RepresentationUtils::ValueSize(representation);
   }
-  body += DropTempsPreserveTop(num_defs);  // Drop chunck defs keep TypedData.
+  body += DropTempsPreserveTop(num_defs);  // Drop chunk defs keep TypedData.
   return body;
 }
 

--- a/runtime/vm/compiler/frontend/kernel_translation_helper.cc
+++ b/runtime/vm/compiler/frontend/kernel_translation_helper.cc
@@ -2962,7 +2962,7 @@ const String& KernelReaderHelper::GetSourceFor(intptr_t index) {
 
 TypedDataPtr KernelReaderHelper::GetLineStartsFor(intptr_t index) {
   // Line starts are delta encoded. So get the max delta first so that we
-  // can store them as tighly as possible.
+  // can store them as tightly as possible.
   AlternativeReadingScope alt(&reader_);
   SetOffset(GetOffsetForSourceInfo(index));
   SkipBytes(ReadUInt());  // skip uri.

--- a/runtime/vm/compiler/frontend/prologue_builder.cc
+++ b/runtime/vm/compiler/frontend/prologue_builder.cc
@@ -352,7 +352,7 @@ Fragment PrologueBuilder::BuildClosureContextHandling() {
   LocalVariable* context = parsed_function_->current_context_var();
 
   // Load closure.context & store it into the context variable.
-  // (both load/store happen on the copyied-down places).
+  // (both load/store happen on the copied-down places).
   Fragment populate_context;
   populate_context += LoadLocal(closure_parameter);
   populate_context += LoadNativeField(Slot::Closure_context());

--- a/runtime/vm/compiler/frontend/prologue_builder.cc
+++ b/runtime/vm/compiler/frontend/prologue_builder.cc
@@ -244,7 +244,7 @@ Fragment PrologueBuilder::BuildParameterHandling() {
       LocalVariable* tuple_diff = MakeTemporary();
 
       // Let's load position from arg descriptor (to see which parameter is the
-      // name) and move kEntrySize forward in ArgDescriptopr names array.
+      // name) and move kEntrySize forward in ArgDescriptor names array.
       //
       // Later we'll either add this fragment directly to the copy_args_prologue
       // if no check is needed or add an appropriate check.

--- a/runtime/vm/compiler/frontend/scope_builder.h
+++ b/runtime/vm/compiler/frontend/scope_builder.h
@@ -61,7 +61,7 @@ class ScopeBuilder {
 
   virtual void ReportUnexpectedTag(const char* variant, Tag tag);
 
-  // This enum controls which parameters would be marked as requring type
+  // This enum controls which parameters would be marked as requiring type
   // check on the callee side.
   enum ParameterTypeCheckMode {
     // All parameters will be checked.

--- a/runtime/vm/compiler/relocation_test.cc
+++ b/runtime/vm/compiler/relocation_test.cc
@@ -333,7 +333,7 @@ ISOLATE_UNIT_TEST_CASE(CodeRelocator_OutOfRangeForwardCall) {
     // no later.
     EXPECT_EQ(ImageWriterCommand::InsertBytesOfTrampoline, commands[1].op);
     EXPECT_EQ(ImageWriterCommand::InsertInstructionOfCode, commands[2].op);
-    // This is the target of the forwwards call.
+    // This is the target of the forwards call.
     EXPECT_EQ(ImageWriterCommand::InsertInstructionOfCode, commands[3].op);
 
     *entry_point = commands[0].expected_offset;

--- a/runtime/vm/compiler/stub_code_compiler_arm64.cc
+++ b/runtime/vm/compiler/stub_code_compiler_arm64.cc
@@ -702,7 +702,7 @@ void StubCodeCompiler::GenerateRangeError(Assembler* assembler,
       __ BranchIf(EQ, &length);
 #endif
       {
-        // Allocate a mint, reload the two registers and popualte the mint.
+        // Allocate a mint, reload the two registers and populate the mint.
         __ PushRegister(NULL_REG);
         __ CallRuntime(kAllocateMintRuntimeEntry, /*argument_count=*/0);
         __ PopRegister(RangeErrorABI::kIndexReg);

--- a/runtime/vm/compiler/stub_code_compiler_riscv.cc
+++ b/runtime/vm/compiler/stub_code_compiler_riscv.cc
@@ -540,7 +540,7 @@ void StubCodeCompiler::GenerateRangeError(Assembler* assembler,
       __ SmiUntag(TMP2, RangeErrorABI::kIndexReg);
       __ beq(TMP, TMP2, &length);  // No overflow.
       {
-        // Allocate a mint, reload the two registers and popualte the mint.
+        // Allocate a mint, reload the two registers and populate the mint.
         __ PushRegister(NULL_REG);
         __ CallRuntime(kAllocateMintRuntimeEntry, /*argument_count=*/0);
         __ PopRegister(RangeErrorABI::kIndexReg);

--- a/runtime/vm/compiler/stub_code_compiler_x64.cc
+++ b/runtime/vm/compiler/stub_code_compiler_x64.cc
@@ -633,7 +633,7 @@ void StubCodeCompiler::GenerateRangeError(Assembler* assembler,
       __ j(BELOW, &length);
 #endif
       {
-        // Allocate a mint, reload the two registers and popualte the mint.
+        // Allocate a mint, reload the two registers and populate the mint.
         __ PushImmediate(Immediate(0));
         __ CallRuntime(kAllocateMintRuntimeEntry, /*argument_count=*/0);
         __ PopRegister(RangeErrorABI::kIndexReg);

--- a/runtime/vm/compiler/stub_code_compiler_x64.cc
+++ b/runtime/vm/compiler/stub_code_compiler_x64.cc
@@ -1560,11 +1560,11 @@ void StubCodeCompiler::GenerateInvokeDartCodeStub(Assembler* assembler) {
 }
 
 // Helper to generate space allocation of context stub.
-// This does not initialise the fields of the context.
+// This does not initialize the fields of the context.
 // Input:
 //   R10: number of context variables.
 // Output:
-//   RAX: new, uinitialised allocated Context object.
+//   RAX: new, uninitialized allocated Context object.
 // Clobbered:
 //   R13
 static void GenerateAllocateContextSpaceStub(Assembler* assembler,
@@ -1652,7 +1652,7 @@ void StubCodeCompiler::GenerateAllocateContextStub(Assembler* assembler) {
 
     // Setup the parent field.
     // RAX: new object.
-    // R9: Parent object, initialised to null.
+    // R9: Parent object, initialized to null.
     // No generational barrier needed, since we are storing null.
     __ StoreCompressedIntoObjectNoBarrier(
         RAX, FieldAddress(RAX, target::Context::parent_offset()), R9);


### PR DESCRIPTION
This change is scoped to runtime/vm/compiler per https://github.com/dart-lang/sdk/issues/50754, it's <50 files.