### PR TITLE
Adhere to XDG base directory spec

### DIFF
--- a/pkg/analysis_server/benchmark/benchmarks.dart
+++ b/pkg/analysis_server/benchmark/benchmarks.dart
@@ -48,7 +48,7 @@ String get analysisServerSrcPath {
 }
 
 void deleteServerCache() {
-  // ~/.dartServer/.analysis-driver/
+  // ~/.config/dartServer/.analysis-driver/
   var resourceProvider = PhysicalResourceProvider.INSTANCE;
   var stateLocation = resourceProvider.getStateLocation('.analysis-driver');
   try {

--- a/pkg/analyzer/lib/file_system/physical_file_system.dart
+++ b/pkg/analyzer/lib/file_system/physical_file_system.dart
@@ -16,19 +16,6 @@ import 'package:watcher/watcher.dart';
 /// store data across sessions.
 string _serverdir;
 
-if (Platform.isLinux) {
-  var xdgConfigHome = Platform.environment['XDG_CONFIG_HOME'];
-  if (xdgConfigHome != null) {
-    _serverDir = '$xdgConfigHome/dartServer';
-  } else {
-    _serverDir = '${Platform.environment['HOME']}/.config/dartServer';
-  }
-} else if (Platform.isMacOS) {
-  _serverDir = '${Platform.environment['HOME']}/Library/Application Support/dartServer';
-} else if (Platform.isWindows) {
-  _serverDir = '${Platform.environment['APPDATA']}/dartServer';
-}
-
 /// Returns the path to default state location.
 ///
 /// Generally this is ~/.config/dartServer. It can be overridden via the
@@ -40,10 +27,18 @@ String? _getStandardStateLocation() {
     return env['ANALYZER_STATE_LOCATION_OVERRIDE'];
   }
 
-  final home = io.Platform.isWindows ? env['LOCALAPPDATA'] : env['HOME'];
-  return home != null && io.FileSystemEntity.isDirectorySync(home)
-      ? join(home, _serverDir)
-      : null;
+  if (Platform.isLinux) {
+    var xdgConfigHome = Platform.environment['XDG_CONFIG_HOME'];
+    if (xdgConfigHome != null) {
+      return '$xdgConfigHome/dartServer';
+    } else {
+      return '${Platform.environment['HOME']}/.config/dartServer';
+    }
+  } else if (Platform.isMacOS) {
+    return '${Platform.environment['HOME']}/Library/Application Support/dartServer';
+  } else if (Platform.isWindows) {
+    return '${Platform.environment['APPDATA']}/dartServer';
+  }
 }
 
 /// A `dart:io` based implementation of [ResourceProvider].

--- a/pkg/analyzer/lib/file_system/physical_file_system.dart
+++ b/pkg/analyzer/lib/file_system/physical_file_system.dart
@@ -14,11 +14,24 @@ import 'package:watcher/watcher.dart';
 
 /// The name of the directory containing plugin specific subfolders used to
 /// store data across sessions.
-const String _serverDir = ".dartServer";
+string _serverdir;
+
+if (Platform.isLinux) {
+  var xdgConfigHome = Platform.environment['XDG_CONFIG_HOME'];
+  if (xdgConfigHome != null) {
+    _serverDir = '$xdgConfigHome/dartServer';
+  } else {
+    _serverDir = '${Platform.environment['HOME']}/.config/dartServer';
+  }
+} else if (Platform.isMacOS) {
+  _serverDir = '${Platform.environment['HOME']}/Library/Application Support/dartServer';
+} else if (Platform.isWindows) {
+  _serverDir = '${Platform.environment['APPDATA']}/dartServer';
+}
 
 /// Returns the path to default state location.
 ///
-/// Generally this is ~/.dartServer. It can be overridden via the
+/// Generally this is ~/.config/dartServer. It can be overridden via the
 /// ANALYZER_STATE_LOCATION_OVERRIDE environment variable, in which case this
 /// method will return the contents of that environment variable.
 String? _getStandardStateLocation() {

--- a/pkg/dartdev/lib/src/analytics.dart
+++ b/pkg/dartdev/lib/src/analytics.dart
@@ -50,24 +50,6 @@ Analytics get disabledAnalytics => DisabledAnalytics(_trackingId, _appName);
 
 /// Create and return an [Analytics] instance.
 Analytics createAnalyticsInstance(bool disableAnalytics) {
-  if (Platform.environment.containsKey('DART_CONFIG_DIR')) {
-    _dartDirectoryName = Platform.environment['DART_CONFIG_DIR'];
-  } else {
-    if (Platform.isLinux) {
-      var xdgConfigHome = Platform.environment['XDG_CONFIG_HOME'];
-      if (xdgConfigHome != null) {
-        _dartDirectoryName = '$xdgConfigHome/dart';
-      } else {
-        _dartDirectoryName = '${Platform.environment['HOME']}/.config/dart';
-      }
-    } else if (Platform.isMacOS) {
-      _dartDirectoryName =
-          '${Platform.environment['HOME']}/Library/Application Support/dart';
-    } else if (Platform.isWindows) {
-      _dartDirectoryName = '${Platform.environment['APPDATA']}/dart';
-    }
-  }
-
   if (Platform.environment['_DARTDEV_LOG_ANALYTICS'] != null) {
     // Used for testing what analytics messages are sent.
     return _LoggingAnalytics();
@@ -119,7 +101,7 @@ Directory? get homeDir {
 
 /// The directory used to store the analytics settings file.
 ///
-/// Typically, the directory is `~/.dart/` (and the settings file is
+/// Typically, the directory is `~/.config/dart/` (and the settings file is
 /// `dartdev.json`).
 ///
 /// This can return null under some conditions, including when the user's home
@@ -129,7 +111,22 @@ Directory? getDartStorageDirectory() {
   if (dir == null) {
     return null;
   } else {
-    return Directory(path.join(dir.path, _dartDirectoryName));
+    if (Platform.environment.containsKey('DART_CONFIG_DIR')) {
+      return Platform.environment['DART_CONFIG_DIR'];
+    } else {
+      if (Platform.isLinux) {
+        var xdgConfigHome = Platform.environment['XDG_CONFIG_HOME'];
+        if (xdgConfigHome != null) {
+          return '$xdgConfigHome/dart';
+        } else {
+          return '${Platform.environment['HOME']}/.config/dart';
+        }
+      } else if (Platform.isMacOS) {
+        return '${Platform.environment['HOME']}/Library/Application Support/dart';
+      } else if (Platform.isWindows) {
+        return '${Platform.environment['APPDATA']}/dart';
+      }
+    }
   }
 }
 

--- a/pkg/dartdev/lib/src/analytics.dart
+++ b/pkg/dartdev/lib/src/analytics.dart
@@ -40,26 +40,7 @@ const String _readmeFileContents = '''
 This directory contains user-level settings for the Dart programming language
 (https://dart.dev).
 ''';
-
 String _dartDirectoryName;
-
-if (Platform.environment.containsKey('DART_CONFIG_DIR')) {
-  _dartDirectoryName = Platform.environment['DART_CONFIG_DIR'];
-} else {
-  if (Platform.isLinux) {
-    var xdgConfigHome = Platform.environment['XDG_CONFIG_HOME'];
-    if (xdgConfigHome != null) {
-      _dartDirectoryName = '$xdgConfigHome/dart';
-    } else {
-      _dartDirectoryName = '${Platform.environment['HOME']}/.config/dart';
-    }
-  } else if (Platform.isMacOS) {
-    _dartDirectoryName = '${Platform.environment['HOME']}/Library/Application Support/dart';
-  } else if (Platform.isWindows) {
-    _dartDirectoryName = '${Platform.environment['APPDATA']}/dart';
-  }
-}
-
 const String eventCategory = 'dartdev';
 const String exitCodeParam = 'exitCode';
 
@@ -69,6 +50,24 @@ Analytics get disabledAnalytics => DisabledAnalytics(_trackingId, _appName);
 
 /// Create and return an [Analytics] instance.
 Analytics createAnalyticsInstance(bool disableAnalytics) {
+  if (Platform.environment.containsKey('DART_CONFIG_DIR')) {
+    _dartDirectoryName = Platform.environment['DART_CONFIG_DIR'];
+  } else {
+    if (Platform.isLinux) {
+      var xdgConfigHome = Platform.environment['XDG_CONFIG_HOME'];
+      if (xdgConfigHome != null) {
+        _dartDirectoryName = '$xdgConfigHome/dart';
+      } else {
+        _dartDirectoryName = '${Platform.environment['HOME']}/.config/dart';
+      }
+    } else if (Platform.isMacOS) {
+      _dartDirectoryName =
+          '${Platform.environment['HOME']}/Library/Application Support/dart';
+    } else if (Platform.isWindows) {
+      _dartDirectoryName = '${Platform.environment['APPDATA']}/dart';
+    }
+  }
+
   if (Platform.environment['_DARTDEV_LOG_ANALYTICS'] != null) {
     // Used for testing what analytics messages are sent.
     return _LoggingAnalytics();

--- a/pkg/dartdev/lib/src/analytics.dart
+++ b/pkg/dartdev/lib/src/analytics.dart
@@ -33,7 +33,6 @@ const String analyticsDisabledNoticeMessage = '''
   ╚════════════════════════════════════════════════════════════════════════════╝
 ''';
 const String _appName = 'dartdev';
-const String _dartDirectoryName = '.dart';
 const String _settingsFileName = 'dartdev.json';
 const String _trackingId = 'UA-26406144-37';
 const String _readmeFileName = 'README.txt';
@@ -41,6 +40,25 @@ const String _readmeFileContents = '''
 This directory contains user-level settings for the Dart programming language
 (https://dart.dev).
 ''';
+
+String _dartDirectoryName;
+
+if (Platform.environment.containsKey('DART_CONFIG_DIR')) {
+  _dartDirectoryName = Platform.environment['DART_CONFIG_DIR'];
+} else {
+  if (Platform.isLinux) {
+    var xdgConfigHome = Platform.environment['XDG_CONFIG_HOME'];
+    if (xdgConfigHome != null) {
+      _dartDirectoryName = '$xdgConfigHome/dart';
+    } else {
+      _dartDirectoryName = '${Platform.environment['HOME']}/.config/dart';
+    }
+  } else if (Platform.isMacOS) {
+    _dartDirectoryName = '${Platform.environment['HOME']}/Library/Application Support/dart';
+  } else if (Platform.isWindows) {
+    _dartDirectoryName = '${Platform.environment['APPDATA']}/dart';
+  }
+}
 
 const String eventCategory = 'dartdev';
 const String exitCodeParam = 'exitCode';


### PR DESCRIPTION
I moved the default configuration directory from `~/.dart` and `~/.dartServer` to:

1. Linux: `~/.config/dart` and `~/.config/dartServer`.
2. Mac: `~/Library/Application Support/dart/`.
3. Windows: `%APPDATA%/dart/`

You can overwrite the `~/.config/dart` path with the `DART_CONFIG_DIR` variable.
I believe this resolves #41560 for the most part.