### PR TITLE
Fix wrong example for queryParametersAll

### DIFF
--- a/sdk/lib/core/uri.dart
+++ b/sdk/lib/core/uri.dart
@@ -568,7 +568,7 @@ abstract interface class Uri {
   /// ```dart import:convert
   /// final uri =
   ///     Uri.parse('https://example.com/api/fetch?limit=10,20,30&max=100');
-  /// print(jsonEncode(uri.queryParameters)); // {"limit":"10,20,30","max":"100"}
+  /// print(jsonEncode(uri.queryParametersAll)); // {"limit":["10,20,30"],"max":["100"]}
   /// ```
   ///
   /// The map and the lists it contains are unmodifiable.

--- a/sdk/lib/core/uri.dart
+++ b/sdk/lib/core/uri.dart
@@ -567,8 +567,8 @@ abstract interface class Uri {
   /// Example:
   /// ```dart import:convert
   /// final uri =
-  ///     Uri.parse('https://example.com/api/fetch?limit=10,20,30&max=100');
-  /// print(jsonEncode(uri.queryParametersAll)); // {"limit":["10,20,30"],"max":["100"]}
+  ///     Uri.parse('https://example.com/api/fetch?limit=10&limit=20&limit=30&max=100');
+  /// print(jsonEncode(uri.queryParametersAll)); // {"limit":["10","20","30"],"max":["100"]}
   /// ```
   ///
   /// The map and the lists it contains are unmodifiable.


### PR DESCRIPTION
This fixes the wrong example for `queryParametersAll` which was a duplicate of example of `queryParameters`.

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
