### PR TITLE
Update add_missing_switch_cases code template

### DIFF
--- a/pkg/analysis_server/lib/src/services/correction/dart/add_missing_switch_cases.dart
+++ b/pkg/analysis_server/lib/src/services/correction/dart/add_missing_switch_cases.dart
@@ -70,11 +70,8 @@ class AddMissingSwitchCases extends ResolvedCorrectionProducer {
         builder.write(location.prefix);
         builder.write(lineIndent);
         builder.write(singleIndent);
-        builder.writeln('// TODO: Handle this case.');
-        builder.write(lineIndent);
-        builder.write(singleIndent);
         _writePatternParts(builder, patternParts);
-        builder.writeln(' => null,');
+        builder.writeln(' => throw UnimplementedError(\'Handle this case\'),');
         builder.write(location.suffix);
       });
     });
@@ -111,9 +108,9 @@ class AddMissingSwitchCases extends ResolvedCorrectionProducer {
   }
 
   void _writePatternParts(
-    DartEditBuilder builder,
-    List<MissingPatternPart> parts,
-  ) {
+      DartEditBuilder builder,
+      List<MissingPatternPart> parts,
+      ) {
     for (final part in parts) {
       if (part is MissingPatternEnumValuePart) {
         builder.writeReference(part.enumElement);

--- a/pkg/analysis_server/lib/src/services/correction/dart/add_missing_switch_cases.dart
+++ b/pkg/analysis_server/lib/src/services/correction/dart/add_missing_switch_cases.dart
@@ -70,8 +70,11 @@ class AddMissingSwitchCases extends ResolvedCorrectionProducer {
         builder.write(location.prefix);
         builder.write(lineIndent);
         builder.write(singleIndent);
+        builder.writeln('// TODO: Handle this case.');
+        builder.write(lineIndent);
+        builder.write(singleIndent);
         _writePatternParts(builder, patternParts);
-        builder.writeln(' => throw UnimplementedError(\'Handle this case\'),');
+        builder.writeln(' => throw UnimplementedError(),');
         builder.write(location.suffix);
       });
     });
