### PR TITLE
Fix SSL certificate check when hostname is an IP address

### DIFF
--- a/runtime/bin/socket_base.cc
+++ b/runtime/bin/socket_base.cc
@@ -301,5 +301,19 @@ void FUNCTION_NAME(SocketBase_IsBindError)(Dart_NativeArguments args) {
   Dart_SetBooleanReturnValue(args, is_bind_error ? true : false);
 }
 
+bool SocketBase::IsValidAddress(const char* address) {
+  ASSERT(address != nullptr);
+  RawAddr raw;
+  memset(&raw, 0, sizeof(raw));
+  int type = strchr(address, ':') == nullptr ? SocketAddress::TYPE_IPV4
+                                             : SocketAddress::TYPE_IPV6;
+  if (type == SocketAddress::TYPE_IPV4) {
+    raw.addr.sa_family = AF_INET;
+  } else {
+    raw.addr.sa_family = AF_INET6;
+  }
+  return SocketBase::ParseAddress(type, address, &raw);
+}
+
 }  // namespace bin
 }  // namespace dart

--- a/runtime/bin/socket_base.h
+++ b/runtime/bin/socket_base.h
@@ -274,6 +274,8 @@ class SocketBase : public AllStatic {
 
   static bool ParseAddress(int type, const char* address, RawAddr* addr);
 
+  static bool IsValidAddress(const char* address);
+
   // Convert address from byte representation to human readable string.
   static bool RawAddrToString(RawAddr* addr, char* str);
   static bool FormatNumericAddress(const RawAddr& addr, char* address, int len);

--- a/tests/standalone/io/secure_server_client_certificate_test.dart
+++ b/tests/standalone/io/secure_server_client_certificate_test.dart
@@ -110,6 +110,7 @@ Future testClientCertificate(
 
 main() async {
   asyncStart();
+  // Test client certificate when host is a DNS name
   HOST = (await InternetAddress.lookup("localhost")).first;
   await testClientCertificate(
       required: false, sendCert: true, certType: 'pem', password: 'dartdart');
@@ -128,5 +129,16 @@ main() async {
       required: false, sendCert: false, certType: 'p12', password: 'dartdart');
   await testClientCertificate(
       required: true, sendCert: false, certType: 'p12', password: 'dartdart');
+
+  // Test client certificate when host is an IP address
+  HOST = InternetAddress.loopbackIPv4;
+  await testClientCertificate(
+      required: false, sendCert: true, certType: 'pem', password: 'dartdart');
+  await testClientCertificate(
+      required: true, sendCert: true, certType: 'pem', password: 'dartdart');
+  await testClientCertificate(
+      required: false, sendCert: false, certType: 'pem', password: 'dartdart');
+  await testClientCertificate(
+      required: true, sendCert: false, certType: 'pem', password: 'dartdart');
   asyncEnd();
 }

--- a/tests/standalone_2/io/secure_server_client_certificate_test.dart
+++ b/tests/standalone_2/io/secure_server_client_certificate_test.dart
@@ -110,6 +110,7 @@ Future testClientCertificate(
 
 main() async {
   asyncStart();
+  // Test client certificate when host is a DNS name
   HOST = (await InternetAddress.lookup("localhost")).first;
   await testClientCertificate(
       required: false, sendCert: true, certType: 'pem', password: 'dartdart');
@@ -128,5 +129,16 @@ main() async {
       required: false, sendCert: false, certType: 'p12', password: 'dartdart');
   await testClientCertificate(
       required: true, sendCert: false, certType: 'p12', password: 'dartdart');
+
+  // Test client certificate when host is an IP address
+  HOST = InternetAddress.loopbackIPv4;
+  await testClientCertificate(
+      required: false, sendCert: true, certType: 'pem', password: 'dartdart');
+  await testClientCertificate(
+      required: true, sendCert: true, certType: 'pem', password: 'dartdart');
+  await testClientCertificate(
+      required: false, sendCert: false, certType: 'pem', password: 'dartdart');
+  await testClientCertificate(
+      required: true, sendCert: false, certType: 'pem', password: 'dartdart');
   asyncEnd();
 }


### PR DESCRIPTION
The previous logic in `SSLFilter::Connect` was assuming the host is always a DNS name so it was unconditionally calling [`X509_VERIFY_PARAM_set1_host`](https://github.com/dart-lang/sdk/blob/9bb4402abdb5784281d43b99f4b45ab852f9eb47/runtime/bin/secure_socket_filter.cc#L543-L544) even for hosts that were actually IP addresses. This in turn was causing a `CERTIFICATE_VERIFY_FAILED: Hostname mismatch(handshake.cc:393)` exception when a client attempted to connect to an IP address (rather than a DNS name) host.

This CL fixes that by checking whether the host is an IP address or a DNS name and calling either `X509_VERIFY_PARAM_set1_ip_asc` or `X509_VERIFY_PARAM_set1_host` depending on the result.

PS: ~The certificates had to be regenerated because the previous configuration in [`sample_certificate_v3_extensions`](https://github.com/dart-lang/sdk/blob/9bb4402abdb5784281d43b99f4b45ab852f9eb47/tests/standalone/io/sample_certificate_v3_extensions#L23-L24) had the `127.0.0.1` and `::1` IP addresses stored as *DNS* subject alternative names. This meant that the newly introduced tests would still pass *even with the previous logic*, but for the wrong reasons.~ EDIT: Regenerating the certificates has been submitted as a separate [change](https://dart-review.googlesource.com/c/sdk/+/300000).

Bug: #35462, #49183
