### PR TITLE
Add missing include for errno.h

### DIFF
--- a/runtime/bin/socket_base.cc
+++ b/runtime/bin/socket_base.cc
@@ -4,6 +4,8 @@
 
 #include "bin/socket_base.h"
 
+#include <errno.h>  // NOLINT
+
 #include "bin/dartutils.h"
 #include "bin/io_buffer.h"
 #include "bin/isolate_data.h"


### PR DESCRIPTION
Musl build is broken on main branch due to a missing include: https://github.com/dart-musl/dart/actions/runs/5217280442/jobs/9417027955

This PR adds the missing include for errno.h.

cc @mraleph
