### PR TITLE
[ANTLR] Various changes.

### DIFF
--- a/tools/spec_parser/Dart.g
+++ b/tools/spec_parser/Dart.g
@@ -6,8 +6,6 @@
 // v0.34
 // - Convert left-recursion in `cascade` to iteration.
 // - Convert right-recursion in `unaryExpression` to iteration.
-// - Add await and negation as prefixes to prefixed super unaryExpressions
-//   to match the implementation.
 // - Remove the dependency on order for disambiguating
 //   `<typeArguments> <arguments>` and `<arguments>` in selectors.
 // - Fix inconsistent order-dependent disambiguation between external

--- a/tools/spec_parser/Dart.g
+++ b/tools/spec_parser/Dart.g
@@ -949,7 +949,7 @@ unaryExpression
 
 unaryExpressionTail
     :    postfixExpression
-    |    prefixOperator SUPER
+    |    (minusOperator | tildeOperator) SUPER
     |    incrementOperator assignableExpression
     ;
 


### PR DESCRIPTION
This PR proposes the following changes:

### Convert left-recursion in `cascade` to iteration.

Since one of the goals of the grammar is to be a reference for recursive-descent-style parsers, I believe this is a desirable change.

### Convert right-recursion in `unaryExpression` to iteration.

In the spirit of the PR that added the previous changelog entry, this simplifies the grammar by making it explicit that unary expressions have a regular structure.
 
### Remove the dependency on order for disambiguating `<typeArguments> <arguments>` and `<arguments>` in selectors.

Closes https://github.com/dart-lang/language/issues/3039

### Fix inconsistent order-dependent disambiguation between methods and external constructors.

The following program
```dart
class Bar {
  Bar();
  external Bar();
}
```

has the following parse tree:
```
<startSymbol>
┗━ <libraryDefinition>
  ┣━ <metadata>
  ┣━ <topLevelDefinition>
  ┃  ┗━ <classDeclaration>
  ┃    ┣━ <classModifiers>
  ┃    ┣━ 'class'
  ┃    ┣━ <typeWithParameters>
  ┃    ┃  ┗━ <typeIdentifier>
  ┃    ┃    ┗━ 'Bar'
  ┃    ┣━ '{'
  ┃    ┣━ <metadata>
  ┃    ┣━ <classMemberDeclaration>
  ┃    ┃  ┣━ <declaration>
  ┃    ┃  ┃  ┗━ <functionSignature>
  ┃    ┃  ┃    ┣━ <identifier>
  ┃    ┃  ┃    ┃  ┗━ 'Bar'
  ┃    ┃  ┃    ┗━ <formalParameterPart>
  ┃    ┃  ┃      ┗━ <formalParameterList>
  ┃    ┃  ┃        ┣━ '('
  ┃    ┃  ┃        ┗━ ')'
  ┃    ┃  ┗━ ';'
  ┃    ┣━ <metadata>
  ┃    ┣━ <classMemberDeclaration>
  ┃    ┃  ┣━ <declaration>
  ┃    ┃  ┃  ┣━ 'external'
  ┃    ┃  ┃  ┗━ <constructorSignature>
  ┃    ┃  ┃    ┣━ <constructorName>
  ┃    ┃  ┃    ┃  ┗━ <typeIdentifier>
  ┃    ┃  ┃    ┃    ┗━ 'Bar'
  ┃    ┃  ┃    ┗━ <formalParameterList>
  ┃    ┃  ┃      ┣━ '('
  ┃    ┃  ┃      ┗━ ')'
  ┃    ┃  ┗━ ';'
  ┃    ┗━ '}'
  ┗━ '<EOF>'
```

Notice how the external method is recognized as being a constructor. This is inconsistent with how non-external constructors are being recognized. This PR fixes this to treat external methods and constructors the way that non-external methods and constructors are being treated.

### Minor formatting changes.

I think the changes related to formatting are self-explanatory. They are meant to make those parts match how the rest of the file is formatted.