### PR TITLE
Change CHANGELOG.md Link 52334 to 53005

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
   `HttpClientResponse.headers` and `HttpRequest.headers` no longer include
   trailing whitespace in their values.
 
-[#52334]: https://dartbug.com/53005
+[#53005]: https://dartbug.com/53005
 
 #### `dart:js_interop`
 


### PR DESCRIPTION
Fixed an incorrect link to changelog.md . 52334 to 53005

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
