### PR TITLE
[build] Statically link libstd++ and libgcc when using clang.

### DIFF
--- a/build/config/linux/BUILD.gn
+++ b/build/config/linux/BUILD.gn
@@ -11,14 +11,14 @@ config("sdk") {
   if (is_clang) {
     # Don't allow visible symbols from libc++ to be re-exported.
     ldflags += [ "-Wl,--exclude-libs=libc++.a" ]
-  } else {
-    # When using gcc, explicitly use static linking for libstdc++ and libgcc to
-    # minimize dependencies. With clang, this the default.
-    ldflags += [
-      "-static-libgcc",
-      "-static-libstdc++",
-    ]
   }
+
+  # Explicitly use static linking for libstdc++ and libgcc to minimize
+  # dependencies.
+  ldflags += [
+    "-static-libgcc",
+    "-static-libstdc++",
+  ]
 
   if (sysroot != "") {
     cflags += [ "--sysroot=" + sysroot ]


### PR DESCRIPTION
This PR fixes a regression on alpine/musl-libc caused by recent commit https://github.com/dart-lang/sdk/commit/8a95be8cda164f0f85da7628183c9611bb4617ec which removed static linking flags when using clang on alpine.

Log for failed nightly build for musl: https://github.com/dart-musl/dart/actions/runs/4169469258/jobs/7217977849#step:11:1848

@rmacnak-google @alexmarkov