### PR TITLE
Tiny code cleanup: Remove `_asyncRunZoned` being an alias of `runZoned`

### DIFF
--- a/sdk/lib/_http/http.dart
+++ b/sdk/lib/_http/http.dart
@@ -11,6 +11,7 @@ import 'dart:_internal'
         valueOfNonNullableParamWithDefault,
         HttpStatus;
 import 'dart:async';
+import 'dart:async' as dart_async show runZoned;
 import 'dart:collection'
     show
         HashMap,

--- a/sdk/lib/_http/overrides.dart
+++ b/sdk/lib/_http/overrides.dart
@@ -52,7 +52,7 @@ abstract class HttpOverrides {
           findProxyFromEnvironment}) {
     HttpOverrides overrides =
         _HttpOverridesScope(createHttpClient, findProxyFromEnvironment);
-    return runZoned<R>(body,
+    return dart_async.runZoned<R>(body,
         zoneValues: {_httpOverridesToken: overrides});
   }
 

--- a/sdk/lib/_http/overrides.dart
+++ b/sdk/lib/_http/overrides.dart
@@ -6,8 +6,6 @@ part of dart._http;
 
 final _httpOverridesToken = Object();
 
-const _asyncRunZoned = runZoned;
-
 /// This class facilitates overriding [HttpClient] with a mock implementation.
 /// It should be extended by another class in client code with overrides
 /// that construct a mock implementation. The implementation in this base class
@@ -54,7 +52,7 @@ abstract class HttpOverrides {
           findProxyFromEnvironment}) {
     HttpOverrides overrides =
         _HttpOverridesScope(createHttpClient, findProxyFromEnvironment);
-    return _asyncRunZoned<R>(body,
+    return runZoned<R>(body,
         zoneValues: {_httpOverridesToken: overrides});
   }
 
@@ -63,7 +61,7 @@ abstract class HttpOverrides {
   /// Note that [overrides] should be an instance of a class that extends
   /// [HttpOverrides].
   static R runWithHttpOverrides<R>(R Function() body, HttpOverrides overrides) {
-    return _asyncRunZoned<R>(body,
+    return runZoned<R>(body,
         zoneValues: {_httpOverridesToken: overrides});
   }
 

--- a/sdk/lib/_http/overrides.dart
+++ b/sdk/lib/_http/overrides.dart
@@ -61,7 +61,7 @@ abstract class HttpOverrides {
   /// Note that [overrides] should be an instance of a class that extends
   /// [HttpOverrides].
   static R runWithHttpOverrides<R>(R Function() body, HttpOverrides overrides) {
-    return runZoned<R>(body,
+    return dart_async.runZoned<R>(body,
         zoneValues: {_httpOverridesToken: overrides});
   }
 

--- a/sdk/lib/io/io.dart
+++ b/sdk/lib/io/io.dart
@@ -191,6 +191,7 @@
 library dart.io;
 
 import 'dart:async';
+import 'dart:async' as dart_async show runZoned;
 import 'dart:_internal' hide Symbol;
 import 'dart:collection'
     show HashMap, HashSet, Queue, ListQueue, MapBase, UnmodifiableMapView;

--- a/sdk/lib/io/overrides.dart
+++ b/sdk/lib/io/overrides.dart
@@ -133,7 +133,7 @@ abstract class IOOverrides {
       stdout,
       stderr,
     );
-    return runZoned<R>(body, zoneValues: {_ioOverridesToken: overrides});
+    return dart_async.runZoned<R>(body, zoneValues: {_ioOverridesToken: overrides});
   }
 
   /// Runs [body] in a fresh [Zone] using the overrides found in [overrides].
@@ -141,7 +141,7 @@ abstract class IOOverrides {
   /// Note that [overrides] should be an instance of a class that extends
   /// [IOOverrides].
   static R runWithIOOverrides<R>(R body(), IOOverrides overrides) {
-    return runZoned<R>(body, zoneValues: {_ioOverridesToken: overrides});
+    return dart_async.runZoned<R>(body, zoneValues: {_ioOverridesToken: overrides});
   }
 
   // Directory

--- a/sdk/lib/io/overrides.dart
+++ b/sdk/lib/io/overrides.dart
@@ -6,8 +6,6 @@ part of dart.io;
 
 final _ioOverridesToken = new Object();
 
-const _asyncRunZoned = runZoned;
-
 /// Facilities for overriding various APIs of `dart:io` with mock
 /// implementations.
 ///
@@ -135,7 +133,7 @@ abstract class IOOverrides {
       stdout,
       stderr,
     );
-    return _asyncRunZoned<R>(body, zoneValues: {_ioOverridesToken: overrides});
+    return runZoned<R>(body, zoneValues: {_ioOverridesToken: overrides});
   }
 
   /// Runs [body] in a fresh [Zone] using the overrides found in [overrides].
@@ -143,7 +141,7 @@ abstract class IOOverrides {
   /// Note that [overrides] should be an instance of a class that extends
   /// [IOOverrides].
   static R runWithIOOverrides<R>(R body(), IOOverrides overrides) {
-    return _asyncRunZoned<R>(body, zoneValues: {_ioOverridesToken: overrides});
+    return runZoned<R>(body, zoneValues: {_ioOverridesToken: overrides});
   }
 
   // Directory


### PR DESCRIPTION
This is just super tiny code cleanup. I am not sure why we have:

```dart
const _asyncRunZoned = runZoned;
```

when reading the IOOverrides code. IMHO, runZoned already handles the async, and everyone using it should be aware of that (at least Dart SDK developers who are very familiar with Dart). In addition, adding such alias will not change the behavior of the function.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
