### PR TITLE
Improve sort_pub_dependencies.dart messages

### DIFF
--- a/pkg/analyzer_cli/test/driver_test.dart
+++ b/pkg/analyzer_cli/test/driver_test.dart
@@ -264,7 +264,7 @@ linter:
   Future<void> test_pubspec_lintsInOptions_generatedLints() async {
     await drive('data/linter_project/pubspec.yaml',
         options: 'data/linter_project/$analysisOptionsYaml');
-    expect(bulletToDash(outSink), contains('lint - Unsorted dependencies.'));
+    expect(bulletToDash(outSink), contains('lint - Dependencies not sorted alphabetically.'));
   }
 
   YamlMap _parseOptions(String src) =>

--- a/pkg/linter/lib/src/rules/pub/sort_pub_dependencies.dart
+++ b/pkg/linter/lib/src/rules/pub/sort_pub_dependencies.dart
@@ -17,7 +17,7 @@ Sorting list of pub dependencies makes maintenance easier.
 
 class SortPubDependencies extends LintRule {
   static const LintCode code = LintCode(
-      'sort_pub_dependencies', Dependencies not sorted alphabetically.',
+      'sort_pub_dependencies', 'Dependencies not sorted alphabetically.',
       correctionMessage: 'Try sorting the dependencies alphabetically (A to Z).');
 
   SortPubDependencies()

--- a/pkg/linter/lib/src/rules/pub/sort_pub_dependencies.dart
+++ b/pkg/linter/lib/src/rules/pub/sort_pub_dependencies.dart
@@ -17,8 +17,8 @@ Sorting list of pub dependencies makes maintenance easier.
 
 class SortPubDependencies extends LintRule {
   static const LintCode code = LintCode(
-      'sort_pub_dependencies', 'Unsorted dependencies.',
-      correctionMessage: 'Try sorting the dependencies.');
+      'sort_pub_dependencies', Dependencies not sorted alphabetically.',
+      correctionMessage: 'Try sorting the dependencies alphabetically (A to Z).');
 
   SortPubDependencies()
       : super(


### PR DESCRIPTION
This is a minor improvement for both messages that user sees when sort_pub_dependencies rule is enabled. For developers not familiar with this rule the analyzer report with current message isn't really clear from my point of view.
Thus, to save time of people who haven't seen this rule before I decided to improve the text, so the person wouldn't have to search this rule.

<img width="619" alt="Screenshot 2024-02-01 at 16 18 09" src="https://github.com/dart-lang/sdk/assets/13467769/372ed710-5ae2-4b6c-9b62-f46fa60f863f">

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
