### PR TITLE
fix: typo in doc comment

### DIFF
--- a/sdk/lib/core/bool.dart
+++ b/sdk/lib/core/bool.dart
@@ -57,7 +57,7 @@ final class bool {
 
   /// Whether there is an environment declaration [name].
   ///
-  /// Returns true iff there is an environment declaration with the name [name]
+  /// Returns true if there is an environment declaration with the name [name].
   /// If there is then the value of that declaration can be accessed using
   /// `const String.fromEnvironment(name)`. Otherwise,
   /// `String.fromEnvironment(name, defaultValue: someString)`


### PR DESCRIPTION
Fixes a typo in "bool.hasEnvironment()" doc comment ("iff" -> "if")

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
