### PR TITLE
[vm/io] Fall back to IfIndex if Ipv6IfIndex is zero

### DIFF
--- a/runtime/bin/socket_base_win.cc
+++ b/runtime/bin/socket_base_win.cc
@@ -380,12 +380,11 @@ AddressList<InterfaceSocketAddress>* SocketBase::ListInterfaces(
   for (IP_ADAPTER_ADDRESSES* a = addrs; a != nullptr; a = a->Next) {
     for (IP_ADAPTER_UNICAST_ADDRESS* u = a->FirstUnicastAddress; u != nullptr;
          u = u->Next) {
-      ASSERT((a->Flags & IP_ADAPTER_IPV4_ENABLED && a->IfIndex != 0) ||
-             (a->Flags & IP_ADAPTER_IPV6_ENABLED && a->Ipv6IfIndex != 0));
+      ASSERT(type != AF_INET || a->Flags & IP_ADAPTER_IPV4_ENABLED);
+      ASSERT(type != AF_INET6 || a->Flags & IP_ADAPTER_IPV6_ENABLED);
       ASSERT(a->IfIndex == a->Ipv6IfIndex ||
-             !!(a->Flags & IP_ADAPTER_IPV4_ENABLED) !=
-                 !!(a->Flags & IP_ADAPTER_IPV6_ENABLED));
-
+             !(a->Flags & IP_ADAPTER_IPV4_ENABLED) ||
+             !(a->Flags & IP_ADAPTER_IPV6_ENABLED));
       addresses->SetAt(i,
                        new InterfaceSocketAddress(
                            u->Address.lpSockaddr,

--- a/runtime/bin/socket_base_win.cc
+++ b/runtime/bin/socket_base_win.cc
@@ -380,6 +380,12 @@ AddressList<InterfaceSocketAddress>* SocketBase::ListInterfaces(
   for (IP_ADAPTER_ADDRESSES* a = addrs; a != nullptr; a = a->Next) {
     for (IP_ADAPTER_UNICAST_ADDRESS* u = a->FirstUnicastAddress; u != nullptr;
          u = u->Next) {
+      ASSERT((a->Flags & IP_ADAPTER_IPV4_ENABLED && a->IfIndex != 0) ||
+             (a->Flags & IP_ADAPTER_IPV6_ENABLED && a->Ipv6IfIndex != 0));
+      ASSERT(a->IfIndex == a->Ipv6IfIndex ||
+             !!(a->Flags & IP_ADAPTER_IPV4_ENABLED) !=
+                 !!(a->Flags & IP_ADAPTER_IPV6_ENABLED));
+
       addresses->SetAt(i,
                        new InterfaceSocketAddress(
                            u->Address.lpSockaddr,

--- a/runtime/bin/socket_base_win.cc
+++ b/runtime/bin/socket_base_win.cc
@@ -380,10 +380,11 @@ AddressList<InterfaceSocketAddress>* SocketBase::ListInterfaces(
   for (IP_ADAPTER_ADDRESSES* a = addrs; a != nullptr; a = a->Next) {
     for (IP_ADAPTER_UNICAST_ADDRESS* u = a->FirstUnicastAddress; u != nullptr;
          u = u->Next) {
-      addresses->SetAt(
-          i, new InterfaceSocketAddress(
-                 u->Address.lpSockaddr,
-                 StringUtilsWin::WideToUtf8(a->FriendlyName), a->Ipv6IfIndex));
+      addresses->SetAt(i,
+                       new InterfaceSocketAddress(
+                           u->Address.lpSockaddr,
+                           StringUtilsWin::WideToUtf8(a->FriendlyName),
+                           a->Ipv6IfIndex != 0 ? a->Ipv6IfIndex : a->IfIndex));
       i++;
     }
   }


### PR DESCRIPTION
On Windows, network interfaces have two indices, `IfIndex` and `Ipv6IfIndex` (see https://learn.microsoft.com/en-us/windows/win32/api/iptypes/ns-iptypes-ip_adapter_addresses_lh).

If both IPv4 and IPv6 are enabled for a particular interface, `IfIndex` corresponds to `Ipv6IfIndex`.
For disabled protocols, however, the corresponding index is zero.

As Dart currently only respects the IPv6 index, `NetworkInterface.list` will return invalid indices for interfaces with IPv6 turned off which will make `RawDatagramSocket.joinMulticast` fail (even when attempting to join an IPv4 multicast group).

This PR adds a fallback to ensure that `NetworkInterface.index` is correct even if IPv6 is turned off.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
