### PR TITLE
Fix typo unawaited_futures.dart

### DIFF
--- a/pkg/linter/lib/src/rules/unawaited_futures.dart
+++ b/pkg/linter/lib/src/rules/unawaited_futures.dart
@@ -46,7 +46,7 @@ class UnawaitedFutures extends LintRule {
   static const LintCode code = LintCode('unawaited_futures',
       "Missing an 'await' for the 'Future' computed by this expression.",
       correctionMessage:
-          "Try adding an 'await' or wrapping the expression un 'unawaited'.");
+          "Try adding an 'await' or wrapping the expression with 'unawaited'.");
 
   UnawaitedFutures()
       : super(


### PR DESCRIPTION
Typo fix in the correction message:

"wrapping the expression un 'unawaited'"
=>
"wrapping the expression with 'unawaited"

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
