### PR TITLE
fix(bin/stdio)[win]: Retrieving Original Input Handle if its piped

### DIFF
--- a/build/toolchain/win/setup_toolchain.py
+++ b/build/toolchain/win/setup_toolchain.py
@@ -184,7 +184,7 @@ def _LoadToolchainEnv(cpu, toolchain_root, sdk_dir, target_store):
     # Explicitly specifying the SDK version to build with to avoid accidentally
     # building with a new and untested SDK. This should stay in sync with the
     # packaged toolchain in build/vs_toolchain.py.
-    args.append('10.0.22621.0')
+    args.append('10.0.20348.0')
     variables = _LoadEnvFromBat(args)
   return _ExtractImportantEnvironment(variables)
 

--- a/build/toolchain/win/setup_toolchain.py
+++ b/build/toolchain/win/setup_toolchain.py
@@ -184,7 +184,7 @@ def _LoadToolchainEnv(cpu, toolchain_root, sdk_dir, target_store):
     # Explicitly specifying the SDK version to build with to avoid accidentally
     # building with a new and untested SDK. This should stay in sync with the
     # packaged toolchain in build/vs_toolchain.py.
-    args.append('10.0.20348.0')
+    args.append('10.0.22621.0')
     variables = _LoadEnvFromBat(args)
   return _ExtractImportantEnvironment(variables)
 

--- a/runtime/bin/stdio_win.cc
+++ b/runtime/bin/stdio_win.cc
@@ -5,8 +5,8 @@
 #include "platform/globals.h"
 #if defined(DART_HOST_OS_WINDOWS)
 
+#include "bin/file.h"
 #include "bin/stdio.h"
-
 // These are not always defined in the header files. See:
 // https://msdn.microsoft.com/en-us/library/windows/desktop/ms686033(v=vs.85).aspx
 #ifndef ENABLE_VIRTUAL_TERMINAL_INPUT
@@ -19,6 +19,18 @@
 
 namespace dart {
 namespace bin {
+
+
+HANDLE GetInpStdHandle(int stdioMode) {
+
+if(stdioMode == File::StdioHandleType::kPipe) {
+    return CreateFileA("CONIN$", GENERIC_READ | GENERIC_WRITE, 0, 
+    NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+  }
+  else {
+    return GetStdHandle(STD_INPUT_HANDLE);
+  }     
+}
 
 bool Stdin::ReadByte(intptr_t fd, int* byte) {
   HANDLE h = GetStdHandle(STD_INPUT_HANDLE);
@@ -42,8 +54,8 @@ bool Stdin::GetEchoMode(intptr_t fd, bool* enabled) {
   return true;
 }
 
-bool Stdin::SetEchoMode(intptr_t fd, bool enabled) {
-  HANDLE h = GetStdHandle(STD_INPUT_HANDLE);
+bool Stdin::SetEchoMode(intptr_t fd, bool enabled, int stdioMode) {
+  HANDLE h = GetInpStdHandle(stdioMode);
   DWORD mode;
   if (!GetConsoleMode(h, &mode)) {
     return false;
@@ -79,8 +91,8 @@ bool Stdin::GetLineMode(intptr_t fd, bool* enabled) {
   return true;
 }
 
-bool Stdin::SetLineMode(intptr_t fd, bool enabled) {
-  HANDLE h = GetStdHandle(STD_INPUT_HANDLE);
+bool Stdin::SetLineMode(intptr_t fd, bool enabled, int stdioMode) {
+  HANDLE h = GetInpStdHandle(stdioMode);
   DWORD mode;
   if (!GetConsoleMode(h, &mode)) {
     return false;


### PR DESCRIPTION
https://github.com/dart-lang/sdk/issues/54630 Trying To Fix this,
The Solution is to retrieve the original input handle as mentioned [here](https://github.com/dart-lang/sdk/issues/54630#issuecomment-1902236707)

But i need help implementing the solution because i dont want to introduce new complexities in the interface.

I need `stdioMode` during runtime of `SetEchoMode` and `setLineMode` where i can get this from, either i need to generate during the method invocation or maybe i can get that as argument but that would break the existing `stdin.h` interface since its only required for the windows. 

Welcome for suggestions  @mraleph @brianquinlan @a-siva 