### PR TITLE
Replace 'explicit_reopen' mention with 'implicit_reopen'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -433,7 +433,7 @@ information on the flag, see [NATIVE_NULL_ASSERTIONS.md][].
 Updates the Linter to `1.35.0`, which includes changes that
 
 - add new lints:
-  - `explicit_reopen`
+  - `implicit_reopen`
   - `unnecessary_breaks`
   - `type_literal_in_constant_pattern`
   - `invalid_case_patterns`


### PR DESCRIPTION
It seems like a typo, there does not seem to be any `explicit_reopen` rule, but there [is a `implicit_reopen`](https://github.com/dart-lang/linter/blob/main/lib/src/rules/implicit_reopen.dart).