### PR TITLE
Spelling runtime vm heap

### DIFF
--- a/runtime/vm/heap/heap.cc
+++ b/runtime/vm/heap/heap.cc
@@ -398,7 +398,7 @@ void Heap::NotifyIdle(int64_t deadline) {
     if (old_space_.ShouldPerformIdleMarkCompact(deadline)) {
       // We prefer mark-compact over other old space GCs if we have enough time,
       // since it removes old space fragmentation and frees up most memory.
-      // Blocks for O(heap), roughtly twice as costly as mark-sweep.
+      // Blocks for O(heap), roughly twice as costly as mark-sweep.
       CollectOldSpaceGarbage(thread, GCType::kMarkCompact, GCReason::kIdle);
     } else if (old_space_.ReachedHardThreshold()) {
       // Even though the following GC may exceed our idle deadline, we need to

--- a/runtime/vm/heap/heap.cc
+++ b/runtime/vm/heap/heap.cc
@@ -977,7 +977,7 @@ void Heap::ForwardWeakTables(ObjectPointerVisitor* visitor) {
     GetWeakTable(Heap::kOld, selector)->Forward(visitor);
   }
 
-  // Isolates might have forwarding tables (used for during snapshoting in
+  // Isolates might have forwarding tables (used for during snapshotting in
   // isolate communication).
   isolate_group()->ForEachIsolate(
       [&](Isolate* isolate) {

--- a/runtime/vm/heap/marker.cc
+++ b/runtime/vm/heap/marker.cc
@@ -880,7 +880,7 @@ void GCMarker::StartConcurrentMark(PageSpace* page_space) {
   {
     // Bulk increase task count before starting any task, instead of
     // incrementing as each task is started, to prevent a task which
-    // races ahead from falsly beleiving it was the last task to complete.
+    // races ahead from falsly believing it was the last task to complete.
     MonitorLocker ml(page_space->tasks_lock());
     ASSERT(page_space->phase() == PageSpace::kDone);
     page_space->set_phase(PageSpace::kMarking);

--- a/runtime/vm/heap/marker.cc
+++ b/runtime/vm/heap/marker.cc
@@ -256,7 +256,7 @@ class MarkingVisitorBase : public ObjectPointerVisitor {
       // failing to acquire the mark bit here doesn't reliably indicate the
       // object was already encountered through the deferred marking stack. Our
       // processing here is idempotent, so repeated visits only hurt performance
-      // but not correctness. Duplicatation is expected to be low.
+      // but not correctness. Duplication is expected to be low.
       // By the absence of a special case, we are treating WeakProperties as
       // strong references here. This guarantees a WeakProperty will only be
       // added to the delayed_weak_properties_ list of the worker that

--- a/runtime/vm/heap/marker.cc
+++ b/runtime/vm/heap/marker.cc
@@ -880,7 +880,7 @@ void GCMarker::StartConcurrentMark(PageSpace* page_space) {
   {
     // Bulk increase task count before starting any task, instead of
     // incrementing as each task is started, to prevent a task which
-    // races ahead from falsly believing it was the last task to complete.
+    // races ahead from falsely believing it was the last task to complete.
     MonitorLocker ml(page_space->tasks_lock());
     ASSERT(page_space->phase() == PageSpace::kDone);
     page_space->set_phase(PageSpace::kMarking);

--- a/runtime/vm/heap/marker.h
+++ b/runtime/vm/heap/marker.h
@@ -25,7 +25,7 @@ class Thread;
 
 // The class GCMarker is used to mark reachable old generation objects as part
 // of the mark-sweep collection. The marking bit used is defined in RawObject.
-// Instances have a lifetime that spans from the beginining of concurrent
+// Instances have a lifetime that spans from the beginning of concurrent
 // marking (or stop-the-world marking) until marking is complete. In particular,
 // an instance may be created and destroyed on different threads if the isolate
 // is exited during concurrent marking.

--- a/runtime/vm/heap/page.cc
+++ b/runtime/vm/heap/page.cc
@@ -22,7 +22,7 @@
 namespace dart {
 
 // This cache needs to be at least as big as FLAG_new_gen_semi_max_size or
-// munmap will noticably impact performance.
+// munmap will noticeably impact performance.
 static constexpr intptr_t kPageCacheCapacity = 8 * kWordSize;
 static Mutex* page_cache_mutex = nullptr;
 static VirtualMemory* page_cache[kPageCacheCapacity] = {nullptr};

--- a/runtime/vm/heap/page.h
+++ b/runtime/vm/heap/page.h
@@ -22,7 +22,7 @@ class Thread;
 
 // Pages are allocated with kPageSize alignment so that the Page of any object
 // can be computed by masking the object with kPageMask. This does not apply to
-// image pages, whose address is choosen by the system loader rather than the
+// image pages, whose address is chosen by the system loader rather than the
 // Dart VM.
 static constexpr intptr_t kPageSize = 512 * KB;
 static constexpr intptr_t kPageSizeInWords = kPageSize / kWordSize;

--- a/runtime/vm/heap/sampler.h
+++ b/runtime/vm/heap/sampler.h
@@ -47,7 +47,7 @@ class HeapProfileSampler {
   // Returns number of bytes that should be be attributed to the sample.
   // If returned size is 0, the allocation should not be sampled.
   //
-  // Due to how the poission sampling works, some samples should be accounted
+  // Due to how the poisson sampling works, some samples should be accounted
   // multiple times if they cover allocations larger than the average sampling
   // rate.
   void SampleSize(intptr_t allocation_size);

--- a/runtime/vm/heap/scavenger.cc
+++ b/runtime/vm/heap/scavenger.cc
@@ -157,7 +157,7 @@ class ScavengerVisitorBase : public ObjectPointerVisitor {
     // update is needed. If the underlying typed data is internal, the pointer
     // must be updated if the typed data was copied or promoted. We cannot
     // safely dereference the underlying typed data to make this distinction.
-    // It may have been forwarded by a different scavanger worker, so the access
+    // It may have been forwarded by a different scavenger worker, so the access
     // could have a data race. Rather than checking the CID of the underlying
     // typed data, which requires dereferencing the copied/promoted header, we
     // compare the view's internal pointer to what it should be if the

--- a/runtime/vm/heap/scavenger.h
+++ b/runtime/vm/heap/scavenger.h
@@ -86,7 +86,7 @@ class ScavengeStats {
 
   // Of all data before scavenge, what fraction was found to be garbage?
   // If this scavenge included growth, assume the extra capacity would become
-  // garbage to give the scavenger a chance to stablize at the new capacity.
+  // garbage to give the scavenger a chance to stabilize at the new capacity.
   double ExpectedGarbageFraction() const {
     double work =
         after_.used_in_words + promoted_in_words_ + abandoned_in_words_;

--- a/runtime/vm/heap/sweeper.cc
+++ b/runtime/vm/heap/sweeper.cc
@@ -30,7 +30,7 @@ bool GCSweeper::SweepPage(Page* page, FreeList* freelist, bool locked) {
     ObjectPtr raw_obj = UntaggedObject::FromAddr(current);
     ASSERT(Page::Of(raw_obj) == page);
     // These acquire operations balance release operations in array
-    // truncaton, ensuring the writes creating the filler object are ordered
+    // truncation, ensuring the writes creating the filler object are ordered
     // before the writes inserting the filler object into the freelist.
     uword tags = raw_obj->untag()->tags_.load(std::memory_order_acquire);
     intptr_t obj_size = raw_obj->untag()->HeapSize(tags);


### PR DESCRIPTION
I'm slicing runtime into pieces, per https://github.com/dart-lang/sdk/issues/50754. This is intentionally on the smaller size because runtime alone would be too large...