### PR TITLE
Unify splay tree iterators and interables constructor argument names.

### DIFF
--- a/sdk/lib/collection/splay_tree.dart
+++ b/sdk/lib/collection/splay_tree.dart
@@ -824,7 +824,7 @@ class _SplayTreeMapEntryIterable<K, V>
 
 class _SplayTreeKeyIterator<K, Node extends _SplayTreeNode<K, Node>>
     extends _SplayTreeIterator<K, Node, K> {
-  _SplayTreeKeyIterator(_SplayTree<K, Node> map) : super(map);
+  _SplayTreeKeyIterator(_SplayTree<K, Node> tree) : super(tree);
   K _getValue(Node node) => node.key;
 }
 
@@ -836,7 +836,7 @@ class _SplayTreeValueIterator<K, V>
 
 class _SplayTreeMapEntryIterator<K, V>
     extends _SplayTreeIterator<K, _SplayTreeMapNode<K, V>, MapEntry<K, V>> {
-  _SplayTreeMapEntryIterator(SplayTreeMap<K, V> tree) : super(tree);
+  _SplayTreeMapEntryIterator(SplayTreeMap<K, V> map) : super(map);
   MapEntry<K, V> _getValue(_SplayTreeMapNode<K, V> node) =>
       MapEntry<K, V>(node.key, node.value);
 


### PR DESCRIPTION
`_SplayTreeKeyIterator` has constructor argument `_SplayTree<K, Node> map` and `_SplayTreeMapEntryIterator` has constructor argument `SplayTreeMap<K, V> tree`. These two places don't follow the naming convention in rest of the file and could be misleading. Correcting them for better readability.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
