### PR TITLE
Replace flutter/plugins analysis

### DIFF
--- a/tools/bots/flutter/analyze_flutter_packages.sh
+++ b/tools/bots/flutter/analyze_flutter_packages.sh
@@ -4,7 +4,7 @@
 # for details. All rights reserved. Use of this source code is governed by a
 # BSD-style license that can be found in the LICENSE file.
 
-# Analyze Dart code in the flutter/plugins repo.
+# Analyze Dart code in the flutter/packages repo.
 
 set -e
 
@@ -26,15 +26,15 @@ git clone --single-branch -vv https://github.com/flutter/flutter
 export PATH="$PATH":"$tmpdir/flutter/bin"
 flutter --version
 
-# get the flutter/plugins repo
-git clone --single-branch -vv https://github.com/flutter/plugins
-cd plugins
+# get the flutter/packages repo
+git clone --single-branch -vv https://github.com/flutter/packages
+cd packages
 
 # validate the tool's source
 (cd script/tool; dart pub get)
 (cd script/tool; dart analyze --fatal-infos)
 
 # Invoke the repo's analysis script.
-./script/tool_runner.sh analyze \
+dart run script/tool/bin/flutter_plugin_tools.dart analyze \
   --analysis-sdk $sdk \
   --custom-analysis=script/configs/custom_analysis.yaml

--- a/tools/bots/test_matrix.json
+++ b/tools/bots/test_matrix.json
@@ -4102,8 +4102,8 @@
           "script": "tools/bots/flutter/analyze_flutter_flutter.sh"
         },
         {
-          "name": "analyze flutter/plugins",
-          "script": "tools/bots/flutter/analyze_flutter_plugins.sh"
+          "name": "analyze flutter/packages",
+          "script": "tools/bots/flutter/analyze_flutter_packages.sh"
         },
         {
           "name": "analyze flutter/gallery",


### PR DESCRIPTION
Replaces the flutter/plugns with analysis of flutter/packages, now that flutter/plugins has been merged into flutter/packages and will no longer be updated.

Also switches to calling the tool script directly, since the wrapper uses branch-based behavior that is no longer correct for this usage. This version matches the invocation used in flutter/flutter, so breakage due to repo changes is unlikely.