### PR TITLE
Store the static type on TypeState

### DIFF
--- a/pkg/analyzer/lib/dart/constant/value.dart
+++ b/pkg/analyzer/lib/dart/constant/value.dart
@@ -145,4 +145,13 @@ abstract class DartObject {
   /// * this object is not of type 'Type', or
   /// * the value of the object being represented is `null`.
   DartType? toTypeValue();
+
+  /// Return the representation of the static type corresponding to the value of
+  /// the object being represented, or `null` if
+  /// * this object is not of type 'Type', or
+  /// * the value of the object being represented is `null`.
+  /// This differs from [toTypeValue] as it represents the extension type of the
+  /// object if it exists. If there is no extension type, the return value is
+  /// identical to [toTypeValue].
+  DartType? toStaticTypeValue();
 }

--- a/pkg/analyzer/lib/src/dart/constant/value.dart
+++ b/pkg/analyzer/lib/src/dart/constant/value.dart
@@ -976,6 +976,12 @@ class DartObjectImpl implements DartObject, Constant {
     return null;
   }
 
+  @override
+  DartType? toStaticTypeValue() {
+    if (state case TypeState(:final _staticType)) return _staticType;
+    return null;
+  }
+
   /// Return the result of type-instantiating this object as [type].
   ///
   /// [typeArguments] are the type arguments used in the instantiation.
@@ -3118,13 +3124,13 @@ class SymbolState extends InstanceState {
 class TypeState extends InstanceState {
   /// The element representing the type being modeled.
   final DartType? _type;
+  final DartType? _staticType;
 
   factory TypeState(DartType? type) {
-    type = type?.extensionTypeErasure;
-    return TypeState._(type);
+    return TypeState._(type?.extensionTypeErasure, type);
   }
 
-  TypeState._(this._type);
+  TypeState._(this._type, this._staticType);
 
   @override
   int get hashCode => _type?.hashCode ?? 0;


### PR DESCRIPTION
This allows users to access the static type of a DartObject through `DartObject#toStaticTypeValue`.

I'm not sure whether this is the best approach or whether it'll solve all future use-cases. I suspect it might be nicer to instead have the TypeState maintain the static type as the default "type value" and have the analyzer erase the types for comparison when necessary. At least as a maintainer of Angular, I feel like I only really care about the static type while the runtime type isn't particularly useful to me.

Please let me know if you think there's a better way to address https://github.com/dart-lang/sdk/issues/55693 or if you think this won't cover it.

For an example in use, see cl/639257690.

Apologies in advance if this PR is formatted weirdly. This is the first time I've used the built-in editor in GitHub.