@@ -108,9 +111,9 @@ class AddMissingSwitchCases extends ResolvedCorrectionProducer {
   }
 
   void _writePatternParts(
-      DartEditBuilder builder,
-      List<MissingPatternPart> parts,
-      ) {
+    DartEditBuilder builder,
+    List<MissingPatternPart> parts,
+  ) {
     for (final part in parts) {
       if (part is MissingPatternEnumValuePart) {
         builder.writeReference(part.enumElement);

--- a/pkg/analysis_server/test/src/services/correction/fix/add_missing_switch_cases_test.dart
+++ b/pkg/analysis_server/test/src/services/correction/fix/add_missing_switch_cases_test.dart
@@ -33,7 +33,8 @@ int f(bool x) {
 int f(bool x) {
   return switch (x) {
     false => 0,
-    true => throw UnimplementedError(\'Handle this case\'),
+    // TODO: Handle this case.
+    true => throw UnimplementedError(),
   };
 }
 ''');
@@ -51,7 +52,8 @@ int f(bool x) {
 int f(bool x) {
   return switch (x) {
     true => 0,
-    false => throw UnimplementedError(\'Handle this case\'),
+    // TODO: Handle this case.
+    false => throw UnimplementedError(),
   };
 }
 ''');
@@ -77,7 +79,8 @@ enum E {
 int f(E x) {
   return switch (x) {
     E.first => 0,
-    E.second => throw UnimplementedError(\'Handle this case\'),
+    // TODO: Handle this case.
+    E.second => throw UnimplementedError(),
   };
 }
 ''');
@@ -103,7 +106,8 @@ import 'a.dart' as prefix;
 
 int f(prefix.E x) {
   return switch (x) {
-    prefix.E.first => throw UnimplementedError(\'Handle this case\'),
+    // TODO: Handle this case.
+    prefix.E.first => throw UnimplementedError(),
   };
 }
 ''');
@@ -142,7 +146,8 @@ import 'b.dart';
 
 int f() {
   return switch (value) {
-    E.first => throw UnimplementedError(\'Handle this case\'),
+    // TODO: Handle this case.
+    E.first => throw UnimplementedError(),
   };
 }
 ''');
@@ -162,7 +167,8 @@ int f(num x) {
   return switch (x) {
     double() => 0,
     int(hashCode: 5) => 0,
-    int() => throw UnimplementedError(\'Handle this case\'),
+    // TODO: Handle this case.
+    int() => throw UnimplementedError(),
   };
 }
 ''');
@@ -180,7 +186,8 @@ int f(num x) {
 int f(num x) {
   return switch (x) {
     double() => 0,
-    int() => throw UnimplementedError(\'Handle this case\'),
+    // TODO: Handle this case.
+    int() => throw UnimplementedError(),
   };
 }
 ''');
@@ -202,7 +209,8 @@ import 'dart:core' as core;
 core.int f(core.num x) {
   return switch (x) {
     core.double() => 0,
-    core.int() => throw UnimplementedError(\'Handle this case\'),
+    // TODO: Handle this case.
+    core.int() => throw UnimplementedError(),
   };
 }
 ''');
@@ -222,7 +230,8 @@ int f(num x) {
   return switch (x) {
     double() => 0,
     int() when x > 5 => 0,
-    int() => throw UnimplementedError(\'Handle this case\'),
+    // TODO: Handle this case.
+    int() => throw UnimplementedError(),
   };
 }
 ''');
@@ -237,7 +246,8 @@ int f(num x) {
     await assertHasFix('''
 int f(num x) {
   return switch (x) {
-    double() => throw UnimplementedError(\'Handle this case\'),
+    // TODO: Handle this case.
+    double() => throw UnimplementedError(),
   };
 }
 ''');

--- a/pkg/analysis_server/test/src/services/correction/fix/add_missing_switch_cases_test.dart
+++ b/pkg/analysis_server/test/src/services/correction/fix/add_missing_switch_cases_test.dart
@@ -33,8 +33,7 @@ int f(bool x) {
 int f(bool x) {
   return switch (x) {
     false => 0,
-    // TODO: Handle this case.
-    true => null,
+    true => throw UnimplementedError(\'Handle this case\'),
   };
 }
 ''');
@@ -52,8 +51,7 @@ int f(bool x) {
 int f(bool x) {
   return switch (x) {
     true => 0,
-    // TODO: Handle this case.
-    false => null,
+    false => throw UnimplementedError(\'Handle this case\'),
   };
 }
 ''');
@@ -79,8 +77,7 @@ enum E {
 int f(E x) {
   return switch (x) {
     E.first => 0,
-    // TODO: Handle this case.
-    E.second => null,
+    E.second => throw UnimplementedError(\'Handle this case\'),
   };
 }
 ''');
@@ -106,8 +103,7 @@ import 'a.dart' as prefix;
 
 int f(prefix.E x) {
   return switch (x) {
-    // TODO: Handle this case.
-    prefix.E.first => null,
+    prefix.E.first => throw UnimplementedError(\'Handle this case\'),
   };
 }
 ''');
@@ -146,8 +142,7 @@ import 'b.dart';
 
 int f() {
   return switch (value) {
-    // TODO: Handle this case.
-    E.first => null,
+    E.first => throw UnimplementedError(\'Handle this case\'),
   };
 }
 ''');
@@ -167,8 +162,7 @@ int f(num x) {
   return switch (x) {
     double() => 0,
     int(hashCode: 5) => 0,
-    // TODO: Handle this case.
-    int() => null,
+    int() => throw UnimplementedError(\'Handle this case\'),
   };
 }
 ''');
@@ -186,8 +180,7 @@ int f(num x) {
 int f(num x) {
   return switch (x) {
     double() => 0,
-    // TODO: Handle this case.
-    int() => null,
+    int() => throw UnimplementedError(\'Handle this case\'),
   };
 }
 ''');
@@ -209,8 +202,7 @@ import 'dart:core' as core;
 core.int f(core.num x) {
   return switch (x) {
     core.double() => 0,
-    // TODO: Handle this case.
-    core.int() => null,
+    core.int() => throw UnimplementedError(\'Handle this case\'),
   };
 }
 ''');
@@ -230,8 +222,7 @@ int f(num x) {
   return switch (x) {
     double() => 0,
     int() when x > 5 => 0,
-    // TODO: Handle this case.
-    int() => null,
+    int() => throw UnimplementedError(\'Handle this case\'),
   };
 }
 ''');
@@ -246,8 +237,7 @@ int f(num x) {
     await assertHasFix('''
 int f(num x) {
   return switch (x) {
-    // TODO: Handle this case.
-    double() => null,
+    double() => throw UnimplementedError(\'Handle this case\'),
   };
 }
 ''');


### PR DESCRIPTION
Updated code generation to 'throw UnimplementedError()' instead of returning 'null' and put the 'Handle this case' reminder message in the Error instead of an additional comment. 

This fix addresses issue [#53832](https://github.com/dart-lang/sdk/issues/53832). 

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
