### PR TITLE
Update dart_native_api.h

### DIFF
--- a/runtime/include/dart_native_api.h
+++ b/runtime/include/dart_native_api.h
@@ -65,7 +65,7 @@ typedef struct _Dart_CObject {
     int32_t as_int32;
     int64_t as_int64;
     double as_double;
-    char* as_string;
+    const char* as_string;
     struct {
       Dart_Port id;
       Dart_Port origin_id;


### PR DESCRIPTION
Make `as_string` field of `_Dart_CObject` a `const char*` instead of `char*` to avoid forcing users to maintain a separate copy of the string passed to this field if they don't want to get a warning from the compiler