### PR TITLE
[infra] Enhance Alpine Linux sysroot support

### DIFF
--- a/build/linux/alpine_sysroot_scripts/README.md
+++ b/build/linux/alpine_sysroot_scripts/README.md
@@ -8,6 +8,19 @@ On Alpine Linux, run the script directly:
 ./build/linux/alpine_sysroot_scripts/install-sysroot.sh
 ```
 
+By default, the script installs sysroots for the following architectures:
+
+- `aarch64`
+- `armv7`
+- `x86_64`
+- `x86`
+
+To install sysroots for specific architectures, you can run:
+
+``` sh
+./build/linux/alpine_sysroot_scripts/install-sysroot.sh aarch64 riscv64 x86_64 ...
+```
+
 On other linux systems, you can run the script with Alpine Linux container:
 
 ``` sh

--- a/build/linux/alpine_sysroot_scripts/install-sysroot.sh
+++ b/build/linux/alpine_sysroot_scripts/install-sysroot.sh
@@ -20,9 +20,8 @@ SCRIPT="$(readlink -f -- "$0")"
 
 WORKDIR="$(dirname -- "$(dirname -- "$SCRIPT")")"
 
-xargs -n 1 -- sh -xc 'apk add --root "$1/alpine-linux-$2-sysroot" --repositories-file /etc/apk/repositories --allow-untrusted --arch "$2" --no-cache --no-scripts --initdb -- alpine-base alpine-sdk linux-headers' -- "$WORKDIR" <<'EOF'
-aarch64
-armv7
-x86
-x86_64
-EOF
+if test $# -eq 0; then
+  set aarch64 armv7 x86_64 x86
+fi
+
+echo "$@" | xargs -n 1 -- sh -xc 'apk add --root "$1/alpine-linux-$2-sysroot" --repositories-file /etc/apk/repositories --allow-untrusted --arch "$2" --no-cache --no-scripts --initdb -- alpine-base alpine-sdk linux-headers' -- "$WORKDIR"


### PR DESCRIPTION
This PR enhances alpine sysroot install script so that user can easily customize which architectures to be installed.

I plan to add `riscv64` dev-channel builds to https://github.com/dart-musl/dart once this lands.

cc @mraleph