### PR TITLE
spelling: is_signed

### DIFF
--- a/runtime/vm/simulator_arm.cc
+++ b/runtime/vm/simulator_arm.cc
@@ -3040,7 +3040,7 @@ void Simulator::DecodeSIMDDataProcessing(Instr* instr) {
                (instr->Bit(23) == 0) && (instr->Bits(25, 3) == 1)) {
       // Format(instr, "vshlqu'sz 'qd, 'qm, 'qn");
       // Format(instr, "vshlqi'sz 'qd, 'qm, 'qn");
-      const bool signd = instr->Bit(24) == 0;
+      const bool is_signed = instr->Bit(24) == 0;
       const int size = instr->Bits(20, 2);
       if (size == 0) {
         for (int i = 0; i < 16; i++) {
@@ -3048,7 +3048,7 @@ void Simulator::DecodeSIMDDataProcessing(Instr* instr) {
           if (shift > 0) {
             s8d_u8[i] = s8m_u8[i] << shift;
           } else if (shift < 0) {
-            if (signd) {
+            if (is_signed) {
               s8d_8[i] = s8m_8[i] >> (-shift);
             } else {
               s8d_u8[i] = s8m_u8[i] >> (-shift);
@@ -3061,7 +3061,7 @@ void Simulator::DecodeSIMDDataProcessing(Instr* instr) {
           if (shift > 0) {
             s8d_u16[i] = s8m_u16[i] << shift;
           } else if (shift < 0) {
-            if (signd) {
+            if (is_signed) {
               s8d_16[i] = s8m_16[i] >> (-shift);
             } else {
               s8d_u16[i] = s8m_u16[i] >> (-shift);
@@ -3074,7 +3074,7 @@ void Simulator::DecodeSIMDDataProcessing(Instr* instr) {
           if (shift > 0) {
             s8d_u32[i] = s8m_u32[i] << shift;
           } else if (shift < 0) {
-            if (signd) {
+            if (is_signed) {
               s8d_32[i] = s8m_32[i] >> (-shift);
             } else {
               s8d_u32[i] = s8m_u32[i] >> (-shift);
@@ -3088,7 +3088,7 @@ void Simulator::DecodeSIMDDataProcessing(Instr* instr) {
           if (shift > 0) {
             s8d_u64[i] = s8m_u64[i] << shift;
           } else if (shift < 0) {
-            if (signd) {
+            if (is_signed) {
               s8d_64[i] = s8m_64[i] >> (-shift);
             } else {
               s8d_u64[i] = s8m_u64[i] >> (-shift);


### PR DESCRIPTION
This change is scoped per https://github.com/dart-lang/sdk/issues/50754

I'm happy to drop this change, but I'm hoping that people will consider that there's value in spelling things out.

I think that `signd` means `signed`, although it's possible that it's `sign`+`d` for something else -- e.g. significant+digits. Given that it's a boolean, this feels like the most likely answer.

The only hunk of this change that gave me confidence in my guess about the meaning of the token was this:
```c++
      const bool signd = instr->Bit(23) == 1;
      // Write the W register for signed values when size < 2.
      // Write the W register for unsigned values when size == 2.
```

I believe the reason that it was written this was is that `signed` is a reserved word. This code uses `_` in various places; including `classes.dart`, `types.dart`, and `dartutils.cc` which specifically use `is_` as a prefix.