### PR TITLE
Add log10, log2 and log1p math functions

### DIFF
--- a/sdk/lib/_internal/js_dev_runtime/patch/math_patch.dart
+++ b/sdk/lib/_internal/js_dev_runtime/patch/math_patch.dart
@@ -61,6 +61,18 @@ double log(@nullCheck num x) => JS<double>('!', r'Math.log(#)', x);
 
 @patch
 @notNull
+double log10(@nullCheck num x) => JS<double>('!', r'Math.log10(#)', x);
+
+@patch
+@notNull
+double log2(@nullCheck num x) => JS<double>('!', r'Math.log2(#)', x);
+
+@patch
+@notNull
+double log1p(@nullCheck num x) => JS<double>('!', r'Math.log1p(#)', x);
+
+@patch
+@notNull
 num pow(@nullCheck num x, @nullCheck num exponent) =>
     JS<num>('!', r'Math.pow(#, #)', x, exponent);
 

--- a/sdk/lib/_internal/js_runtime/lib/math_patch.dart
+++ b/sdk/lib/_internal/js_runtime/lib/math_patch.dart
@@ -54,6 +54,15 @@ double exp(num x) => JS('num', r'Math.exp(#)', checkNum(x));
 double log(num x) => JS('num', r'Math.log(#)', checkNum(x));
 
 @patch
