### PR TITLE
Add Mach-O support to analyze_snapshot.

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -54,19 +54,14 @@ group("runtime") {
     "utils/kernel-service:kernel-service",
   ]
 
-  # This flag is set in runtime/runtime_args.gni
-  # The analyze_snapshot tool is only supported on 64 bit AOT builds running
-  # under linux and android platforms
-  if (build_analyze_snapshot) {
-    deps += [
-      # The `analyze_snapshot` tests require the `analyze_snapshot` as well as
-      # `gen_snapshot` binaries.
-      "runtime/bin:analyze_snapshot",
-      "runtime/bin:analyze_snapshot($host_toolchain)",
-      "runtime/bin:gen_snapshot",
-      "runtime/bin:gen_snapshot($host_toolchain)",
-    ]
-  }
+  deps += [
+    # The `analyze_snapshot` tests require the `analyze_snapshot` as well as
+    # `gen_snapshot` binaries.
+    "runtime/bin:analyze_snapshot",
+    "runtime/bin:analyze_snapshot($host_toolchain)",
+    "runtime/bin:gen_snapshot",
+    "runtime/bin:gen_snapshot($host_toolchain)",
+  ]
 
   if (is_linux || is_android) {
     deps += [ "runtime/bin:abstract_socket_test" ]

--- a/runtime/bin/BUILD.gn
+++ b/runtime/bin/BUILD.gn
@@ -913,38 +913,35 @@ dart_executable("dart_precompiled_runtime_product") {
   extra_deps += [ ":elf_loader_product" ]
 }
 
-# This flag is set in runtime/runtime_args.gni
-# The analyze_snapshot tool is only supported on 64 bit AOT builds running under
-# linux and android platforms
-if (build_analyze_snapshot) {
-  dart_executable("analyze_snapshot") {
-    use_product_mode = dart_runtime_mode == "release"
-    extra_configs = [ "..:dart_precompiled_runtime_config" ]
+dart_executable("analyze_snapshot") {
+  use_product_mode = dart_runtime_mode == "release"
+  extra_configs = [ "..:dart_precompiled_runtime_config" ]
 
-    if (use_product_mode) {
-      extra_deps = [
-        "..:libdart_precompiled_runtime_product",
-        "../platform:libdart_platform_precompiled_runtime_product",
-      ]
-    } else {
-      extra_deps = [
-        "..:libdart_precompiled_runtime",
-        "../platform:libdart_platform_precompiled_runtime",
-      ]
-    }
-
-    extra_sources = [
-      "analyze_snapshot.cc",
-      "builtin.cc",
-      "loader.cc",
-      "loader.h",
+  if (use_product_mode) {
+    extra_deps = [
+      "..:libdart_precompiled_runtime_product",
+      "../platform:libdart_platform_precompiled_runtime_product",
     ]
+  } else {
+    extra_deps = [
+      "..:libdart_precompiled_runtime",
+      "../platform:libdart_platform_precompiled_runtime",
+    ]
+  }
 
-    if (use_product_mode) {
-      extra_deps += [ ":elf_loader_product" ]
-    } else {
-      extra_deps += [ ":elf_loader" ]
-    }
+  extra_sources = [
+    "analyze_snapshot.cc",
+    "mach_o_loader.cc",
+    "mach_o_loader.h",
+    "builtin.cc",
+    "loader.cc",
+    "loader.h",
+  ]
+
+  if (use_product_mode) {
+    extra_deps += [ ":elf_loader_product" ]
+  } else {
+    extra_deps += [ ":elf_loader" ]
   }
 }
 

--- a/runtime/bin/analyze_snapshot.cc
+++ b/runtime/bin/analyze_snapshot.cc
@@ -163,12 +163,15 @@ int RunAnalyzer(int argc, char** argv) {
 
   AppSnapshot* app_snapshot = Snapshot::TryReadAppSnapshot(script_name);
   if (app_snapshot == nullptr) {
-    Syslog::PrintErr("Failure reading snapshot\n");
+    if (File::Exists(/*namespc=*/nullptr, script_name)) {
+      Syslog::PrintErr("Failure reading snapshot\n");
+    } else {
+      Syslog::PrintErr("Snapshot file does not exist\n");
+    }
     return kErrorExitCode;
   }
-  app_snapshot->SetBuffers(
-        &vm_snapshot_data, &vm_snapshot_instructions,
-        &vm_isolate_data, &vm_isolate_instructions);
+  app_snapshot->SetBuffers(&vm_snapshot_data, &vm_snapshot_instructions,
+                           &vm_isolate_data, &vm_isolate_instructions);
 
   // Begin initialization
   Dart_InitializeParams init_params = {};

--- a/runtime/bin/analyze_snapshot.cc
+++ b/runtime/bin/analyze_snapshot.cc
@@ -2,25 +2,17 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-#include "bin/elf_loader.h"
 #include "bin/error_exit.h"
 #include "bin/file.h"
 
 #include "bin/options.h"
 #include "bin/platform.h"
+#include "bin/snapshot_utils.h"
 
-#if defined(TARGET_ARCH_IS_64_BIT) && defined(DART_PRECOMPILED_RUNTIME) &&     \
-    (defined(DART_TARGET_OS_ANDROID) || defined(DART_TARGET_OS_LINUX))
-#define SUPPORT_ANALYZE_SNAPSHOT
-#endif
-
-#ifdef SUPPORT_ANALYZE_SNAPSHOT
 #include "include/analyze_snapshot_api.h"
-#endif
 
 namespace dart {
 namespace bin {
-#ifdef SUPPORT_ANALYZE_SNAPSHOT
 #define STRING_OPTIONS_LIST(V) V(out, out_path)
 
 #define BOOL_OPTIONS_LIST(V)                                                   \
@@ -169,24 +161,14 @@ int RunAnalyzer(int argc, char** argv) {
   const char* script_name = nullptr;
   script_name = inputs.GetArgument(0);
 
-  // Dart_LoadELF will crash on nonexistent file non-gracefully
-  // even though it should return `nullptr`.
-  File* const file = File::Open(/*namespc=*/nullptr, script_name, File::kRead);
-  if (file == nullptr) {
-    Syslog::PrintErr("Snapshot file does not exist\n");
+  AppSnapshot* app_snapshot = Snapshot::TryReadAppSnapshot(script_name);
+  if (app_snapshot == nullptr) {
+    Syslog::PrintErr("Failure reading snapshot\n");
     return kErrorExitCode;
   }
-  file->Release();
-
-  const char* loader_error = nullptr;
-  Dart_LoadedElf* loaded_elf = Dart_LoadELF(
-      script_name, 0, &loader_error, &vm_snapshot_data,
-      &vm_snapshot_instructions, &vm_isolate_data, &vm_isolate_instructions);
-
-  if (loaded_elf == nullptr) {
-    Syslog::PrintErr("Failure calling Dart_LoadELF:\n%s\n", loader_error);
-    return kErrorExitCode;
-  }
+  app_snapshot->SetBuffers(
+        &vm_snapshot_data, &vm_snapshot_instructions,
+        &vm_isolate_data, &vm_isolate_instructions);
 
   // Begin initialization
   Dart_InitializeParams init_params = {};
@@ -248,23 +230,13 @@ int RunAnalyzer(int argc, char** argv) {
 
   Dart_ExitScope();
   Dart_ShutdownIsolate();
-  // Unload our DartELF to avoid leaks
-  Dart_UnloadELF(loaded_elf);
+  // Unload our snapshot to avoid leaks
+  delete app_snapshot;
   return 0;
 }
-#endif
 }  // namespace bin
 }  // namespace dart
 
 int main(int argc, char** argv) {
-#ifdef SUPPORT_ANALYZE_SNAPSHOT
   return dart::bin::RunAnalyzer(argc, argv);
-#else
-  dart::Syslog::PrintErr("Unsupported platform.\n");
-  dart::Syslog::PrintErr(
-      "Requires SDK with following "
-      "flags:\n\tTARGET_ARCH_IS_64_BIT\n\tDART_PRECOMPILED_RUNTIME\n\tDART_"
-      "TARGET_OS_ANDROID || DART_TARGET_OS_LINUX");
-  return dart::bin::kErrorExitCode;
-#endif
 }

--- a/runtime/bin/mach_o_loader.cc
+++ b/runtime/bin/mach_o_loader.cc
@@ -454,7 +454,6 @@ DART_EXPORT Dart_LoadedMachO* Dart_LoadMachO(
       !mach_o->ResolveSymbols(vm_snapshot_data, vm_snapshot_instrs,
                               vm_isolate_data, vm_isolate_instrs)) {
     *error = mach_o->error();
-    printf("error: %s\n", *error);
     return nullptr;
   }
 

--- a/runtime/bin/mach_o_loader.cc
+++ b/runtime/bin/mach_o_loader.cc
@@ -1,0 +1,466 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+#include "bin/mach_o_loader.h"
+#include <sys/types.h>
+
+#include "platform/globals.h"
+
+#include <cstdio>
+#include <functional>
+#include <memory>
+#include <utility>
+
+#include "bin/file.h"
+#include "bin/virtual_memory.h"
+#include "platform/utils.h"
+
+#include "platform/mach_o.h"
+#include "platform/syslog.h"
+#include "platform/unwinding_records.h"
+#include "vm/compiler/runtime_api.h"
+
+namespace dart {
+namespace bin {
+
+namespace mach_o {
+
+// This mappable abstraction matches what ElfLoader uses, but probably
+// could be removed since we don't need to support loading from memory.
+class Mappable {
+ public:
+  static Mappable* FromPath(const char* path);
+
+  virtual MappedMemory* Map(File::MapType type,
+                            uint64_t position,
+                            uint64_t length,
+                            void* start = nullptr) = 0;
+
+  virtual bool SetPosition(uint64_t position) = 0;
+  virtual bool ReadFully(void* dest, int64_t length) = 0;
+
+  virtual ~Mappable() {}
+
+ protected:
+  Mappable() {}
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(Mappable);
+};
+
+class FileMappable : public Mappable {
+ public:
+  explicit FileMappable(File* file) : Mappable(), file_(file) {}
+
+  ~FileMappable() override { file_->Release(); }
+
+  MappedMemory* Map(File::MapType type,
+                    uint64_t position,
+                    uint64_t length,
+                    void* start = nullptr) override {
+    return file_->Map(type, position, length, start);
+  }
+
+  bool SetPosition(uint64_t position) override {
+    return file_->SetPosition(position);
+  }
+
+  bool ReadFully(void* dest, int64_t length) override {
+    return file_->ReadFully(dest, length);
+  }
+
+ private:
+  File* const file_;
+  DISALLOW_COPY_AND_ASSIGN(FileMappable);
+};
+
+Mappable* Mappable::FromPath(const char* path) {
+  return new FileMappable(File::Open(/*namespc=*/nullptr, path, File::kRead));
+}
+
+/// A loader for a subset of Mach-O which can be used to load AOT snapshots
+/// built for iOS by XCode from the output of gen_snapshot in app-aot-assembly
+/// or vm-aot-assembly mode.
+class LoadedMachO {
+ public:
+  // Unlike LoadedElf, LoadedMachO does not take an offset, it uses
+  // the offset from the fat header to the Mach-O header.  This could be
+  // easily changed if needed.
+  explicit LoadedMachO(std::unique_ptr<Mappable> mappable)
+      : mappable_(std::move(mappable)) {}
+
+  ~LoadedMachO();
+
+  /// Loads the Mach-O object into memory. Returns whether the load was
+  /// successful. On failure, the error may be retrieved by 'error()'.
+  bool Load();
+
+  /// Reads Dart-specific symbols from the loaded Mach-O file.
+  ///
+  /// Stores the address of the corresponding symbol in each non-null output
+  /// parameter.
+  ///
+  /// Fails if any output parameter is non-null but points to null and the
+  /// corresponding symbol was not found, or if the dynamic symbol table could
+  /// not be decoded.
+  ///
+  /// Has the side effect of initializing the relocated addresses for the text
+  /// sections corresponding to non-null output parameters in the BSS segment.
+  ///
+  /// On failure, the error may be retrieved by 'error()'.
+  bool ResolveSymbols(const uint8_t** vm_data,
+                      const uint8_t** vm_instrs,
+                      const uint8_t** isolate_data,
+                      const uint8_t** isolate_instrs);
+
+  const char* error() { return error_; }
+
+ private:
+  bool ReadFatHeader(dart::mach_o::fat_header& fat_header);
+  bool LoadArch(const dart::mach_o::fat_header& fat_header,
+                dart::mach_o::fat_arch& fat_arch,
+                dart::mach_o::cpu_type_t cpu_type);
+  bool ReadMachOHeader();
+  bool ReadLoadCommands();
+  bool LoadSegments();
+
+  bool ForEachLoadCommand(
+      std::function<bool(const dart::mach_o::load_command*)> callback);
+  bool LoadSegment(const dart::mach_o::segment_command_64& segment);
+
+  // TODO(eseidel): LoadedMachO is intended for analysis (not execution) and
+  // should work on machines with different page size than the target.
+  // This should probably just hardcode to 16KB, matching iOS and MacOS.
+  static uword PageSize() { return VirtualMemory::PageSize(); }
+
+  // Unlike File::Map, allows non-aligned 'start' and 'length'.
+  MappedMemory* MapFilePiece(uword start,
+                             uword length,
+                             const void** mapping_start);
+
+  // Initialized on a successful Load().
+  // mappable_ is the entire file.
+  std::unique_ptr<Mappable> mappable_;
+  // mach_o_data_offset is the offset into mapped_ where the mach-o header
+  // starts. For a fat file, this will be the offset of the architecture
+  // being loaded, for a "thin" file it will be 0.
+  uint64_t mach_o_data_offset_ = 0;
+
+  // Initialized on error.
+  const char* error_ = nullptr;
+
+  // Initialized by ReadMachOHeader().
+  dart::mach_o::mach_header_64 header_;
+
+  // Initialized by ReadLoadCommands().
+  std::unique_ptr<MappedMemory> load_commands_mapping_;
+  const dart::mach_o::load_command* load_commands_ = nullptr;
+
+  // Initialized by LoadSegments().
+  std::unique_ptr<VirtualMemory> base_;
+  dart::mach_o::segment_command_64 link_edit_segment_ = {0};
+  dart::mach_o::nlist_64* symbol_table_ = nullptr;
+  uint32_t symbol_table_length_ = 0;
+  const char* string_table_ = nullptr;
+
+  DISALLOW_COPY_AND_ASSIGN(LoadedMachO);
+};
+
+#define CHECK(value)                                                           \
+  if (!(value)) {                                                              \
+    ASSERT(error_ != nullptr);                                                 \
+    return false;                                                              \
+  }
+
+#define ERROR(message)                                                         \
+  {                                                                            \
+    error_ = (message);                                                        \
+    return false;                                                              \
+  }
+
+#define CHECK_ERROR(value, message)                                            \
+  if (!(value)) {                                                              \
+    error_ = (message);                                                        \
+    return false;                                                              \
+  }
+
+bool LoadedMachO::Load() {
+  VirtualMemory::Init();
+  if (error_ != nullptr) {
+    return false;
+  }
+  ASSERT(mappable_ != nullptr);
+  // Read the fat header if it exists and jump to the architecture we are
+  // reading.  Failure of ReadFatHeader may mean this is a "thin" file
+  // and we should just read try reading the Mach-O header directly.
+  // iOS and MacOS seem to use a 32-bit fat header even for 64-bit binaries.
+  dart::mach_o::fat_header fat_header;
+  if (ReadFatHeader(fat_header)) {
+    dart::mach_o::fat_arch fat_arch;
+    CHECK_ERROR(LoadArch(fat_header, fat_arch, dart::mach_o::CPU_TYPE_ARM64),
+                "Failed to load ARM64 architecture.");
+    mach_o_data_offset_ = fat_arch.offset;
+  }
+
+  // Whether we read a fat header or not, we now try to read the Mach-O header.
+  CHECK_ERROR(Utils::IsAligned(mach_o_data_offset_, PageSize()),
+              "Mach-O data offset must be page-aligned.");
+  CHECK_ERROR(mappable_->SetPosition(mach_o_data_offset_),
+              "Invalid file offset.");
+  CHECK(ReadMachOHeader());
+  CHECK(ReadLoadCommands());
+  CHECK(LoadSegments());
+  return true;
+}
+
+bool LoadedMachO::LoadArch(const dart::mach_o::fat_header& fat_header,
+                           dart::mach_o::fat_arch& fat_arch,
+                           dart::mach_o::cpu_type_t cpu_type) {
+  if (fat_header.magic != dart::mach_o::FAT_MAGIC) {
+    ERROR("Not a 32-bit Mach-O fat header.");
+  }
+  for (uint32_t i = 0; i < fat_header.nfat_arch; i++) {
+    CHECK(mappable_->ReadFully(&fat_arch, sizeof(fat_arch)));
+    // Mach-O fat header is big endian.
+    fat_arch.cputype = Utils::BigEndianToHost32(fat_arch.cputype);
+    fat_arch.cpusubtype = Utils::BigEndianToHost32(fat_arch.cpusubtype);
+    fat_arch.offset = Utils::BigEndianToHost32(fat_arch.offset);
+    fat_arch.size = Utils::BigEndianToHost32(fat_arch.size);
+    fat_arch.align = Utils::BigEndianToHost32(fat_arch.align);
+    if (fat_arch.cputype == cpu_type) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool LoadedMachO::ReadFatHeader(dart::mach_o::fat_header& fat_header) {
+  CHECK(mappable_->ReadFully(&fat_header, sizeof(fat_header)));
+  // Mach-O fat file header is big endian.
+  fat_header.magic = Utils::BigEndianToHost32(fat_header.magic);
+  fat_header.nfat_arch = Utils::BigEndianToHost32(fat_header.nfat_arch);
+  CHECK_ERROR(fat_header.magic != dart::mach_o::FAT_MAGIC_64,
+              "64 bit fat files not supported.");
+  CHECK_ERROR(fat_header.magic == dart::mach_o::FAT_MAGIC,
+              "Not a Mach-O fat file.");
+  return true;
+}
+
+bool LoadedMachO::ReadMachOHeader() {
+  // Mach-O header and beyond is little endian.
+  CHECK(mappable_->ReadFully(&header_, sizeof(header_)));
+  CHECK_ERROR(header_.magic == dart::mach_o::MH_MAGIC_64,
+              "Not a 64-bit Mach-O file.")
+  return true;
+}
+
+bool LoadedMachO::ReadLoadCommands() {
+  // Mach-O header and beyond is little endian.
+  uint64_t commands_start = sizeof(header_);
+  uint64_t commands_length = header_.sizeofcmds;
+  load_commands_mapping_.reset(
+      MapFilePiece(commands_start, commands_length,
+                   reinterpret_cast<const void**>(&load_commands_)));
+  CHECK(load_commands_mapping_ != nullptr);
+  return true;
+}
+
+bool LoadedMachO::ForEachLoadCommand(
+    std::function<bool(const dart::mach_o::load_command*)> callback) {
+  uint64_t commands_length = header_.sizeofcmds;
+  const dart::mach_o::load_command* command = load_commands_;
+  while (commands_length > 0) {
+    if (!callback(command)) {
+      return false;
+    }
+    commands_length -= command->cmdsize;
+    command = reinterpret_cast<const dart::mach_o::load_command*>(
+        reinterpret_cast<const uint8_t*>(command) + command->cmdsize);
+  }
+  return true;
+}
+
+bool LoadedMachO::LoadSegment(const dart::mach_o::segment_command_64& segment) {
+  const uword memory_offset = segment.vmaddr, file_offset = segment.fileoff;
+  CHECK_ERROR(
+      (memory_offset % PageSize()) == (file_offset % PageSize()),
+      "Difference between file and memory offset must be page-aligned.");
+
+  const intptr_t adjustment = segment.vmaddr % PageSize();
+
+  void* const memory_start =
+      static_cast<char*>(base_->address()) + memory_offset - adjustment;
+  const uword file_start = mach_o_data_offset_ + file_offset - adjustment;
+  const uword length = segment.vmsize + adjustment;
+
+  // Even though we only want to read the snapshot, we still need to load
+  // the DATA segment RW, or the Dart VM will crash when it tries to write
+  // to the BSS segment.
+  File::MapType map_type = File::kReadOnly;
+  if (segment.initprot ==
+      (dart::mach_o::VM_PROT_READ | dart::mach_o::VM_PROT_WRITE)) {
+    map_type = File::kReadWrite;
+  } else if (segment.initprot ==
+             (dart::mach_o::VM_PROT_READ | dart::mach_o::VM_PROT_EXECUTE)) {
+    // Ignoring the execute bit for now.
+    map_type = File::kReadOnly;
+  } else if (segment.initprot == dart::mach_o::VM_PROT_READ) {
+    map_type = File::kReadOnly;
+  } else {
+    ERROR("Unsupported segment initprot set.");
+  }
+
+  std::unique_ptr<MappedMemory> memory(
+      mappable_->Map(map_type, file_start, length, memory_start));
+  CHECK_ERROR(memory != nullptr, "Could not map segment.");
+  CHECK_ERROR(memory->address() == memory_start,
+              "Mapping not at requested address.");
+  return true;
+}
+
+bool LoadedMachO::LoadSegments() {
+  // Calculate the total amount of virtual memory needed.
+  uword total_memory = 0;
+  ForEachLoadCommand([&](const dart::mach_o::load_command* command) {
+    if (command->cmd == dart::mach_o::LC_SEGMENT_64) {
+      const dart::mach_o::segment_command_64* segment =
+          reinterpret_cast<const dart::mach_o::segment_command_64*>(command);
+      total_memory += segment->vmsize;
+    }
+    return true;
+  });
+  total_memory = Utils::RoundUp(total_memory, PageSize());
+  base_.reset(VirtualMemory::Allocate(total_memory,
+                                      /*is_executable=*/false,
+                                      "dart-compiled-image"));
+  CHECK_ERROR(base_ != nullptr, "Could not reserve virtual memory.");
+
+  CHECK(ForEachLoadCommand([&](const dart::mach_o::load_command* command) {
+    if (command->cmd == dart::mach_o::LC_SEGMENT_64) {
+      const dart::mach_o::segment_command_64& segment =
+          *reinterpret_cast<const dart::mach_o::segment_command_64*>(command);
+      LoadSegment(segment);
+
+      if (strcmp(segment.segname, "__LINKEDIT") == 0) {
+        // Remember the link_edit_segment so we can compute the memory location
+        // of it's contents (symbol table, string table, etc) which are provided
+        // as file offsets in the load commands.
+        link_edit_segment_ = segment;
+      }
+    } else if (command->cmd == dart::mach_o::LC_SYMTAB) {
+      CHECK_ERROR(link_edit_segment_.cmd != 0, "Link edit segment not found.");
+      CHECK_ERROR(symbol_table_ == nullptr, "Multiple symbol tables found.");
+      const dart::mach_o::symtab_command& symtab =
+          *reinterpret_cast<const dart::mach_o::symtab_command*>(command);
+
+      uint64_t linkedit_offset =
+          link_edit_segment_.vmaddr - link_edit_segment_.fileoff;
+      symbol_table_ = reinterpret_cast<dart::mach_o::nlist_64*>(
+          base_->start() + symtab.symoff + linkedit_offset);
+      symbol_table_length_ = symtab.nsyms;
+      string_table_ = reinterpret_cast<const char*>(
+          base_->start() + symtab.stroff + linkedit_offset);
+    }
+    return true;
+  }));
+
+  // If we didn't find a symbol table, then we can't resolve symbols.
+  CHECK_ERROR(symbol_table_ != nullptr, "No symbol table found.");
+  return true;
+}
+
+LoadedMachO::~LoadedMachO() {}
+
+bool LoadedMachO::ResolveSymbols(const uint8_t** vm_data,
+                                 const uint8_t** vm_instrs,
+                                 const uint8_t** isolate_data,
+                                 const uint8_t** isolate_instrs) {
+  if (error_ != nullptr) {
+    return false;
+  }
+
+  for (uint32_t i = 0; i < symbol_table_length_; i++) {
+    const dart::mach_o::nlist_64& symbol = symbol_table_[i];
+    const char* name = string_table_ + symbol.n_un.n_strx;
+
+    const uint8_t** output = nullptr;
+    if (strcmp(name, kVmSnapshotDataAsmSymbol) == 0) {
+      output = vm_data;
+    } else if (strcmp(name, kVmSnapshotInstructionsAsmSymbol) == 0) {
+      output = vm_instrs;
+    } else if (strcmp(name, kIsolateSnapshotDataAsmSymbol) == 0) {
+      output = isolate_data;
+    } else if (strcmp(name, kIsolateSnapshotInstructionsAsmSymbol) == 0) {
+      output = isolate_instrs;
+    }
+
+    if (output != nullptr) {
+      *output =
+          reinterpret_cast<const uint8_t*>(base_->start() + symbol.n_value);
+    }
+  }
+
+  CHECK_ERROR(isolate_data == nullptr || *isolate_data != nullptr,
+              "Could not find isolate snapshot data.");
+  CHECK_ERROR(isolate_instrs == nullptr || *isolate_instrs != nullptr,
+              "Could not find isolate instructions.");
+
+  return true;
+}
+
+MappedMemory* LoadedMachO::MapFilePiece(uword file_start,
+                                        uword file_length,
+                                        const void** mem_start) {
+  const uword adjustment = (mach_o_data_offset_ + file_start) % PageSize();
+  const uword mapping_offset = mach_o_data_offset_ + file_start - adjustment;
+  const uword mapping_length =
+      Utils::RoundUp(mach_o_data_offset_ + file_start + file_length,
+                     PageSize()) -
+      mapping_offset;
+
+  MappedMemory* const mapping =
+      mappable_->Map(bin::File::kReadOnly, mapping_offset, mapping_length);
+
+  if (mapping != nullptr) {
+    *mem_start = reinterpret_cast<uint8_t*>(mapping->start() +
+                                            (file_start % PageSize()));
+  }
+
+  return mapping;
+}
+
+}  // namespace mach_o
+}  // namespace bin
+}  // namespace dart
+
+using namespace dart::bin::mach_o;
+
+DART_EXPORT Dart_LoadedMachO* Dart_LoadMachO(
+    const char* filename,
+    const char** error,
+    const uint8_t** vm_snapshot_data,
+    const uint8_t** vm_snapshot_instrs,
+    const uint8_t** vm_isolate_data,
+    const uint8_t** vm_isolate_instrs) {
+  std::unique_ptr<Mappable> mappable(Mappable::FromPath(filename));
+  if (mappable == nullptr) {
+    *error = "Couldn't open file.";
+    return nullptr;
+  }
+  std::unique_ptr<LoadedMachO> mach_o(new LoadedMachO(std::move(mappable)));
+
+  if (!mach_o->Load() ||
+      !mach_o->ResolveSymbols(vm_snapshot_data, vm_snapshot_instrs,
+                              vm_isolate_data, vm_isolate_instrs)) {
+    *error = mach_o->error();
+    printf("error: %s\n", *error);
+    return nullptr;
+  }
+
+  return reinterpret_cast<Dart_LoadedMachO*>(mach_o.release());
+}
+
+DART_EXPORT void Dart_UnloadMachO(Dart_LoadedMachO* loaded) {
+  delete reinterpret_cast<Dart_LoadedMachO*>(loaded);
+}

--- a/runtime/bin/mach_o_loader.h
+++ b/runtime/bin/mach_o_loader.h
@@ -1,0 +1,37 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+#ifndef RUNTIME_BIN_MACH_O_LOADER_H_
+#define RUNTIME_BIN_MACH_O_LOADER_H_
+
+#include "../include/dart_api.h"
+
+typedef struct {
+} Dart_LoadedMachO;
+
+/// Load an Mach-O object from a file.
+///
+/// On success, return a handle to the library which may be used to close it
+/// in Dart_UnloadMachO. On error, returns 'nullptr' and sets 'error'. The error
+/// string should not be 'free'-d.
+///
+/// Look up the Dart snapshot symbols "_kVmSnapshotData",
+/// "_kVmSnapshotInstructions", "_kVmIsolateData" and "_kVmIsolateInstructions"
+/// into the respectively named out-parameters.
+///
+DART_EXPORT Dart_LoadedMachO* Dart_LoadMachO(const char* filename,
+                                         const char** error,
+                                         const uint8_t** vm_snapshot_data,
+                                         const uint8_t** vm_snapshot_instrs,
+                                         const uint8_t** vm_isolate_data,
+                                         const uint8_t** vm_isolate_instrs);
+
+/// Unloads an ELF object loaded through Dart_LoadELF{_Fd, _Memory}.
+///
+/// Unlike dlclose(), this does not use reference counting.
+/// Dart_LoadELF{_Fd, _Memory} will return load the target library separately
+/// each time it is called, and the results must be unloaded separately.
+DART_EXPORT void Dart_UnloadMachO(Dart_LoadedMachO* loaded);
+
+#endif  // RUNTIME_BIN_ELF_LOADER_H_

--- a/runtime/platform/mach_o.h
+++ b/runtime/platform/mach_o.h
@@ -17,6 +17,30 @@ typedef int cpu_type_t;
 typedef int cpu_subtype_t;
 typedef int vm_prot_t;
 
+// Mach-O FAT header is big-endian.
+static constexpr uint32_t FAT_MAGIC = 0xcafebabe;
+static constexpr uint32_t FAT_MAGIC_64 = 0xcafebabf;
+
+struct fat_header {
+  uint32_t magic;      // FAT_MAGIC or FAT_MAGIC_64
+  uint32_t nfat_arch;  // Number of fat_arch structs that follow.
+};
+
+// iOS uses a 32-bit fat_arch struct, despite being a 64-bit platform.
+struct fat_arch {
+  cpu_type_t cputype;
+  cpu_subtype_t cpusubtype;
+  uint32_t offset;
+  uint32_t size;
+  uint32_t align;
+};
+
+// We only care about 64-bit ARM for iOS.
+static constexpr uint32_t CPU_ARCH_MASK = 0xff000000;
+static constexpr uint32_t CPU_ARCH_ABI64 = 0x01000000;
+static constexpr cpu_type_t CPU_TYPE_ARM = 12;
+static constexpr cpu_type_t CPU_TYPE_ARM64 = CPU_TYPE_ARM | CPU_ARCH_ABI64;
+
 struct mach_header {
   uint32_t magic;
   cpu_type_t cputype;
@@ -43,6 +67,73 @@ struct mach_header_64 {
 
 static constexpr uint32_t MH_MAGIC_64 = 0xfeedfacf;
 static constexpr uint32_t MH_CIGAM_64 = 0xcffaedfe;
+
+static constexpr uint32_t LC_SYMTAB = 0x2;
+static constexpr uint32_t LC_SEGMENT_64 = 0x19;
+
+struct symtab_command {
+  uint32_t cmd;
+  uint32_t cmdsize;
+  uint32_t symoff;  // Offset to the symbol table, relative to beginning of the
+                    // loaded linkedit segment.
+  uint32_t nsyms;
+  uint32_t stroff;   // Offset to the string table, relative to beginning of the
+                     // loaded linkedit segment.  The string table immediately
+                     // follows the symbol table and is just an series of
+                     // null-terminated strings one after the other.
+  uint32_t strsize;  // Size of the string table.
+};
+
+// Symbol table entry.
+struct nlist_64 {
+  union {
+    uint32_t n_strx;  // index into the string table.
+  } n_un;
+  uint8_t n_type;
+  uint8_t n_sect;  // Section number (1-based).
+  uint16_t n_desc;
+  uint64_t n_value;  // Value of this symbol (e.g. address)
+};
+
+// A Segment Load Command.  In a Dart snapshot, there will only be 3 segments:
+// __TEXT, __DATA, and __LINKEDIT.
+// The __TEXT segment contains the code and read-only data.
+// The __DATA segment contains the read-write data.
+// The __LINKEDIT segment contains the symbol table and string table.
+struct segment_command_64 {
+  uint32_t cmd;
+  uint32_t cmdsize;
+  char segname[16];
+  uint64_t vmaddr;
+  uint64_t vmsize;
+  uint64_t fileoff;
+  uint64_t filesize;
+  vm_prot_t maxprot;
+  vm_prot_t initprot;
+  uint32_t nsects;
+  uint32_t flags;
+};
+
+static constexpr uint32_t VM_PROT_NONE = 0x00;
+static constexpr uint32_t VM_PROT_READ = 0x01;
+static constexpr uint32_t VM_PROT_WRITE = 0x02;
+static constexpr uint32_t VM_PROT_EXECUTE = 0x04;
+
+// Segments may contain zero or more sections.
+struct section_64 {
+  char sectname[16];
+  char segname[16];
+  uint64_t addr;
+  uint64_t size;
+  uint32_t offset;
+  uint32_t align;
+  uint32_t reloff;
+  uint32_t nreloc;
+  uint32_t flags;
+  uint32_t reserved1;
+  uint32_t reserved2;
+  uint32_t reserved3;
+};
 
 struct load_command {
   uint32_t cmd;

--- a/runtime/runtime_args.gni
+++ b/runtime/runtime_args.gni
@@ -86,12 +86,3 @@ declare_args() {
   # library.
   dart_support_perfetto = true
 }
-
-declare_args() {
-  # The analyze_snapshot tool is only supported on 64 bit AOT builds that use
-  # ELF.
-  build_analyze_snapshot =
-      (target_os == "linux" || target_os == "android" ||
-       target_os == "fuchsia") &&
-      (dart_target_arch == "x64" || dart_target_arch == "arm64")
-}


### PR DESCRIPTION
Fixes https://github.com/dart-lang/sdk/issues/53938

This also removes the build guards around analyze_snapshot since it now should support all AOT snapshots on all platforms.

I don't know how to run the tests for this change.

FYI @perks.  I don't really plan to spend a bunch of time trying to land this, but I wrote this for Shorebird, and it seems to work (on our branch), figured you might want it upstream as well.

---
- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.