### PR TITLE
Make `sign` faster.

### DIFF
--- a/sdk/lib/_internal/vm/lib/integers.dart
+++ b/sdk/lib/_internal/vm/lib/integers.dart
@@ -188,13 +188,7 @@ abstract final class _IntegerImplementation implements int {
     return this < 0 ? -this : this;
   }
 
-  int get sign {
-    return (this > 0)
-        ? 1
-        : (this < 0)
-            ? -1
-            : 0;
-  }
+  int get sign => (this >> 63) | (-this >>> 63);
 
   bool get isEven => ((this & 1) == 0);
   bool get isOdd => !isEven;

--- a/sdk/lib/_internal/vm/lib/integers.dart
+++ b/sdk/lib/_internal/vm/lib/integers.dart
@@ -188,6 +188,7 @@ abstract final class _IntegerImplementation implements int {
     return this < 0 ? -this : this;
   }
 
+  @pragma('vm:prefer-inline')
   int get sign => (this >> 63) | (-this >>> 63);
 
   bool get isEven => ((this & 1) == 0);

--- a/sdk/lib/_internal/vm_shared/lib/bigint_patch.dart
+++ b/sdk/lib/_internal/vm_shared/lib/bigint_patch.dart
@@ -1767,7 +1767,10 @@ class _BigIntImpl implements BigInt {
    * Returns 0 for zero, -1 for values less than zero and
    * +1 for values greater than zero.
    */
-  int get sign => (this >> 63) | (-this >>> 63);
+  int get sign {
+    if (_used == 0) return 0;
+    return _isNegative ? -1 : 1;
+  }
 
   /// Whether this big integer is even.
   bool get isEven => _used == 0 || (_digits[0] & 1) == 0;

--- a/sdk/lib/_internal/vm_shared/lib/bigint_patch.dart
+++ b/sdk/lib/_internal/vm_shared/lib/bigint_patch.dart
@@ -1767,10 +1767,7 @@ class _BigIntImpl implements BigInt {
    * Returns 0 for zero, -1 for values less than zero and
    * +1 for values greater than zero.
    */
-  int get sign {
-    if (_used == 0) return 0;
-    return _isNegative ? -1 : 1;
-  }
+  int get sign => (this >> 63) | (-this >>> 63);
 
   /// Whether this big integer is even.
   bool get isEven => _used == 0 || (_digits[0] & 1) == 0;

--- a/sdk/lib/_internal/wasm/lib/boxed_int.dart
+++ b/sdk/lib/_internal/wasm/lib/boxed_int.dart
@@ -136,13 +136,7 @@ final class _BoxedInt extends int {
   }
 
   @pragma("wasm:prefer-inline")
-  int get sign {
-    return (this > 0)
-        ? 1
-        : (this < 0)
-            ? -1
-            : 0;
-  }
+  int get sign => (this >> 63) | (-this >>> 63);
 
   @pragma("wasm:prefer-inline")
   bool get isEven => (this & 1) == 0;


### PR DESCRIPTION
Inspired by https://www.romainguy.dev/posts/2024/micro-optimizations-in-kotlin-1/

We use on vm and wasm.

We shouldn't use in JsInt because:
> JsInt and JsDouble is basically the same thing because they are backed by the same representation (JS number type). In JS  bitwise operations truncate the number to 32-bits so you can't really use them for this case.

Java and Kotlin 2.0 are doing this. [Benchmark on JVM](https://jmh.morethan.io/?source=https://raw.githubusercontent.com/fzhinkin/kt-64361-benchmarks/main/results/2024-01-02T155941-linux-x64-1c68796.json).