### PR TITLE
Optimize `thisOrAncestorOfType`

### DIFF
--- a/pkg/analyzer/lib/src/dart/element/element.dart
+++ b/pkg/analyzer/lib/src/dart/element/element.dart
@@ -2422,15 +2422,13 @@ abstract class ElementImpl implements Element {
 
   @override
   E? thisOrAncestorOfType<E extends Element>() {
-    Element? element = this;
-    while (element != null && element is! E) {
-      if (element is CompilationUnitElement) {
-        element = element.enclosingElement;
-      } else {
-        element = element.enclosingElement;
-      }
+    Element element = this;
+    while (element is! E) {
+      var ancestor = element.enclosingElement;
+      if (ancestor == null) return null;
+      element = ancestor ;
     }
-    return element as E?;
+    return element;
   }
 
   @override


### PR DESCRIPTION
Remove unnecessary `instanceOf` (bottleneck)

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
