### PR TITLE
Add `--downgrade` to flutter/packages analysis

### DIFF
--- a/tools/bots/flutter/analyze_flutter_packages.sh
+++ b/tools/bots/flutter/analyze_flutter_packages.sh
@@ -35,6 +35,10 @@ cd packages
 (cd script/tool; dart analyze --suppress-analytics --fatal-infos)
 
 # Invoke the repo's analysis script.
+# Use --downgrade to avoid potential breakage from transitive
+# dependency publishing. See
+# https://github.com/flutter/flutter/issues/129633
 dart run script/tool/bin/flutter_plugin_tools.dart analyze \
+  --downgrade \
   --analysis-sdk $sdk \
   --custom-analysis=script/configs/custom_analysis.yaml


### PR DESCRIPTION
See https://github.com/flutter/flutter/issues/129633 for context.

Since flutter/packages doesn't pin, this test is somewhat prone to out-of-band failures when transitive dependencies are published. Using the `--downgrade` flag uses the oldest possible versions of dependencies rather than the newest, which avoids picking up newly published versions.
