### PR TITLE
feat: add missing generic type to Stream.close

### DIFF
--- a/sdk/lib/async/broadcast_stream_controller.dart
+++ b/sdk/lib/async/broadcast_stream_controller.dart
@@ -257,14 +257,14 @@ abstract class _BroadcastStreamController<T>
     _sendError(error, stackTrace);
   }
 
-  Future close() {
+  Future<void> close() {
     if (isClosed) {
       assert(_doneFuture != null);
       return _doneFuture!;
     }
     if (!_mayAddEvent) throw _addEventError();
     _state |= _STATE_CLOSED;
-    Future doneFuture = _ensureDoneFuture();
+    var doneFuture = _ensureDoneFuture();
     _sendDone();
     return doneFuture;
   }
@@ -496,13 +496,13 @@ class _AsBroadcastStreamController<T> extends _SyncBroadcastStreamController<T>
     }
   }
 
-  Future close() {
+  Future<void> close() {
     if (!isClosed && _isFiring) {
       _addPendingEvent(const _DelayedDone());
       _state |= _BroadcastStreamController._STATE_CLOSED;
       return super.done;
     }
-    Future result = super.close();
+    var result = super.close();
     assert(!_hasPending);
     return result;
   }


### PR DESCRIPTION
The returned future comes from the `_ensureDoneFuture` helper function which always returns `Future<void>`. Making the return type more specific should not be a breaking change because the changed classes are 
private.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
