### PR TITLE
`@JsonCodable()` macro: escape field names with raw string

### DIFF
--- a/pkg/json/CHANGELOG.md
+++ b/pkg/json/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.20.2-wip
+
+- Fix generated code syntax error when defining fields containing the dollar sign `$` by using raw strings.
+
 # 0.20.1
 
 - Vendor macro packages as workaround for analyzer issue.

--- a/pkg/json/lib/json.dart
+++ b/pkg/json/lib/json.dart
@@ -239,7 +239,7 @@ mixin _FromJson on _Shared {
             field.type,
             RawCode.fromParts([
               jsonParam,
-              "['",
+              "[r'",
               field.identifier.name,
               "']",
             ]),
@@ -501,7 +501,7 @@ mixin _ToJson on _Shared {
         ]);
       }
       parts.addAll([
-        "json['",
+        "json[r'",
         field.identifier.name,
         "'] = ",
         await _convertTypeToJson(

--- a/pkg/json/pubspec.yaml
+++ b/pkg/json/pubspec.yaml
@@ -5,7 +5,7 @@ description: >
   `toJson` encoding method.
 
 repository: https://github.com/dart-lang/sdk/tree/main/pkg/json
-version: 0.20.1
+version: 0.20.2-wip
 environment:
   sdk: ^3.5.0-0
 dependencies:

--- a/pkg/json/test/json_codable_test.dart
+++ b/pkg/json/test/json_codable_test.dart
@@ -198,6 +198,16 @@ void main() {
 
       expect(e.toJson(), equals(json));
     });
+
+    test(r'field with dollar sign $', () {
+      var json = {
+        r'fieldWithDollarSign$': 1,
+      };
+      var f = F.fromJson(json);
+      expect(f.fieldWithDollarSign$, 1);
+
+      expect(f.toJson(), equals(json));
+    });
   });
 }
 
@@ -268,4 +278,9 @@ class E {
   final Map<String, C?> mapOfNullableSerializables;
 
   final Map<String, Set<int?>?> mapOfNullableSetsOfNullableInts;
+}
+
+@JsonCodable()
+class F {
+  final int fieldWithDollarSign$;
 }

--- a/pkg/json/test/json_decodable_test.dart
+++ b/pkg/json/test/json_decodable_test.dart
@@ -9,7 +9,8 @@ import 'package:test/test.dart';
 
 void main() {
   test('generates a fromJson constructor', () {
-    expect(A.fromJson({'b': 5}), predicate<A>((a) => a.b == 5));
+    expect(A.fromJson({'b': 5, r'$b': 5}),
+        predicate<A>((a) => a.b == 5 && a.$b == 5));
   });
 
   test('does not generate a toJson method', () {
@@ -20,6 +21,7 @@ void main() {
 @JsonDecodable()
 class A {
   final int b;
+  int? $b;
 
   A(this.b);
 }


### PR DESCRIPTION
Minor change to escape strings inside `@JsonCodable()` macro.

See related issue here #55798 

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
