### PR TITLE
Fix incorrect definition and usage of REUSABLE_TYPE_PARAMETERS_HANDLESCOPE

### DIFF
--- a/runtime/vm/object.cc
+++ b/runtime/vm/object.cc
@@ -3626,7 +3626,7 @@ intptr_t Class::NumTypeParameters(Thread* thread) const {
   if (type_parameters() == TypeParameters::null()) {
     return 0;
   }
-  REUSABLE_TYPE_ARGUMENTS_HANDLESCOPE(thread);
+  REUSABLE_TYPE_PARAMETERS_HANDLESCOPE(thread);
   TypeParameters& type_params = thread->TypeParametersHandle();
   type_params = type_parameters();
   return type_params.Length();

--- a/runtime/vm/reusable_handles.h
+++ b/runtime/vm/reusable_handles.h
@@ -109,7 +109,7 @@ REUSABLE_HANDLE_LIST(REUSABLE_SCOPE)
 #define REUSABLE_STRING_HANDLESCOPE(thread)                                    \
   ReusableStringHandleScope reused_string_handle(thread);
 #define REUSABLE_TYPE_PARAMETERS_HANDLESCOPE(thread)                           \
-  ReusableTypeArgumentsHandleScope reused_type_parameters_handle(thread);
+  ReusableTypeParametersHandleScope reused_type_parameters_handle(thread);
 #define REUSABLE_TYPE_ARGUMENTS_HANDLESCOPE(thread)                            \
   ReusableTypeArgumentsHandleScope reused_type_arguments_handle(thread);
 #define REUSABLE_TYPE_PARAMETER_HANDLESCOPE(thread)                            \


### PR DESCRIPTION
- The macro `REUSABLE_TYPE_PARAMETERS_HANDLESCOPE` was incorrectly defined as `ReusableTypeArgumentsHandleScope`. It has been renamed to the correct `ReusableTypeParametersHandleScope`.

- In the place where the macro `REUSABLE_TYPE_PARAMETERS_HANDLESCOPE` should have been used, the incorrect macro `REUSABLE_TYPE_ARGUMENTS_HANDLESCOPE` was used instead. It has been updated to use the correct one.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
