### PR TITLE
Add extra documentation to Enum to point to EnumName.

### DIFF
--- a/sdk/lib/core/enum.dart
+++ b/sdk/lib/core/enum.dart
@@ -11,7 +11,7 @@ part of dart.core;
 /// Non-platform classes cannot extend or mix in this class.
 /// Concrete classes cannot implement the interface.
 ///
-/// The intentifier used to name an `enum` value is available as a [String],
+/// The identifier used to name an `enum` value is available as a [String],
 /// via the [EnumName.name] extension property on the `enum` value.
 @Since("2.14")
 abstract interface class Enum {

--- a/sdk/lib/core/enum.dart
+++ b/sdk/lib/core/enum.dart
@@ -11,8 +11,8 @@ part of dart.core;
 /// Non-platform classes cannot extend or mix in this class.
 /// Concrete classes cannot implement the interface.
 ///
-/// The string name of a value is available via the `name` property                                                                                                                    
-/// exposed by the [EnumName] extension (see [EnumName.name]).                                                                                                                         
+/// The intentifier used to name an `enum` value is available as a [String],
+/// via the [EnumName.name] extension property on the `enum` value.
 @Since("2.14")
 abstract interface class Enum {
   /// A numeric identifier for the enumerated value.

--- a/sdk/lib/core/enum.dart
+++ b/sdk/lib/core/enum.dart
@@ -10,6 +10,9 @@ part of dart.core;
 /// introduced using an `enum` declaration.
 /// Non-platform classes cannot extend or mix in this class.
 /// Concrete classes cannot implement the interface.
+///
+/// The string name of a value is available via the `name` property                                                                                                                    
+/// exposed by the [EnumName] extension (see [EnumName.name]).                                                                                                                         
 @Since("2.14")
 abstract interface class Enum {
   /// A numeric identifier for the enumerated value.


### PR DESCRIPTION
I keep forgetting you can use `.name` because the only sign that it exists in the `Enum` documentation is the in-passing mention that `Enum` has an extension, without mentioning why. This add an explicit callout to the `Enum` class definition.

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR, as far as I can tell.