### PR TITLE
Show a message when DAP is connected to the VM service.

### DIFF
--- a/pkg/dds/lib/src/dap/adapters/dart.dart
+++ b/pkg/dds/lib/src/dap/adapters/dart.dart
@@ -646,6 +646,7 @@ abstract class DartDebugAdapter<TL extends LaunchRequestArguments,
     sendConsoleOutput('Connecting to VM Service at $uri');
     final vmService = await _vmServiceConnectUri(uri.toString());
     logger?.call('Connected to debugger at $uri!');
+    sendConsoleOutput('Connected to the VM Service.');
 
     // Fetch DDS capabilities.
     final supportedProtocols = await vmService.getSupportedProtocols();

--- a/pkg/dds/test/dap/integration/debug_attach_test.dart
+++ b/pkg/dds/test/dap/integration/debug_attach_test.dart
@@ -45,7 +45,7 @@ main() {
 
       // Expect the normal applications output.
       final output = outputEvents
-          .skip(1)
+          .skip(2)
           .map((e) => e.output)
           // The stdout also contains the VM Service+DevTools banners.
           .where(
@@ -98,7 +98,7 @@ main() {
 
       // Expect the normal applications output.
       final output = outputEvents
-          .skip(1)
+          .skip(2)
           .map((e) => e.output)
           // The stdout also contains the VM Service+DevTools banners.
           .where(

--- a/pkg/dds/test/dap/integration/debug_logging_test.dart
+++ b/pkg/dds/test/dap/integration/debug_logging_test.dart
@@ -55,8 +55,8 @@ void main(List<String> args) async {
 
       var outputEvents = await dap.client.collectOutput(file: testFile);
 
-      // Skip the first line because it's the VM Service connection info.
-      final output = outputEvents.skip(1).map((e) => e.output).join();
+      // Skip the first two lines because it's the VM Service connection info.
+      final output = outputEvents.skip(2).map((e) => e.output).join();
       expectLines(output, [
         '[log] this is a test',
         '      across two lines',

--- a/pkg/dds/test/dap/integration/debug_test.dart
+++ b/pkg/dds/test/dap/integration/debug_test.dart
@@ -40,7 +40,7 @@ main() {
       expect(vmConnection.category, anyOf('console', isNull));
 
       // Expect the normal applications output.
-      final output = outputEvents.skip(1).map((e) => e.output).join();
+      final output = outputEvents.skip(2).map((e) => e.output).join();
       expectLines(output, [
         'Hello!',
         'World!',
@@ -119,7 +119,7 @@ main() {
       // Expect the normal applications output. This means we set up the
       // debugger without crashing, even though we imported files with commas
       // in the name.
-      final output = outputEvents.skip(1).map((e) => e.output).join();
+      final output = outputEvents.skip(2).map((e) => e.output).join();
       expectLines(output, [
         'Hello!',
         'World!',

--- a/pkg/dds/test/dap/integration/test_support.dart
+++ b/pkg/dds/test/dap/integration/test_support.dart
@@ -17,8 +17,8 @@ import 'test_server.dart';
 
 /// A [RegExp] that matches the "Connecting to VM Service" banner that is sent
 /// by the DAP adapter as the first output event for a debug session.
-final dapVmServiceBannerPattern =
-    RegExp(r'Connecting to VM Service at ([^\s]+)\s');
+final dapVmServiceBannerPattern = RegExp(
+    r'Connecting to VM Service at ([^\s]+)\s|Connected to the VM Service');
 
 /// Whether to run the DAP server in-process with the tests, or externally in
 /// another process.


### PR DESCRIPTION
Currently the "connecting" message is logged to the debug console, but not when it's connected. The user would be confused about why connection took so long.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
