### PR TITLE
[infra] Update alpine sysroot

### DIFF
--- a/build/.gitignore
+++ b/build/.gitignore
@@ -1,8 +1,2 @@
 # Generated file containing information about the VS toolchain on Windows.
 win_toolchain.json
-
-# Pulled linux sysroots.
-# Regex to prevent large when comparing checkouts with commits in which the
-# sysroot has been rolled.
-linux/alpine-linux-**-sysroot
-linux/debian_**-sysroot

--- a/build/config/sysroot.gni
+++ b/build/config/sysroot.gni
@@ -19,18 +19,18 @@ if (is_linux) {
   if (dart_sysroot == "alpine") {
     if (current_cpu == "x86") {
       target_sysroot =
-          rebase_path("//build/linux/alpine-linux-x86-sysroot", root_build_dir)
+          rebase_path("//buildtools/sysroot/alpine-linux-x86", root_build_dir)
     } else if (current_cpu == "x64") {
-      target_sysroot = rebase_path("//build/linux/alpine-linux-x86_64-sysroot",
+      target_sysroot = rebase_path("//buildtools/sysroot/alpine-linux-x86_64",
                                    root_build_dir)
     } else if (current_cpu == "arm") {
-      target_sysroot = rebase_path("//build/linux/alpine-linux-armv7-sysroot",
+      target_sysroot = rebase_path("//buildtools/sysroot/alpine-linux-armv7",
                                    root_build_dir)
     } else if (current_cpu == "arm64") {
-      target_sysroot = rebase_path("//build/linux/alpine-linux-aarch64-sysroot",
+      target_sysroot = rebase_path("//buildtools/sysroot/alpine-linux-aarch64",
                                    root_build_dir)
     } else if (current_cpu == "riscv64") {
-      target_sysroot = rebase_path("//build/linux/alpine-linux-riscv64-sysroot",
+      target_sysroot = rebase_path("//buildtools/sysroot/alpine-linux-riscv64",
                                    root_build_dir)
     } else {
       print("There is no $dart_sysroot sysroot present for $current_cpu")

--- a/build/linux/alpine_sysroot_scripts/install-sysroot.sh
+++ b/build/linux/alpine_sysroot_scripts/install-sysroot.sh
@@ -2,7 +2,7 @@
 
 # Install Alpine sysroots for building with musl libc.
 #
-# Sysroots will be installed into //build/linux/alpine-linux-$arch-sysroot
+# Sysroots will be installed into //buildtools/sysroot/alpine-linux-$arch
 #
 # Architectures to be installed can be configured at the end of the script
 #
@@ -18,10 +18,10 @@ fi
 
 SCRIPT="$(readlink -f -- "$0")"
 
-WORKDIR="$(dirname -- "$(dirname -- "$SCRIPT")")"
+WORKDIR="$(dirname -- "$(dirname -- "$(dirname -- "$(dirname -- "$SCRIPT")")")")"
 
 if test $# -eq 0; then
   set aarch64 armv7 x86_64 x86
 fi
 
-echo "$@" | xargs -n 1 -- sh -xc 'apk add --root "$1/alpine-linux-$2-sysroot" --repositories-file /etc/apk/repositories --allow-untrusted --arch "$2" --no-cache --no-scripts --initdb -- alpine-base alpine-sdk linux-headers' -- "$WORKDIR"
+echo "$@" | xargs -n 1 -- sh -xc 'apk add --root "$1/buildtools/sysroot/alpine-linux-$2" --repositories-file /etc/apk/repositories --allow-untrusted --arch "$2" --no-cache --no-scripts --initdb -- build-base linux-headers' -- "$WORKDIR"


### PR DESCRIPTION
This PR moves the alpine-linux sysroot installation into `//buildtools/sysroot` aside with the debain sysroot. It also reduces the size of alpine-linux sysroot from 70 packages to 25 packages.