### PR TITLE
[ANTLR] Move optional trailing question mark up.

### DIFF
--- a/tools/spec_parser/Dart.g
+++ b/tools/spec_parser/Dart.g
@@ -1397,18 +1397,18 @@ type
 typeNotVoid
     :    functionType '?'?
     |    recordType '?'?
-    |    typeNotVoidNotFunction
+    |    typeNotVoidNotFunction '?'?
     ;
 
 typeNotFunction
-    :    typeNotVoidNotFunction
+    :    typeNotVoidNotFunction '?'?
     |    recordType '?'?
     |    VOID
     ;
 
 typeNotVoidNotFunction
-    :    typeName typeArguments? '?'?
-    |    FUNCTION '?'?
+    :    typeName typeArguments?
+    |    FUNCTION
     ;
 
 typeName


### PR DESCRIPTION
Move optional trailing question mark in typeNotVoidNotFunction to where typeNotVoidNotFunction is being referenced from except for places that are not expected to take nullable types.

Closes #51706

For reference: [here's](https://github.com/dart-lang/language/blob/abca38c39e9bea0af2ff47fce55d6686207178e7/specification/dartLangSpec.tex#L20180-L20187) the matching grammar snippet in the language spec.
