### PR TITLE
added doc to RegExp.firstMatch for getting first match from offset

### DIFF
--- a/sdk/lib/core/regexp.dart
+++ b/sdk/lib/core/regexp.dart
@@ -305,6 +305,13 @@ abstract interface class RegExp implements Pattern {
   /// final match = regExp.firstMatch(string)!;
   /// print(match[0]); // chat
   /// ```
+  ///
+  /// If we need to find the [firstMatch] but starting from an offset, we can
+  /// achieve this using the [allMatches] method. Because [allMatches] is lazy,
+  /// it wont match beyond the first [RegExpMatch].
+  /// ```
+  /// RegExpMatch? match = pattern.allMatches(source, start).firstOrNull;
+  /// ```
   RegExpMatch? firstMatch(String input);
 
   Iterable<RegExpMatch> allMatches(String input, [int start = 0]);


### PR DESCRIPTION
Added documentation of how to combine get first RegExp match starting from an offset.
As discussed here:
https://github.com/dart-lang/sdk/issues/26815

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
