### PR TITLE
Drop `dart:html` from readme

### DIFF
--- a/sdk/api_readme.md
+++ b/sdk/api_readme.md
@@ -6,9 +6,17 @@ Welcome to the Dart API reference documentation, covering the
   * [dart:core](dart-core/dart-core-library.html): Core functionality such as
     strings, numbers, collections, errors, dates, and URIs.
   * [dart:io](dart-io/dart-io-library.html): I/O for non-web apps.
-  * [dart:js_interop](dart-js_interop/dart-js_interop-library.html)
-    and [package:web](https://pub.dev/documentation/web):
-    Web interop features and API bindings for accessing JavaScript and web libraries.
+  * [dart:async](dart-async/dart-async-library.html): Functionality for
+    asynchronous programming with Futures, Streams, and Zones.
+    
+You'll also find reference documentation covering Dart's various interop options,
+such as:
+
+  * [dart:js_interop](dart-js_interop/dart-js_interop-library.html): Library including
+    a sound type hierarchy and helper functions for interoping with JavaScript.
+  * [package:web](https://pub.dev/documentation/web): DOM manipulation for web apps.
+  * [dart:ffi](dart-ffi/dart-ffi-library.html): Foreign funtion interfaces for
+    interoping with the C language.
 
 The core libraries - except for `dart:core` - must be imported before they're
 available for use:

--- a/sdk/api_readme.md
+++ b/sdk/api_readme.md
@@ -8,8 +8,8 @@ Welcome to the Dart API reference documentation, covering the
   * [dart:io](dart-io/dart-io-library.html): I/O for non-web apps.
   * [dart:js_interop](dart-js_interop/dart-js_interop-library.html)
     and [package:web](https://pub.dev/documentation/web):
-    Web interop features and APIs for accessing JavaScript and browser bindings.
-    
+    Web interop features and API bindings for accessing JavaScript and web libraries.
+
 The core libraries - except for `dart:core` - must be imported before they're
 available for use:
 

--- a/sdk/api_readme.md
+++ b/sdk/api_readme.md
@@ -6,9 +6,10 @@ Welcome to the Dart API reference documentation, covering the
   * [dart:core](dart-core/dart-core-library.html): Core functionality such as
     strings, numbers, collections, errors, dates, and URIs.
   * [dart:io](dart-io/dart-io-library.html): I/O for non-web apps.
-  * [dart:html](dart-html/dart-html-library.html): DOM manipulation for web apps
-    (available only to web apps).
-
+  * [dart:js_interop](dart-js_interop/dart-js_interop-library.html)
+    and [package:web](https://pub.dev/documentation/web):
+    Web interop features and APIs for accessing JavaScript and browser bindings.
+    
 The core libraries - except for `dart:core` - must be imported before they're
 available for use:
 


### PR DESCRIPTION
> Update readme.md to drop dart:html link and point to "future JS"

Changed the `dart:html` bullet. I didn't want to point to [go/next-gen-js-interop](https://dart.dev/interop/js-interop#next-generation-js-interop-preview) because we have actual reference docs and I think we should keep that consistent on the page (nothing else links to dart.dev). 

### Other options

I found it a little weird calling out only JS interop when we have other interop options too? Could be overthinking it, but just in case anyone agrees I also tried a couple other versions to cover that discrepancy. They're longer but, imo, are more cohesive and stay true to the original page layout better:

#### 1. Listing out everything in the original bullet list:

```
# Welcome!

Welcome to the Dart API reference documentation, covering the
[Dart core libraries](https://dart.dev/guides/libraries). These include:

  * [dart:core](dart-core/dart-core-library.html): Core functionality such as
    strings, numbers, collections, errors, dates, and URIs.
  * [dart:io](dart-io/dart-io-library.html): I/O for non-web apps.
  * [dart:js_interop](), [dart:ffi](), [package:web](): Libraries and packages
    for interfacing with other languages and the browser. 
```

#### 2. Separate bullet list for all interop options (add async library to first list to fill it out):

```
# Welcome!

Welcome to the Dart API reference documentation, covering the
[Dart core libraries](https://dart.dev/guides/libraries). These include:

  * [dart:core](dart-core/dart-core-library.html): Core functionality such as
    strings, numbers, collections, errors, dates, and URIs.
  * [dart:io](dart-io/dart-io-library.html): I/O for non-web apps.
  * [dart:async](dart-async/dart-async-library.html): Functionality for
    asynchronous programming with Futures, Streams, and Zones.

You'll also find reference documentation covering Dart's various interop options,
such as:

  * [dart:js_interop](dart-js_interop/dart-js_interop-library.html): Library including
    a sound type hierarchy and helper functions for interoping with JavaScript.
  * [package:web](https://pub.dev/documentation/web): DOM manipulation for web apps.
  * [dart:ffi](dart-ffi/dart-ffi-library.html): Foreign funtion interfaces for
    interoping with the C language.

``` 
---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
