### PR TITLE
Document that writeAsBytes truncates values beyond 0..255

### DIFF
--- a/sdk/lib/io/file.dart
+++ b/sdk/lib/io/file.dart
@@ -520,6 +520,10 @@ abstract interface class File implements FileSystemEntity {
   /// file if it already exists. In order to append the bytes to an existing
   /// file, pass [FileMode.append] as the optional mode parameter.
   ///
+  /// [bytes] is treated as a list of 8-bit values. Values outside of 0..255
+  /// are truncated by taking the low 8 bits. For example, `256` is treated
+  /// as `0`, `257` as `1`, `-1` as `255`, etc.
+  ///
   /// If the argument [flush] is set to `true`, the data written will be
   /// flushed to the file system before the returned future completes.
   Future<File> writeAsBytes(List<int> bytes,
@@ -535,6 +539,10 @@ abstract interface class File implements FileSystemEntity {
   ///
   /// If the [flush] argument is set to `true` data written will be
   /// flushed to the file system before returning.
+  ///
+  /// [bytes] is treated as a list of 8-bit values. Values outside of 0..255
+  /// are truncated by taking the low 8 bits. For example, `256` is treated
+  /// as `0`, `257` as `1`, `-1` as `255`, etc.
   ///
   /// Throws a [FileSystemException] if the operation fails.
   void writeAsBytesSync(List<int> bytes,


### PR DESCRIPTION
I just ran into this myself, no sense in anyone else having to hit this issue again.

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
