### PR TITLE
Suppress sign-compare warnings for musl libc

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -672,11 +672,8 @@ config("chromium_code") {
     cflags = [
       "-Wall",
       "-Wextra",
+      "-Werror",
     ]
-
-    if (dart_sysroot != "alpine") {
-      cflags += [ "-Werror" ]
-    }
 
     defines = []
     if (!using_sanitizer && !is_clang) {

--- a/runtime/bin/socket_base_posix.cc
+++ b/runtime/bin/socket_base_posix.cc
@@ -21,6 +21,24 @@
 #include "bin/socket_base_macos.h"
 #include "platform/signal_blocker.h"
 
+// We wrap CMSG_NXTHDR to suppress sign-compare warnings which occur on musl.
+#if defined(__clang__)
+#define CMSG_NEXTHDR(mhdr, cmsg)                         \
+  _Pragma("clang diagnostic push")                       \
+  _Pragma("clang diagnostic ignored \"-Wsign-compare\"") \
+  CMSG_NXTHDR(mhdr, cmsg)                                \
+  _Pragma("clang diagnostic pop")
+#elif defined(__GNUC__)
+#define CMSG_NEXTHDR(mhdr, cmsg)                       \
+  _Pragma("GCC diagnostic push")                       \
+  _Pragma("GCC diagnostic ignored \"-Wsign-compare\"") \
+  CMSG_NXTHDR(mhdr, cmsg)                              \
+  _Pragma("GCC diagnostic pop")
+#else
+#define CMSG_NEXTHDR(mhdr, cmsg) \
+  CMSG_NXTHDR(mhdr, cmsg)
+#endif
+
 namespace dart {
 namespace bin {
 
@@ -151,13 +169,13 @@ intptr_t SocketBase::ReceiveMessage(intptr_t fd,
   size_t num_messages = 0;
   while (cmsg != nullptr) {
     num_messages++;
-    cmsg = CMSG_NXTHDR(&msg, cmsg);
+    cmsg = CMSG_NEXTHDR(&msg, cmsg);
   }
   (*p_messages) = reinterpret_cast<SocketControlMessage*>(
       Dart_ScopeAllocate(sizeof(SocketControlMessage) * num_messages));
   SocketControlMessage* control_message = *p_messages;
   for (cmsg = CMSG_FIRSTHDR(&msg); cmsg != nullptr;
-       cmsg = CMSG_NXTHDR(&msg, cmsg), control_message++) {
+       cmsg = CMSG_NEXTHDR(&msg, cmsg), control_message++) {
     void* data = CMSG_DATA(cmsg);
     size_t data_length = cmsg->cmsg_len - (reinterpret_cast<uint8_t*>(data) -
                                            reinterpret_cast<uint8_t*>(cmsg));
@@ -260,7 +278,7 @@ intptr_t SocketBase::SendMessage(intptr_t fd,
     struct cmsghdr* cmsg = CMSG_FIRSTHDR(&msg);
     message = messages;
     for (intptr_t i = 0; i < num_messages;
-         i++, message++, cmsg = CMSG_NXTHDR(&msg, cmsg)) {
+         i++, message++, cmsg = CMSG_NEXTHDR(&msg, cmsg)) {
       ASSERT(message->is_file_descriptors_control_message());
       cmsg->cmsg_level = SOL_SOCKET;
       cmsg->cmsg_type = SCM_RIGHTS;


### PR DESCRIPTION
Apologize that it looks like my previous attempt in #51191 breaks gcc for unknown pragma and had to be reverted.

This PR now conditionally uses different pragma so that it should work on both gcc (>=4.6) and clang.

cc @mraleph @rmacnak-google