### PR TITLE
Add enumerate method to List

### DIFF
--- a/sdk/lib/collection/list.dart
+++ b/sdk/lib/collection/list.dart
@@ -342,6 +342,10 @@ abstract mixin class ListBase<E> implements List<E> {
     return ListMapView<E>(this);
   }
 
+  Iterable<R> enumerate<R>(R Function(int index, E item) mapper) {
+    return asMap().entries.map((entry) => mapper(entry.key, entry.value));
+  }
+
   List<E> operator +(List<E> other) => [...this, ...other];
 
   List<E> sublist(int start, [int? end]) {


### PR DESCRIPTION
This contribution add a new feature to List, it allow the creation of a new List using the method ".enumerate" in analogy to other languages, this method allows to use the value and the position of this value in the List to do operations and create the new List.

The use look like this:

List\<String\> sections = ['apple', 'orange', 'lemon'];

List\<String\> titles = sections.enumerate((index, section) => '${index + 1} - $section').toList();