### PR TITLE
add fix for removing the leading underscore in constructor parameter lists

### DIFF
--- a/pkg/analysis_server/lib/src/services/correction/dart/remove_leading_underscore.dart
+++ b/pkg/analysis_server/lib/src/services/correction/dart/remove_leading_underscore.dart
@@ -85,7 +85,8 @@ class RemoveLeadingUnderscore extends ResolvedCorrectionProducer {
         var root = node
             .thisOrAncestorMatching((node) =>
                 node.parent is FunctionDeclaration ||
-                node.parent is MethodDeclaration)
+                node.parent is MethodDeclaration ||
+                node.parent is ConstructorDeclaration)
             ?.parent;
         if (root != null) {
           references = findLocalElementReferences(root, element);

--- a/pkg/analysis_server/test/src/services/correction/fix/remove_leading_underscore_test.dart
+++ b/pkg/analysis_server/test/src/services/correction/fix/remove_leading_underscore_test.dart
@@ -222,6 +222,23 @@ void f() {
 ''');
   }
 
+  Future<void> test_parameter_constructor() async {
+    await resolveTestCode('''
+class A {
+  A(int _foo) {
+    print(_foo);
+  }
+}
+''');
+    await assertHasFix('''
+class A {
+  A(int foo) {
+    print(foo);
+  }
+}
+''');
+  }
+
   Future<void> test_parameter_function() async {
     await resolveTestCode('''
 void f(int _foo) {


### PR DESCRIPTION
Parameters to constructors that have a leading underscore in the name were not being auto fixed for `no_leading_underscores_for_local_identifiers`.
This corrects that.

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
