### PR TITLE
Added missing content-disposition header

### DIFF
--- a/sdk/lib/_http/http.dart
+++ b/sdk/lib/_http/http.dart
@@ -389,6 +389,7 @@ abstract interface class HttpHeaders {
   static const viaHeader = "via";
   static const warningHeader = "warning";
   static const wwwAuthenticateHeader = "www-authenticate";
+  static const contentDisposition = "content-disposition";
 
   // Cookie headers from RFC 6265.
   static const cookieHeader = "cookie";
@@ -429,7 +430,8 @@ abstract interface class HttpHeaders {
     retryAfterHeader,
     serverHeader,
     varyHeader,
-    wwwAuthenticateHeader
+    wwwAuthenticateHeader,
+    contentDisposition
   ];
 
   static const requestHeaders = [


### PR DESCRIPTION
Added missing [content-disposition](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition) header in `HttpHeaders` interface and added it in `responseHeaders` constant list

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
