### PR TITLE
Fix bool.parse() examples

### DIFF
--- a/sdk/lib/core/bool.dart
+++ b/sdk/lib/core/bool.dart
@@ -112,15 +112,15 @@ final class bool {
   ///
   /// Example:
   /// ```dart
-  /// print(bool.tryParse('true')); // true
-  /// print(bool.tryParse('false')); // false
-  /// print(bool.tryParse('TRUE')); // throws FormatException
-  /// print(bool.tryParse('TRUE', caseSensitive: false)); // true
-  /// print(bool.tryParse('FALSE', caseSensitive: false)); // false
-  /// print(bool.tryParse('NO')); // throws FormatException
-  /// print(bool.tryParse('YES')); // throws FormatException
-  /// print(bool.tryParse('0')); // throws FormatException
-  /// print(bool.tryParse('1')); // throws FormatException
+  /// print(bool.parse('true')); // true
+  /// print(bool.parse('false')); // false
+  /// print(bool.parse('TRUE')); // throws FormatException
+  /// print(bool.parse('TRUE', caseSensitive: false)); // true
+  /// print(bool.parse('FALSE', caseSensitive: false)); // false
+  /// print(bool.parse('NO')); // throws FormatException
+  /// print(bool.parse('YES')); // throws FormatException
+  /// print(bool.parse('0')); // throws FormatException
+  /// print(bool.parse('1')); // throws FormatException
   /// ```
   @Since("3.0")
   external static bool parse(String source, {bool caseSensitive = true});


### PR DESCRIPTION
It seems the examples are incorrect, and the intention was to show `parse()` examples, not `tryParse()` ones. This is made more confusing by the recommendation to use `tryParse()` in some cases, directly above the examples.


---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

#### Contribution guidelines:

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.

---
