### PR TITLE
CP issue template assignees - remove whesse

### DIFF
--- a/.github/ISSUE_TEMPLATE/2_cherry_pick.yml
+++ b/.github/ISSUE_TEMPLATE/2_cherry_pick.yml
@@ -4,7 +4,6 @@ title: '[CP] <title>'
 labels: ['cherry-pick-review']
 assignees:
   - mit-mit
-  - whesse
   - athomas
   - vsmenon
   - itsjustkevin


### PR DESCRIPTION
whesse no longer has any special role in cherry-picks.