### PR TITLE
Fix issue with invoking main function from browser 

### DIFF
--- a/pkg/dart2wasm/lib/js/runtime_blob.dart
+++ b/pkg/dart2wasm/lib/js/runtime_blob.dart
@@ -149,12 +149,12 @@ const jsRuntimeBlobPart5 = r'''
         "substring": (s, a, b) => s.substring(a, b),
     };
 
-    dartInstance = await WebAssembly.instantiate(await modulePromise, {
+    const wasmInstance = await WebAssembly.instantiate(await modulePromise, {
         ...baseImports,
         ...(await importObjectPromise),
         "wasm:js-string": jsStringPolyfill,
     });
-
+    dartInstance = wasmInstance.instance;
     return dartInstance;
 }
 


### PR DESCRIPTION
When trying to invoke main method the following error occurs.
![image](https://github.com/dart-lang/sdk/assets/23008400/2e702f00-fcfb-4515-875f-4046f8a4ffe4)

this happens because of we store the result from `WebAssembly.instantiate()`, which is a **WebAssemblyInstantiatedSource** type value. We should store the instance value inside the returned object


![image](https://github.com/dart-lang/sdk/assets/23008400/17045f9e-3385-4f4d-9e0f-1a0b83a28dc1)
