### PR TITLE
Update dart doc for `Service.getIsolateId`

### DIFF
--- a/sdk/lib/developer/service.dart
+++ b/sdk/lib/developer/service.dart
@@ -103,6 +103,9 @@ final class Service {
   ///
   /// Returns null if the running Dart environment does not support the service
   /// protocol.
+  ///
+  /// To get the isolate id of the current isolate, pass [Isolate.current] as
+  /// the [isolate] parameter.
   @Since('3.2')
   static String? getIsolateId(Isolate isolate) {
     // TODO: When NNBD is complete, delete the following line.


### PR DESCRIPTION
This dart doc makes it more clear how to get the isolate id for the current isolate. Otherwise, a user has to know how to get an Isolate value from `dart:isolate`. 