### PR TITLE
Remove unused ArgumentError.checkNotNull for exitCode

### DIFF
--- a/sdk/lib/io/process.dart
+++ b/sdk/lib/io/process.dart
@@ -48,7 +48,6 @@ class _ProcessUtils {
 /// program to the surrounding environment. This will avoid any
 /// cross-platform issues.
 Never exit(int code) {
-  ArgumentError.checkNotNull(code, "code");
   if (!_EmbedderConfig._mayExit) {
     throw new UnsupportedError(
         "This embedder disallows calling dart:io's exit()");
@@ -67,7 +66,6 @@ Never exit(int code) {
 /// See [exit] for more information on how to chose a value for the
 /// exit code.
 void set exitCode(int code) {
-  ArgumentError.checkNotNull(code, "code");
   _ProcessUtils._setExitCode(code);
 }
 


### PR DESCRIPTION
Dart is sound now, so we we can skip this unused check

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
