### PR TITLE
fix //build/config/linux/pkg_config.gni

### DIFF
--- a/build/config/linux/pkg-config.py
+++ b/build/config/linux/pkg-config.py
@@ -161,7 +161,7 @@ try:
     # For now just split on spaces to get the args out. This will break if
     # pkgconfig returns quoted things with spaces in them, but that doesn't seem
     # to happen in practice.
-    all_flags = flag_string.strip().split(' ')
+    all_flags = flag_string.decode('utf-8').strip().split(' ')
 except:
     print("Could not run pkg-config.")
     sys.exit(1)


### PR DESCRIPTION
part of #51535

subprocess.check_output returns bytes, not str

it doesn't seem to be used yet in the project, so I assume it doesn't work for anyone. not sure how did it land here if it doesn't work (returned type changed in python 3?)