### PR TITLE
Trim Content-Length before checking if it contains only digits

### DIFF
--- a/sdk/lib/_http/http_headers.dart
+++ b/sdk/lib/_http/http_headers.dart
@@ -379,10 +379,11 @@ class _HttpHeaders implements HttpHeaders {
         throw HttpException("Content-Length must contain only digits");
       }
     } else if (value is String) {
-      if (!_digitsValidator.hasMatch(value)) {
+      final trimmedValue = value.trim();
+      if (!_digitsValidator.hasMatch(trimmedValue)) {
         throw HttpException("Content-Length must contain only digits");
       }
-      value = int.parse(value);
+      value = int.parse(trimmedValue);
     } else {
       throw HttpException("Unexpected type for header named $name");
     }


### PR DESCRIPTION
An http server may send a content length that contains only digits plus whitespaces at the beginning or at the end of the header value. Most http clients can deal with this, but the dart-sdk throws a HttpExecption "Content-Length must contain only digits".

To allow dealing with http servers, that send Content-Length with whitespaces, the Content-Length value is trimmed before checking if it contains only digits.

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