+double log10(num x) => JS('num', r'Math.log10(#)', checkNum(x));
+
+@patch
+double log2(num x) => JS('num', r'Math.log2(#)', checkNum(x));
+
+@patch
+double log1p(num x) => JS('num', r'Math.log1p(#)', checkNum(x));
+
+@patch
 num pow(num x, num exponent) {
   checkNum(x);
   checkNum(exponent);

--- a/sdk/lib/_internal/vm/lib/math_patch.dart
+++ b/sdk/lib/_internal/vm/lib/math_patch.dart
@@ -161,6 +161,18 @@ double exp(num x) => _exp(x.toDouble());
 @pragma("vm:exact-result-type", "dart:core#_Double")
 @pragma("vm:prefer-inline")
 double log(num x) => _log(x.toDouble());
+@patch
+@pragma("vm:exact-result-type", "dart:core#_Double")
+@pragma("vm:prefer-inline")
+double log10(num x) => _log10(x.toDouble());
+@patch
+@pragma("vm:exact-result-type", "dart:core#_Double")
+@pragma("vm:prefer-inline")
+double log2(num x) => _log2(x.toDouble());
+@patch
+@pragma("vm:exact-result-type", "dart:core#_Double")
+@pragma("vm:prefer-inline")
+double log1p(num x) => _log1p(x.toDouble());
 
 @pragma("vm:recognized", "other")
 @pragma("vm:prefer-inline")
@@ -192,6 +204,15 @@ external double _exp(double x);
 @pragma("vm:recognized", "other")
 @pragma("vm:prefer-inline")
 external double _log(double x);
+@pragma("vm:recognized", "other")
+@pragma("vm:prefer-inline")
+external double _log10(double x);
+@pragma("vm:recognized", "other")
+@pragma("vm:prefer-inline")
+external double _log2(double x);
+@pragma("vm:recognized", "other")
+@pragma("vm:prefer-inline")
+external double _log1p(double x);
 
 // TODO(iposva): Handle patch methods within a patch class correctly.
 @patch

--- a/sdk/lib/_internal/wasm/lib/math_patch.dart
+++ b/sdk/lib/_internal/wasm/lib/math_patch.dart
@@ -118,6 +118,12 @@ double sqrt(num x) => _sqrt(x.toDouble());
 double exp(num x) => _exp(x.toDouble());
 @patch
 double log(num x) => _log(x.toDouble());
+@patch
+double log10(num x) => _log10(x.toDouble());
+@patch
+double log2(num x) => _log2(x.toDouble());
+@patch
+double log1p(num x) => _log1p(x.toDouble());
 
 @pragma("wasm:import", "Math.atan2")
 external double _atan2(double a, double b);
@@ -139,6 +145,12 @@ external double _sqrt(double x);
 external double _exp(double x);
 @pragma("wasm:import", "Math.log")
 external double _log(double x);
+@pragma("wasm:import", "Math.log10")
+external double _log10(double x);
+@pragma("wasm:import", "Math.log2")
+external double _log2(double x);
+@pragma("wasm:import", "Math.log1p")
+external double _log1p(double x);
 
 // TODO(iposva): Handle patch methods within a patch class correctly.
 @patch

--- a/sdk/lib/math/math.dart
+++ b/sdk/lib/math/math.dart
@@ -253,3 +253,21 @@ external double exp(num x);
 /// Returns negative infinity if [x] is equal to zero.
 /// Returns NaN if [x] is NaN or less than zero.
 external double log(num x);
+
+/// Converts [x] to a [double] and returns the base 10 logarithm of the value.
+///
+/// Returns negative infinity if [x] is equal to zero.
+/// Returns NaN if [x] is NaN or less than zero.
+external double log10(num x);
+
+/// Converts [x] to a [double] and returns the base 2 logarithm of the value.
+///
+/// Returns negative infinity if [x] is equal to zero.
+/// Returns NaN if [x] is NaN or less than zero.
+external double log2(num x);
+
+/// Converts [x] to a [double] and returns the natural logarithm of 1 + [x].
+///
+/// Returns negative infinity if [x] is equal to zero.
+/// Returns NaN if [x] is NaN or less than zero.
+external double log1p(num x);

--- a/tests/lib/math/math_test.dart
+++ b/tests/lib/math/math_test.dart
@@ -146,6 +146,25 @@ class MathTest {
     checkVeryClose(ln2, log(2.0));
   }
 
+  static void testLog10() {
+    checkVeryClose(1.0, log10(10));
+    // Even though E is imprecise, it is good enough to get really close to log10e.
+    // We still provide an epsilon.
+    checkClose(log10e, log10(e), 1e-16);
+  }
+
+  static void testLog2() {
+    checkVeryClose(1.0, log2(2));
+    // Even though E is imprecise, it is good enough to get really close to log2e.
+    // We still provide an epsilon.
+    checkClose(log2e, log2(e), 1e-16);
+  }
+
+  static void testLog1p() {
+    checkVeryClose(ln10, log1p(9.0));
+    checkVeryClose(ln2, log1p(1.0));
+  }
+
   static bool parseIntThrowsFormatException(str) {
     try {
       int.parse(str);

--- a/tests/lib_2/math/math_test.dart
+++ b/tests/lib_2/math/math_test.dart
@@ -148,6 +148,25 @@ class MathTest {
     checkVeryClose(ln2, log(2.0));
   }
 
+  static void testLog10() {
+    checkVeryClose(1.0, log10(10.0));
+    // Even though E is imprecise, it is good enough to get really close to log10e.
+    // We still provide an epsilon.
+    checkClose(log10e, log10(e), 1e-16);
+  }
+
+  static void testLog2() {
+    checkVeryClose(1.0, log2(2.0));
+    // Even though E is imprecise, it is good enough to get really close to log2e.
+    // We still provide an epsilon.
+    checkClose(log2e, log2(e), 1e-16);
+  }
+
+  static void testLog1p() {
+    checkVeryClose(ln10, log1p(9.0));
+    checkVeryClose(ln2, log1p(1.0));
+  }
+
   static bool parseIntThrowsFormatException(str) {
     try {
       int.parse(str);


### PR DESCRIPTION
JavaScript and native platforms have already had log10, log2 and log1p functions for a long time. It's time to add it to SDK.

These functions are not just only convenient aliases

- log(x) / ln10 => log10(x)
- log(x) / ln2 => log2(x)
- log(x+1) => log1p

but also, ones are more accurate. Consider JS REPL:

```javascript
console.log(Math.LN10)
// 2.302585092994046
console.log(Math.log(1000.0) / Math.LN10)
// 2.9999999999999996

// But native implementation is accurate
console.log(Math.log10(1000.0))
// 3

// let's try more precise constant
let ln10 = 2.3025850929940456840179914546843642076011014886288;
console.log(Math.log(1000.0) / ln10)
// 2.9999999999999996
```


_Thanks for your contribution! Please replace this text with a description of what this PR is changing or adding and why, list any relevant issues, and review the contribution guidelines below._

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
