### PR TITLE
[vm/ffi] Use LoadNativeField for FFI pointers

### DIFF
--- a/runtime/vm/compiler/backend/inliner.cc
+++ b/runtime/vm/compiler/backend/inliner.cc
@@ -969,7 +969,8 @@ static void ReplaceParameterStubs(Zone* zone,
   for (intptr_t i = 0; i < defns->length(); ++i) {
     ConstantInstr* constant = (*defns)[i]->AsConstant();
     if (constant != nullptr && constant->HasUses()) {
-      constant->ReplaceUsesWith(caller_graph->GetConstant(constant->value()));
+      constant->ReplaceUsesWith(caller_graph->GetConstant(
+          constant->value(), constant->representation()));
     }
   }
 
@@ -977,7 +978,8 @@ static void ReplaceParameterStubs(Zone* zone,
   for (intptr_t i = 0; i < defns->length(); ++i) {
     ConstantInstr* constant = (*defns)[i]->AsConstant();
     if (constant != nullptr && constant->HasUses()) {
-      constant->ReplaceUsesWith(caller_graph->GetConstant(constant->value()));
+      constant->ReplaceUsesWith(caller_graph->GetConstant(
+          constant->value(), constant->representation()));
     }
 
     SpecialParameterInstr* param = (*defns)[i]->AsSpecialParameter();

--- a/runtime/vm/compiler/backend/redundancy_elimination.cc
+++ b/runtime/vm/compiler/backend/redundancy_elimination.cc
@@ -2187,6 +2187,12 @@ class LoadOptimizer : public ValueObject {
             if (auto* const load = use->instruction()->AsLoadField()) {
               place_id = GetPlaceId(load);
               slot = &load->slot();
+              if (alloc->IsAllocateTypedData() &&
+                  slot == &Slot::PointerBase_data()) {
+                // Typed data payload elements are unboxed and initialized to
+                // zero, so don't forward a tagged null value.
+                continue;
+              }
             } else if (auto* const store = use->instruction()->AsStoreField()) {
               ASSERT(!alloc->IsArrayAllocation());
               place_id = GetPlaceId(store);


### PR DESCRIPTION
This allows the VM to elide FFI Pointer allocations during pointer arithmetic.

Bug: https://github.com/dart-lang/sdk/issues/42793

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

#### Contribution guidelines:

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.

---
