### PR TITLE
[js_runtime/js_dev_runtime] Prefer Array.isArray over checking prototype

### DIFF
--- a/sdk/lib/_internal/js_dev_runtime/patch/convert_patch.dart
+++ b/sdk/lib/_internal/js_dev_runtime/patch/convert_patch.dart
@@ -54,10 +54,7 @@ _convertJsonToDart(json, reviver(Object? key, Object? value)) {
       return e;
     }
 
-    // This test is needed to avoid identifying '{"__proto__":[]}' as an Array.
-    // TODO(sra): Replace this test with cheaper '#.constructor === Array' when
-    // bug 621 below is fixed.
-    if (JS<bool>('!', 'Object.getPrototypeOf(#) === Array.prototype', e)) {
+    if (JS<bool>('!', 'Array.isArray(#)', e)) {
       // In-place update of the elements since JS Array is a Dart List.
       for (int i = 0; i < JS<int>('!', '#.length', e); i++) {
         // Use JS indexing to avoid range checks.  We know this is the only
@@ -99,10 +96,7 @@ _convertJsonToDartLazy(object) {
     return object;
   }
 
-  // This test is needed to avoid identifying '{"__proto__":[]}' as an array.
-  // TODO(sra): Replace this test with cheaper '#.constructor === Array' when
-  // bug https://code.google.com/p/v8/issues/detail?id=621 is fixed.
-  if (JS<bool>('!', 'Object.getPrototypeOf(#) !== Array.prototype', object)) {
+  if (JS<bool>('!', '!Array.isArray(#)', object)) {
     return _JsonMap(object);
   }
 

--- a/sdk/lib/_internal/js_runtime/lib/convert_patch.dart
+++ b/sdk/lib/_internal/js_runtime/lib/convert_patch.dart
@@ -54,10 +54,7 @@ _convertJsonToDart(json, reviver(Object? key, Object? value)) {
       return e;
     }
 
-    // This test is needed to avoid identifying '{"__proto__":[]}' as an Array.
-    // TODO(sra): Replace this test with cheaper '#.constructor === Array' when
-    // bug 621 below is fixed.
-    if (JS<bool>('bool', 'Object.getPrototypeOf(#) === Array.prototype', e)) {
+    if (JS<bool>('bool', 'Array.isArray(#)', e)) {
       // In-place update of the elements since JS Array is a Dart List.
       for (int i = 0; i < JS<int>('int', '#.length', e); i++) {
         // Use JS indexing to avoid range checks.  We know this is the only
@@ -99,11 +96,7 @@ _convertJsonToDartLazy(object) {
     return object;
   }
 
-  // This test is needed to avoid identifying '{"__proto__":[]}' as an array.
-  // TODO(sra): Replace this test with cheaper '#.constructor === Array' when
-  // bug https://code.google.com/p/v8/issues/detail?id=621 is fixed.
-  if (JS<bool>(
-      'bool', 'Object.getPrototypeOf(#) !== Array.prototype', object)) {
+  if (JS<bool>('bool', '!Array.isArray(#)', object)) {
     return _JsonMap(object);
   }
 


### PR DESCRIPTION
Inspired by https://github.com/dart-lang/sdk/issues/54933, this change updates the array-checking in the dart:convert patches to use `Array.isArray`.

Compared to `#.constructor === Array`, the performance difference seems negligible. Speaking to the comments deleted in this change, it seems that `({"__proto__":[]}).constructor === Array` produces `true` today, but I suspect that comment referred to
`JSON.parse({"__proto__":[]}).constructor === Array` instead, as that's what this code operates on. Both approaches behave as expected then.

Array.isArray has its own advantages like recognizing arrays from other windows, but that's not a concern here.

On performance, testing parsing of internal array-based protobuf formats yields ~3% improvement for large protos. This seems like a significant win for the minimal change.
