### PR TITLE
[infra] Create a GIT_TIMESTAMP file for tarball

### DIFF
--- a/tools/linux_dist_support/create_tarball.py
+++ b/tools/linux_dist_support/create_tarball.py
@@ -133,6 +133,9 @@ def GenerateGitRevision(filename, git_revision):
     with open(filename, 'w') as f:
         f.write(str(git_revision))
 
+def GenerateGitTimestamp(filename, git_timestamp):
+    with open(filename, 'w') as f:
+        f.write(str(git_timestamp))
 
 def CreateTarball(tarfilename):
     global ignoredPaths  # Used for adding the output directory.
@@ -177,6 +180,11 @@ def CreateTarball(tarfilename):
                 tar.add(git_revision,
                         arcname='%s/dart/tools/GIT_REVISION' % versiondir)
 
+            # Add GIT_TIMESTAMP file as git is not available in tarball.
+            git_timestamp = join(temp_dir, 'GIT_TIMESTAMP')
+            GenerateGitTimestamp(git_timestamp, utils.GetGitTimestamp())
+            tar.add(git_timestamp,
+                    arcname='%s/dart/tools/GIT_TIMESTAMP' % versiondir)
 
 def Main():
     if HOST_OS != 'linux':

--- a/tools/make_version.py
+++ b/tools/make_version.py
@@ -54,7 +54,8 @@ def FormatVersionString(version,
                         no_git_hash,
                         no_sdk_hash,
                         version_file=None,
-                        git_revision_file=None):
+                        git_revision_file=None,
+                        git_timestamp_file=None):
     semantic_sdk_version = utils.GetSemanticSDKVersion(no_git_hash,
                                                        version_file,
                                                        git_revision_file)
@@ -79,7 +80,7 @@ def FormatVersionString(version,
 
     version_time = None
     if not no_git_hash:
-        version_time = utils.GetGitTimestamp()
+        version_time = utils.GetGitTimestamp(git_timestamp_file)
     if version_time == None:
         version_time = 'Unknown timestamp'
     version = version.replace('{{COMMIT_TIME}}', version_time)
@@ -115,6 +116,8 @@ def main():
         parser.add_argument('--version-file', help='Path to the VERSION file.')
         parser.add_argument('--git-revision-file',
                             help='Path to the GIT_REVISION file.')
+        parser.add_argument('--git-timestamp-file',
+                            help='Path to the GIT_TIMESTAMP file.')
         parser.add_argument(
             '--format',
             default='{{VERSION_STR}}',
@@ -136,7 +139,8 @@ def main():
 
         version = FormatVersionString(version_template, args.no_git_hash,
                                       args.no_sdk_hash, args.version_file,
-                                      args.git_revision_file)
+                                      args.git_revision_file,
+                                      args.git_timestamp_file)
 
         if args.output:
             with open(args.output, 'w') as fh:

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -420,7 +420,7 @@ def GetGitRevision(git_revision_file=None, repo_path=DART_DIR):
         git_revision_file = os.path.join(repo_path, 'tools', 'GIT_REVISION')
     try:
         with open(git_revision_file) as fd:
-            return fd.read().decode('utf-8').strip()
+            return fd.read().strip()
     except:
         pass
     p = subprocess.Popen(['git', 'rev-parse', 'HEAD'],
@@ -478,7 +478,15 @@ def GetLatestDevTag(repo_path=DART_DIR):
     return tag
 
 
-def GetGitTimestamp(repo_path=DART_DIR):
+def GetGitTimestamp(git_timestamp_file=None, repo_path=DART_DIR):
+    # When building from tarball use tools/GIT_TIMESTAMP
+    if git_timestamp_file is None:
+        git_timestamp_file = os.path.join(repo_path, 'tools', 'GIT_TIMESTAMP')
+    try:
+        with open(git_timestamp_file) as fd:
+            return fd.read().strip()
+    except:
+        pass
     p = subprocess.Popen(['git', 'log', '-n', '1', '--pretty=format:%cd'],
                          stdout=subprocess.PIPE,
                          stderr=subprocess.STDOUT,


### PR DESCRIPTION
When building from debian tarball generated from `tools/linux_dist_support/create_tarball.py`, we get `Unknown timestamp` when running `dart --version`.

This PR addresses that by adding a `GIT_TIMESTAMP` file similar to how `GIT_REVISION` file works today.

This also removes a `.decode('utf-8')` call on string which was for Python 2 and no longer works in Python 3.