### PR TITLE
No Longer Considering lineMode to check whether CR is line break

### DIFF
--- a/sdk/lib/io/stdio.dart
+++ b/sdk/lib/io/stdio.dart
@@ -59,9 +59,8 @@ class Stdin extends _StdStream implements Stream<List<int>> {
     const LF = 10;
     final List<int> line = <int>[];
     // On Windows, if lineMode is disabled, only CR is received.
-    bool crIsNewline = Platform.isWindows &&
-        (stdioType(stdin) == StdioType.terminal) &&
-        !lineMode;
+    bool crIsNewline =
+        Platform.isWindows && (stdioType(stdin) == StdioType.terminal);
     if (retainNewlines) {
       int byte;
       do {


### PR DESCRIPTION
Primarily fixes https://github.com/dart-lang/sdk/issues/54588
`lineMode` is seems unnecessary to check for crnewline, since regardless of `lineMode` the <Enter> is interpreted as `CR` in windows (Native Console Based Application such as xterm)

Also planning to fix https://github.com/dart-lang/sdk/issues/54630
Edit: Plan to fix this separately https://github.com/dart-lang/sdk/issues/54630


