### PR TITLE
Fix grammar docs for type aliases in AST

### DIFF
--- a/pkg/analyzer/lib/src/dart/ast/ast.dart
+++ b/pkg/analyzer/lib/src/dart/ast/ast.dart
@@ -3152,8 +3152,7 @@ abstract final class ClassTypeAlias implements TypeAlias {
 /// A class type alias.
 ///
 ///    classTypeAlias ::=
-///        [SimpleIdentifier] [TypeParameterList]? '=' classModifiers
-///        mixinApplication
+///        classModifiers 'class' [SimpleIdentifier] [TypeParameterList]? '=' mixinApplication
 ///
 ///    classModifiers ::= 'sealed'
 ///      | 'abstract'? ('base' | 'interface' | 'final')?
@@ -8906,10 +8905,10 @@ abstract final class FunctionTypeAlias implements TypeAlias {
 /// A function type alias.
 ///
 ///    functionTypeAlias ::=
-///        functionPrefix [TypeParameterList]? [FormalParameterList] ';'
+///        'typedef' functionPrefix [TypeParameterList]? [FormalParameterList] ';'
 ///
 ///    functionPrefix ::=
-///        [TypeName]? [SimpleIdentifier]
+///        [TypeAnnotation]? [SimpleIdentifier]
 final class FunctionTypeAliasImpl extends TypeAliasImpl
     implements FunctionTypeAlias {
   /// The name of the return type of the function type being defined, or `null`
@@ -9327,8 +9326,7 @@ abstract final class GenericTypeAlias implements TypeAlias {
 /// A generic type alias.
 ///
 ///    functionTypeAlias ::=
-///        metadata 'typedef' [SimpleIdentifier] [TypeParameterList]? =
-///        [FunctionType] ';'
+///        'typedef' [SimpleIdentifier] [TypeParameterList]? = [FunctionType] ';'
 final class GenericTypeAliasImpl extends TypeAliasImpl
     implements GenericTypeAlias {
   /// The type being defined by the alias.
@@ -18489,14 +18487,12 @@ abstract final class TypeAlias implements NamedCompilationUnitMember {
 /// The declaration of a type alias.
 ///
 ///    typeAlias ::=
-///        'typedef' typeAliasBody
-///
-///    typeAliasBody ::=
-///        classTypeAlias
-///      | functionTypeAlias
+///        [ClassTypeAlias]
+///      | [FunctionTypeAlias]
+///      | [GenericTypeAlias]
 sealed class TypeAliasImpl extends NamedCompilationUnitMemberImpl
     implements TypeAlias {
-  /// The token representing the 'typedef' keyword.
+  /// The token representing the 'typedef' or 'class' keyword.
   @override
   final Token typedefKeyword;
 

--- a/pkg/analyzer/lib/src/dart/ast/ast.dart
+++ b/pkg/analyzer/lib/src/dart/ast/ast.dart
@@ -3098,7 +3098,7 @@ abstract final class ClassOrAugmentationDeclaration
 /// A class type alias.
 ///
 ///    classTypeAlias ::=
-///        name [TypeParameterList]? '=' classModifiers mixinApplication
+///        classModifiers 'class' [SimpleIdentifier] [TypeParameterList]? '=' mixinApplication
 ///
 ///    classModifiers ::= 'sealed'
 ///      | 'abstract'? ('base' | 'interface' | 'final')?
@@ -8881,7 +8881,7 @@ final class FunctionReferenceImpl extends CommentReferableExpressionImpl
 /// A function type alias.
 ///
 ///    functionTypeAlias ::=
-///        functionPrefix [TypeParameterList]? [FormalParameterList] ';'
+///        'typedef' functionPrefix [TypeParameterList]? [FormalParameterList] ';'
 ///
 ///    functionPrefix ::=
 ///        [TypeAnnotation]? [SimpleIdentifier]
@@ -9302,7 +9302,7 @@ final class GenericFunctionTypeImpl extends TypeAnnotationImpl
 /// A generic type alias.
 ///
 ///    functionTypeAlias ::=
-///        metadata 'typedef' name [TypeParameterList]? = [FunctionType] ';'
+///        'typedef' [SimpleIdentifier] [TypeParameterList]? = [FunctionType] ';'
 ///
 /// Clients may not extend, implement or mix-in this class.
 abstract final class GenericTypeAlias implements TypeAlias {
@@ -18473,18 +18473,16 @@ final class TryStatementImpl extends StatementImpl implements TryStatement {
 /// The declaration of a type alias.
 ///
 ///    typeAlias ::=
-///        'typedef' typeAliasBody
-///
-///    typeAliasBody ::=
-///        classTypeAlias
-///      | functionTypeAlias
+///        [ClassTypeAlias]
+///      | [FunctionTypeAlias]
+///      | [GenericTypeAlias]
 ///
 /// Clients may not extend, implement or mix-in this class.
 abstract final class TypeAlias implements NamedCompilationUnitMember {
   /// Return the semicolon terminating the declaration.
   Token get semicolon;
 
-  /// Return the token representing the 'typedef' keyword.
+  /// Return the token representing the 'typedef' or 'class' keyword.
   Token get typedefKeyword;
 }
 


### PR DESCRIPTION
- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

Noticed issues when researching this mystical "class alias" feature. There are a few issues still:

- The AST node `TypeAlias` has a getter called `typedefKeyword` which says it will return the token for the 'typedef' token. This, however, is not true. For a class type alias this will return the token for 'class'. Is that something that should be fixed (at least the docs)?
- The language spec calls this feature "mixin classes" or "mixin application class" https://github.com/dart-lang/language/blob/cc2c933b1ae5a2c837f89ca4490040ff158a676f/specification/dartLangSpec.tex#L5428. In the AST this is called "ClassTypeAlias". This is somewhat confusing, especially when trying to find any documentation for this feature. Which, to my knowledge is very scares. I could not find any mention of it on dart.dev. The lang spec is also outdated, since it does not mention dart 3 class modifiers.

Maybe I am nitpicking here, but is this really a "type alias"? It introduces a new nominal type which exists at runtime, unlike standard `typedef`s. TBH it is quite unclear what this feature is for exactly.

Let me know if I should convert any of the above to an issue.


closes #35485
