### PR TITLE
Fix Uri.toString() for empty string field

### DIFF
--- a/sdk/lib/core/uri.dart
+++ b/sdk/lib/core/uri.dart
@@ -2935,11 +2935,11 @@ class _Uri implements Uri {
       _writeAuthority(sb);
     }
     sb.write(path);
-    if (_query != null)
+    if (_query != null && _query.isNotEmpty)
       sb
         ..write("?")
         ..write(_query);
-    if (_fragment != null)
+    if (_fragment != null && _fragment.isNotEmpty)
       sb
         ..write("#")
         ..write(_fragment);


### PR DESCRIPTION
`_initializeText()` should check if query and fragment string is empty.