### PR TITLE
replace logging.warn with logging.warning

### DIFF
--- a/pkg/compiler/test/codesize/swarm/appengine/main.py
+++ b/pkg/compiler/test/codesize/swarm/appengine/main.py
@@ -272,7 +272,7 @@ class UploadFeed(webapp.RequestHandler):
             section = findSectionByTitle(sectionTitle)
             if section != None:
                 if feed.key() in section.feeds:
-                    logging.warn('Already contains feed %s, replacing' % feedId)
+                    logging.warning('Already contains feed %s, replacing' % feedId)
                     section.feeds.remove(feed.key())
 
                 # Add the feed to the section.


### PR DESCRIPTION
logging.warn is an alias to logging.warning since Python 3.3 and will be removed in Python 3.13.

- Thanks for your contribution! Please replace this text with a description of what this PR is changing or adding and why, list any relevant issues, and review the contribution guidelines below.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
