### PR TITLE
Generate class names from filenames in completion snippets

### DIFF
--- a/pkg/analysis_server/lib/src/services/snippets/dart/class_declaration.dart
+++ b/pkg/analysis_server/lib/src/services/snippets/dart/class_declaration.dart
@@ -10,6 +10,9 @@ import 'package:analyzer_plugin/utilities/change_builder/change_builder_core.dar
 class ClassDeclaration extends DartSnippetProducer {
   static const prefix = 'class';
   static const label = 'class';
+  /// Use the currently selected file name to generate the class name for vscode.<br/>
+  /// `class_name.dart`->`ClassName`
+  static const className = '\${1:\${TM_FILENAME_BASE/(_|^|\\.)(\\w)/\${2:/capitalize}/g}}';
 
   ClassDeclaration(super.request, {required super.elementImportCache});
 
@@ -25,12 +28,7 @@ class ClassDeclaration extends DartSnippetProducer {
       builder.addReplacement(request.replacementRange, (builder) {
         void writeIndented(String string) => builder.write('$indent$string');
         builder.write('class ');
-        /// Use the currently selected file name to generate the class name for vscode.<br/>
-        /// `my_red_color_car.dart`->`MyRedColorCar`
-        builder.addSimpleLinkedEdit(
-          'className',
-          '\${1:\${TM_FILENAME_BASE/(_|^|\\.)(\\w)/\${2:/capitalize}/g}}',
-        );
+        builder.addSimpleLinkedEdit('className', className);
         builder.writeln(' {');
         writeIndented('  ');
         builder.selectHere();

--- a/pkg/analysis_server/lib/src/services/snippets/dart/class_declaration.dart
+++ b/pkg/analysis_server/lib/src/services/snippets/dart/class_declaration.dart
@@ -25,7 +25,12 @@ class ClassDeclaration extends DartSnippetProducer {
       builder.addReplacement(request.replacementRange, (builder) {
         void writeIndented(String string) => builder.write('$indent$string');
         builder.write('class ');
-        builder.addSimpleLinkedEdit('className', 'ClassName');
+        /// Use the currently selected file name to generate the class name for vscode.<br/>
+        /// `my_red_color_car.dart`->`MyRedColorCar`
+        builder.addSimpleLinkedEdit(
+          'className',
+          '\${1:\${TM_FILENAME_BASE/(_|^|\\.)(\\w)/\${2:/capitalize}/g}}',
+        );
         builder.writeln(' {');
         writeIndented('  ');
         builder.selectHere();

--- a/pkg/analysis_server/lib/src/services/snippets/dart/flutter_stateful_widget.dart
+++ b/pkg/analysis_server/lib/src/services/snippets/dart/flutter_stateful_widget.dart
@@ -13,6 +13,10 @@ class FlutterStatefulWidget extends FlutterSnippetProducer
     with FlutterWidgetSnippetProducerMixin {
   static const prefix = 'stful';
   static const label = 'Flutter Stateful Widget';
+  static String get widgetClassName =>
+      FlutterWidgetSnippetProducerMixin.widgetClassName;
+  static String get widgetClassNameRef =>
+      FlutterWidgetSnippetProducerMixin.widgetClassNameRef;
 
   late ClassElement? classStatefulWidget;
   late ClassElement? classState;
@@ -56,11 +60,11 @@ class FlutterStatefulWidget extends FlutterSnippetProducer
 
         // Write the State class.
         builder.write('class _');
-        builder.addSimpleLinkedEdit('name', widgetClassName);
+        builder.addSimpleLinkedEdit('name', widgetClassNameRef);
         builder.write('State extends ');
         builder.writeReference(classState);
         builder.write('<');
-        builder.addSimpleLinkedEdit('name', widgetClassName);
+        builder.addSimpleLinkedEdit('name', widgetClassNameRef);
         builder.writeln('> {');
         {
           writeBuildMethod(builder);

--- a/pkg/analysis_server/lib/src/services/snippets/dart/flutter_stateful_widget_with_animation.dart
+++ b/pkg/analysis_server/lib/src/services/snippets/dart/flutter_stateful_widget_with_animation.dart
@@ -14,6 +14,10 @@ class FlutterStatefulWidgetWithAnimationController
     extends FlutterSnippetProducer with FlutterWidgetSnippetProducerMixin {
   static const prefix = 'stanim';
   static const label = 'Flutter Widget with AnimationController';
+  static String get widgetClassName =>
+      FlutterWidgetSnippetProducerMixin.widgetClassName;
+  static String get widgetClassNameRef =>
+    FlutterWidgetSnippetProducerMixin.widgetClassNameRef;
 
   late ClassElement? classStatefulWidget;
   late ClassElement? classState;
@@ -63,11 +67,11 @@ class FlutterStatefulWidgetWithAnimationController
 
         // Write the State class.
         builder.write('class _');
-        builder.addSimpleLinkedEdit('name', widgetClassName);
+        builder.addSimpleLinkedEdit('name', widgetClassNameRef);
         builder.write('State extends ');
         builder.writeReference(classState);
         builder.write('<');
-        builder.addSimpleLinkedEdit('name', widgetClassName);
+        builder.addSimpleLinkedEdit('name', widgetClassNameRef);
         builder.writeln('>');
         builder.write('    with ');
         builder.writeReference(classSingleTickerProviderStateMixin);

--- a/pkg/analysis_server/lib/src/services/snippets/dart/flutter_stateless_widget.dart
+++ b/pkg/analysis_server/lib/src/services/snippets/dart/flutter_stateless_widget.dart
@@ -12,6 +12,10 @@ class FlutterStatelessWidget extends FlutterSnippetProducer
     with FlutterWidgetSnippetProducerMixin {
   static const prefix = 'stless';
   static const label = 'Flutter Stateless Widget';
+  static String get widgetClassName =>
+      FlutterWidgetSnippetProducerMixin.widgetClassName;
+  static String get widgetClassNameRef =>
+      FlutterWidgetSnippetProducerMixin.widgetClassNameRef;
 
   late ClassElement? classStatelessWidget;
   @override

--- a/pkg/analysis_server/lib/src/services/snippets/snippet_producer.dart
+++ b/pkg/analysis_server/lib/src/services/snippets/snippet_producer.dart
@@ -122,7 +122,9 @@ abstract class FlutterSnippetProducer extends DartSnippetProducer {
 mixin FlutterWidgetSnippetProducerMixin on FlutterSnippetProducer {
   ClassElement? get classBuildContext;
   ClassElement? get classKey;
-  String get widgetClassName => 'MyWidget';
+  /// Generate widget names using the currently selected file name for vscode.<br/>
+  /// `my_widget.dart`->`MyWidget`
+  String get widgetClassName => '\${1:\${TM_FILENAME_BASE/(_|^|\\.)(\\w)/\${2:/capitalize}/g}}';
 
   void writeBuildMethod(DartEditBuilder builder) {
     // Checked by isValid() before this will be called.

--- a/pkg/analysis_server/lib/src/services/snippets/snippet_producer.dart
+++ b/pkg/analysis_server/lib/src/services/snippets/snippet_producer.dart
@@ -122,9 +122,12 @@ abstract class FlutterSnippetProducer extends DartSnippetProducer {
 mixin FlutterWidgetSnippetProducerMixin on FlutterSnippetProducer {
   ClassElement? get classBuildContext;
   ClassElement? get classKey;
+
   /// Generate widget names using the currently selected file name for vscode.<br/>
   /// `my_widget.dart`->`MyWidget`
-  String get widgetClassName => '\${1:\${TM_FILENAME_BASE/(_|^|\\.)(\\w)/\${2:/capitalize}/g}}';
+  static String widgetClassName =  
+      '\${1:\${TM_FILENAME_BASE/(_|^|\\.)(\\w)/\${2:/capitalize}/g}}';
+  static String widgetClassNameRef = "\$1";
 
   void writeBuildMethod(DartEditBuilder builder) {
     // Checked by isValid() before this will be called.
@@ -161,9 +164,9 @@ mixin FlutterWidgetSnippetProducerMixin on FlutterSnippetProducer {
   void writeCreateStateMethod(DartEditBuilder builder) {
     builder.writeln('  @override');
     builder.write('  State<');
-    builder.addSimpleLinkedEdit('name', widgetClassName);
+    builder.addSimpleLinkedEdit('name', widgetClassNameRef);
     builder.write('> createState() => _');
-    builder.addSimpleLinkedEdit('name', widgetClassName);
+    builder.addSimpleLinkedEdit('name', widgetClassNameRef);
     builder.writeln('State();');
   }
 
@@ -184,7 +187,7 @@ mixin FlutterWidgetSnippetProducerMixin on FlutterSnippetProducer {
 
     builder.write('  ');
     builder.writeConstructorDeclaration(
-      widgetClassName,
+      widgetClassNameRef,
       classNameGroupName: 'name',
       isConst: true,
       parameterWriter: () {

--- a/pkg/analysis_server/test/services/snippets/dart/class_declaration_test.dart
+++ b/pkg/analysis_server/test/services/snippets/dart/class_declaration_test.dart
@@ -44,19 +44,19 @@ class B {}''';
     expect(code, '''
 class A {}
   
-class ClassName {
+class ${ClassDeclaration.className} {
   
 }
 
 class B {}''');
     expect(snippet.change.selection!.file, testFile.path);
-    expect(snippet.change.selection!.offset, 34);
+    expect(snippet.change.selection!.offset, 81);
     expect(snippet.change.linkedEditGroups.map((group) => group.toJson()), [
       {
         'positions': [
           {'file': testFile.path, 'offset': 20},
         ],
-        'length': 9,
+        'length': 56,
         'suggestions': []
       }
     ]);

--- a/pkg/analysis_server/test/services/snippets/dart/flutter_stateful_widget_test.dart
+++ b/pkg/analysis_server/test/services/snippets/dart/flutter_stateful_widget_test.dart
@@ -27,6 +27,10 @@ class FlutterStatefulWidgetTest extends FlutterSnippetProducerTest {
   @override
   String get prefix => FlutterStatefulWidget.prefix;
 
+  String get widgetClassName => FlutterStatefulWidget.widgetClassName;
+
+  String get widgetClassNameRef => FlutterStatefulWidget.widgetClassNameRef;
+
   Future<void> test_noSuperParams() async {
     writeTestPackageConfig(flutter: true, languageVersion: '2.16');
 
@@ -41,14 +45,14 @@ class FlutterStatefulWidgetTest extends FlutterSnippetProducerTest {
     expect(code, '''
 import 'package:flutter/widgets.dart';
 
-class MyWidget extends StatefulWidget {
-  const MyWidget({Key? key}) : super(key: key);
+class $widgetClassName extends StatefulWidget {
+  const $widgetClassNameRef({Key? key}) : super(key: key);
 
   @override
-  State<MyWidget> createState() => _MyWidgetState();
+  State<$widgetClassNameRef> createState() => _${widgetClassNameRef}State();
 }
 
-class _MyWidgetState extends State<MyWidget> {
+class _${widgetClassNameRef}State extends State<$widgetClassNameRef> {
   @override
   Widget build(BuildContext context) {
     return const Placeholder();
@@ -71,19 +75,21 @@ class _MyWidgetState extends State<MyWidget> {
     final expected = TestCode.parse('''
 import 'package:flutter/widgets.dart';
 
-class /*0*/MyWidget extends StatefulWidget {
-  const /*1*/MyWidget({super.key});
+class /*0*/$widgetClassName extends StatefulWidget {
+  const /*1*/$widgetClassNameRef({super.key});
 
   @override
-  State</*2*/MyWidget> createState() => _/*3*/MyWidgetState();
+  State</*2*/$widgetClassNameRef> createState() => _/*3*/${widgetClassNameRef}State();
 }
 
-class _/*4*/MyWidgetState extends State</*5*/MyWidget> {
+class _$widgetClassNameRef\$1State extends State</*5*/$widgetClassNameRef> {
   @override
   Widget build(BuildContext context) {
     return /*[0*/const Placeholder()/*0]*/;
   }
-}''');
-    assertFlutterSnippetChange(snippet.change, 'MyWidget', expected);
+}''',
+    positionShorthand:false,
+    );
+    assertFlutterSnippetChange(snippet.change, widgetClassNameRef, expected);
   }
 }

--- a/pkg/analysis_server/test/services/snippets/dart/flutter_stateful_widget_with_animation_controller_test.dart
+++ b/pkg/analysis_server/test/services/snippets/dart/flutter_stateful_widget_with_animation_controller_test.dart
@@ -28,6 +28,10 @@ class FlutterStatefulWidgetWithAnimationControllerTest
   @override
   String get prefix => FlutterStatefulWidgetWithAnimationController.prefix;
 
+  String get widgetClassName => FlutterStatefulWidgetWithAnimationController.widgetClassName;
+
+  String get widgetClassNameRef => FlutterStatefulWidgetWithAnimationController.widgetClassNameRef;
+
   Future<void> test_noSuperParams() async {
     writeTestPackageConfig(flutter: true, languageVersion: '2.16');
 
@@ -42,14 +46,14 @@ class FlutterStatefulWidgetWithAnimationControllerTest
     expect(code, '''
 import 'package:flutter/widgets.dart';
 
-class MyWidget extends StatefulWidget {
-  const MyWidget({Key? key}) : super(key: key);
+class $widgetClassName extends StatefulWidget {
+  const $widgetClassNameRef({Key? key}) : super(key: key);
 
   @override
-  State<MyWidget> createState() => _MyWidgetState();
+  State<$widgetClassNameRef> createState() => _${widgetClassNameRef}State();
 }
 
-class _MyWidgetState extends State<MyWidget>
+class _${widgetClassNameRef}State extends State<$widgetClassNameRef>
     with SingleTickerProviderStateMixin {
   late AnimationController _controller;
 
@@ -87,14 +91,14 @@ class _MyWidgetState extends State<MyWidget>
     final expected = TestCode.parse('''
 import 'package:flutter/widgets.dart';
 
-class /*0*/MyWidget extends StatefulWidget {
-  const /*1*/MyWidget({super.key});
+class /*0*/$widgetClassName extends StatefulWidget {
+  const /*1*/$widgetClassNameRef({super.key});
 
   @override
-  State</*2*/MyWidget> createState() => _/*3*/MyWidgetState();
+  State</*2*/$widgetClassNameRef> createState() => _/*3*/${widgetClassNameRef}State();
 }
 
-class _/*4*/MyWidgetState extends State</*5*/MyWidget>
+class _/*4*/${widgetClassNameRef}State extends State</*5*/$widgetClassNameRef>
     with SingleTickerProviderStateMixin {
   late AnimationController _controller;
 
@@ -114,7 +118,9 @@ class _/*4*/MyWidgetState extends State</*5*/MyWidget>
   Widget build(BuildContext context) {
     return /*[0*/const Placeholder()/*0]*/;
   }
-}''');
-    assertFlutterSnippetChange(snippet.change, 'MyWidget', expected);
+}''',
+    positionShorthand:false,
+    );
+    assertFlutterSnippetChange(snippet.change, widgetClassNameRef, expected);
   }
 }

--- a/pkg/analysis_server/test/services/snippets/dart/flutter_stateless_widget_test.dart
+++ b/pkg/analysis_server/test/services/snippets/dart/flutter_stateless_widget_test.dart
@@ -26,6 +26,10 @@ class FlutterStatelessWidgetTest extends FlutterSnippetProducerTest {
   @override
   String get prefix => FlutterStatelessWidget.prefix;
 
+  String get widgetClassName => FlutterStatelessWidget.widgetClassName;
+
+  String get widgetClassNameRef => FlutterStatelessWidget.widgetClassNameRef;
+
   Future<void> test_noSuperParams() async {
     writeTestPackageConfig(flutter: true, languageVersion: '2.16');
 
@@ -35,15 +39,17 @@ class FlutterStatelessWidgetTest extends FlutterSnippetProducerTest {
     final expected = TestCode.parse('''
 import 'package:flutter/widgets.dart';
 
-class /*0*/MyWidget extends StatelessWidget {
-  const /*1*/MyWidget({Key? key}) : super(key: key);
+class /*0*/$widgetClassName extends StatelessWidget {
+  const /*1*/$widgetClassNameRef({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     return /*[0*/const Placeholder()/*0]*/;
   }
-}''');
-    assertFlutterSnippetChange(snippet.change, 'MyWidget', expected);
+}''',
+    positionShorthand:false,
+    );
+    assertFlutterSnippetChange(snippet.change, widgetClassNameRef, expected);
   }
 
   Future<void> test_notValid_notFlutterProject() async {
@@ -61,14 +67,16 @@ class /*0*/MyWidget extends StatelessWidget {
     final expected = TestCode.parse('''
 import 'package:flutter/widgets.dart';
 
-class /*0*/MyWidget extends StatelessWidget {
-  const /*1*/MyWidget({super.key});
+class /*0*/$widgetClassName extends StatelessWidget {
+  const /*1*/$widgetClassNameRef({super.key});
 
   @override
   Widget build(BuildContext context) {
     return /*[0*/const Placeholder()/*0]*/;
   }
-}''');
-    assertFlutterSnippetChange(snippet.change, 'MyWidget', expected);
+}''',
+    positionShorthand:false,
+    );
+    assertFlutterSnippetChange(snippet.change, widgetClassNameRef, expected);
   }
 }


### PR DESCRIPTION
1. Generates a class name from the selected file name
`tk_question_extra_data_dto.dart` -> `class TkQuestionExtraDataDto {}`
link the PR [Generates a class name from the selected file name](https://github.com/Dart-Code/Dart-Code/pull/4691)

2. Change snippets of class name and widget name
3. Change the snippet unit test of class name
---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
