### PR TITLE
Add missing include <initializer_list>

### DIFF
--- a/runtime/vm/compiler/compiler_pass.h
+++ b/runtime/vm/compiler/compiler_pass.h
@@ -9,6 +9,8 @@
 #error "AOT runtime should not use compiler sources (including header files)"
 #endif  // defined(DART_PRECOMPILED_RUNTIME)
 
+#include <initializer_list>
+
 #include "vm/growable_array.h"
 #include "vm/timer.h"
 #include "vm/token_position.h"

--- a/runtime/vm/compiler/compiler_pass.h
+++ b/runtime/vm/compiler/compiler_pass.h
@@ -9,8 +9,6 @@
 #error "AOT runtime should not use compiler sources (including header files)"
 #endif  // defined(DART_PRECOMPILED_RUNTIME)
 
-#include <initializer_list>
-
 #include "vm/growable_array.h"
 #include "vm/timer.h"
 #include "vm/token_position.h"

--- a/runtime/vm/growable_array.h
+++ b/runtime/vm/growable_array.h
@@ -10,6 +10,8 @@
 #ifndef RUNTIME_VM_GROWABLE_ARRAY_H_
 #define RUNTIME_VM_GROWABLE_ARRAY_H_
 
+#include <initializer_list>
+
 #include "platform/growable_array.h"
 #include "vm/thread_state.h"
 #include "vm/zone.h"


### PR DESCRIPTION
@mraleph https://github.com/dart-lang/sdk/commit/cc8877fcc71691f071c33ef65ca8af9e06264469 started to use `std::initializer_list` in `runtime/vm/growable_array.h`, but the header `<initializer_list>` is not included in the file, which causes the following error when building for musl.

```
ninja: job failed: /usr/bin/clang++ -MMD -MF obj/runtime/lib/libdart_lib_precompiled_runtime.ffi_dynamic_library.o.d -DNDEBUG -DTARGET_ARCH_X64 -DDART_TARGET_OS_LINUX -DDART_PRECOMPILED_RUNTIME -DEXCLUDE_CFE_AND_KERNEL_PLATFORM -I../../runtime -I../.. -Igen -I../../runtime/include -m64 -march=x86-64 -msse2 -fPIC --target=x86_64-alpine-linux-musl -fcolor-diagnostics -Wall -Wextra -Werror -Wendif-labels -Wno-missing-field-initializers -Wno-unused-parameter -Wno-tautological-constant-compare -Wno-unused-but-set-variable -Wno-unused-but-set-parameter -Wno-deprecated-non-prototype -fdebug-prefix-map=/__w/dart/dart/dart-sdk/sdk=../.. -no-canonical-prefixes --sysroot=../../build/linux/alpine-linux-x86_64-sysroot -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -Wheader-hygiene -Wstring-conversion -O2 -fno-ident -fdata-sections -ffunction-sections -g3 -ggdb3 -Wno-unused-parameter -Wno-unused-private-field -Wnon-virtual-dtor -Wvla -Woverloaded-virtual -Wno-comments -g3 -ggdb3 -fno-rtti -fno-exceptions -Wimplicit-fallthrough -fno-strict-vtable-pointers -O2 -fvisibility-inlines-hidden -fno-omit-frame-pointer -std=c++17 -fno-rtti -c ../../runtime/lib/ffi_dynamic_library.cc -o obj/runtime/lib/libdart_lib_precompiled_runtime.ffi_dynamic_library.o
In file included from ../../runtime/lib/ffi_dynamic_library.cc:14:
In file included from ../../runtime/vm/bootstrap_natives.h:8:
In file included from ../../runtime/vm/native_entry.h:12:
In file included from ../../runtime/vm/heap/verifier.h:12:
In file included from ../../runtime/vm/thread.h:26:
In file included from ../../runtime/vm/pending_deopts.h:12:
../../runtime/vm/growable_array.h:33:22: error: no template named 'initializer_list' in namespace 'std'
  GrowableArray(std::initializer_list<T> values)
                ~~~~~^
1 error generated.
```