### PR TITLE
Add missing #include <cstdlib>

### DIFF
--- a/runtime/platform/utils.h
+++ b/runtime/platform/utils.h
@@ -5,6 +5,7 @@
 #ifndef RUNTIME_PLATFORM_UTILS_H_
 #define RUNTIME_PLATFORM_UTILS_H_
 
+#include <cstdlib>
 #include <limits>
 #include <memory>
 #include <type_traits>


### PR DESCRIPTION
A recent patch to libc++ (https://github.com/llvm/llvm-project/commit/a65070a76a7c823c28f1c95a21e4857ed6e123ef) removed some transitive includes, which causes build failures when using libc++ at HEAD. In particular, this file uses `std::free` without including `<cstdlib>`:

```
error: missing '#include <cstdlib>'; 'free' must be declared before it is used
  592 |   typedef std::unique_ptr<char, decltype(std::free)*> CStringUniquePtr;
```

Relevant issue: b/308435622

