### PR TITLE
Add support for more default URI ports

### DIFF
--- a/sdk/lib/core/uri.dart
+++ b/sdk/lib/core/uri.dart
@@ -1720,30 +1720,10 @@ class _Uri implements Uri {
     // TODO: Magic numbers could be replaced with constants
     switch (scheme) {
       case "http":
-        return 80;
-      case "https":
-        return 443;
       case "ws":
         return 80;
+      case "https":
       case "wss":
-        return 443;
-      case "nntp":
-        return 119;
-      case "sftp":
-        return 22;
-      case "gopher":
-        return 70;
-      case "coap":
-        return 5683;
-      case "coaps":
-        return 5684;
-      case "coap+tcp":
-        return 5683;
-      case "coaps+tcp":
-        return 5684;
-      case "coap+ws":
-        return 80;
-      case "coaps+ws":
         return 443;
     }
     return 0;

--- a/sdk/lib/core/uri.dart
+++ b/sdk/lib/core/uri.dart
@@ -139,9 +139,9 @@ abstract class Uri {
   /// [port].
   /// If [port] is omitted or `null`, it implies the default port for
   /// the URI's scheme, and is equivalent to passing that port explicitly.
-  /// The recognized schemes, and their default ports, are "http" (80) and
-  /// "https" (443). All other schemes are considered as having zero as the
-  /// default port.
+  /// The recognized schemes, and their default ports, are "http" and "ws" (80)
+  /// as well as "https" and "wss" (443). All other schemes are considered as
+  /// having zero as the default port.
   ///
   /// If any of `userInfo`, `host` or `port` are provided,
   /// the URI has an authority according to [hasAuthority].
@@ -489,7 +489,8 @@ abstract class Uri {
   /// The port part of the authority component.
   ///
   /// The value is the default port if there is no port number in the authority
-  /// component. That's 80 for http, 443 for https, and 0 for everything else.
+  /// component. That's 80 for http and ws, 443 for https and wss, and 0 for
+  /// everything else.
   int get port;
 
   /// The path component.
@@ -589,8 +590,8 @@ abstract class Uri {
   /// Whether the URI has an explicit port.
   ///
   /// If the port number is the default port number
-  /// (zero for unrecognized schemes, with http (80) and https (443) being
-  /// recognized),
+  /// (zero for unrecognized schemes, with http and ws (80) as well as https
+  /// and wss (443) being recognized),
   /// then the port is made implicit and omitted from the URI.
   bool get hasPort;
 

--- a/sdk/lib/core/uri.dart
+++ b/sdk/lib/core/uri.dart
@@ -1717,8 +1717,35 @@ class _Uri implements Uri {
 
   /// The default port for the scheme of this Uri.
   static int _defaultPort(String scheme) {
-    if (scheme == "http") return 80;
-    if (scheme == "https") return 443;
+    // TODO: Magic numbers could be replaced with constants
+    switch (scheme) {
+      case "http":
+        return 80;
+      case "https":
+        return 443;
+      case "ws":
+        return 80;
+      case "wss":
+        return 443;
+      case "nntp":
+        return 119;
+      case "sftp":
+        return 22;
+      case "gopher":
+        return 70;
+      case "coap":
+        return 5683;
+      case "coaps":
+        return 5684;
+      case "coap+tcp":
+        return 5683;
+      case "coaps+tcp":
+        return 5684;
+      case "coap+ws":
+        return 80;
+      case "coaps+ws":
+        return 443;
+    }
     return 0;
   }
 

--- a/sdk/lib/core/uri.dart
+++ b/sdk/lib/core/uri.dart
@@ -1717,6 +1717,14 @@ class _Uri implements Uri {
   }
 
   /// The default port for the scheme of this Uri.
+  ///
+  /// Currently, the default ports for HTTP and WebSockets are supported.
+  ///
+  /// See [RFC 9110, section 4.2] for HTTP and [RFC 6455, section 3] for
+  /// WebSockets.
+  ///
+  /// [RFC 6455, section 3]: https://www.rfc-editor.org/rfc/rfc6455#section-3
+  /// [RFC 9110, section 4.2]: https://www.rfc-editor.org/rfc/rfc9110#section-4.2
   static int _defaultPort(String scheme) {
     switch (scheme) {
       case "http":

--- a/sdk/lib/core/uri.dart
+++ b/sdk/lib/core/uri.dart
@@ -1717,12 +1717,13 @@ class _Uri implements Uri {
 
   /// The default port for the scheme of this Uri.
   static int _defaultPort(String scheme) {
-    // TODO: Magic numbers could be replaced with constants
     switch (scheme) {
       case "http":
+        return 80;
       case "ws":
         return 80;
       case "https":
+        return 443;
       case "wss":
         return 443;
     }

--- a/sdk/lib/core/uri.dart
+++ b/sdk/lib/core/uri.dart
@@ -1720,11 +1720,9 @@ class _Uri implements Uri {
   static int _defaultPort(String scheme) {
     switch (scheme) {
       case "http":
-        return 80;
       case "ws":
         return 80;
       case "https":
-        return 443;
       case "wss":
         return 443;
     }


### PR DESCRIPTION
This PR contains an initial proposal for the default URI port additions discussed in #51163.

As mentioned by me in https://github.com/dart-lang/sdk/issues/51163#issuecomment-1410183342, the proposal also contains the default ports for CoAP (see [RFC 7252](https://www.rfc-editor.org/rfc/rfc7252) for CoAP over UDP and [RFC 8323](https://www.rfc-editor.org/rfc/rfc8323) for CoAP over TCP, TLS, and WebSockets). Since CoAP is designed to be very closely aligned with HTTP, adding the corresponding port numbers should not cause any harm and should be compatible right away. However, let me know if you would prefer to see these additions removed.