### PR TITLE
Document the return value of `any` and `every` for empty values.

### DIFF
--- a/sdk/lib/core/iterable.dart
+++ b/sdk/lib/core/iterable.dart
@@ -412,6 +412,7 @@ abstract mixin class Iterable<E> {
   ///
   /// Checks every element in iteration order, and returns `false` if
   /// any of them make [test] return `false`, otherwise returns `true`.
+  /// Returns `true` if the iterable is empty.
   ///
   /// Example:
   /// ```dart
@@ -465,6 +466,7 @@ abstract mixin class Iterable<E> {
   ///
   /// Checks every element in iteration order, and returns `true` if
   /// any of them make [test] return `true`, otherwise returns false.
+  /// Returns `false` if the iterable is empty.
   ///
   /// Example:
   /// ```dart


### PR DESCRIPTION
The current documentation is not explicit about the returned bool value for an empty `Iterable`. The developer needs to look at the implementation code to ensure the correct behavior.

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
