### PR TITLE
fix: mismatched #ifdef in dartdev_isolate.cc

### DIFF
--- a/runtime/bin/dartdev_isolate.cc
+++ b/runtime/bin/dartdev_isolate.cc
@@ -298,7 +298,7 @@ DartDevIsolate::DartDev_Result DartDevIsolate::RunDartDev(
   return runner_.result();
 }
 
-#endif  // if !defined(DART_PRECOMPILED_RUNTIME)
-
 }  // namespace bin
 }  // namespace dart
+
+#endif  // if !defined(DART_PRECOMPILED_RUNTIME)


### PR DESCRIPTION
I accidentally included dartdev_isolate.cc with precompiled runtime enabled, and discovered this file has mismatched braces with that combination of flags.

If this file wants to enforce that it's not included in precompiled mode that's fine, just probably not with an accidental syntax error.

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
