### PR TITLE
Add `topics` to  `pubspec.yaml`

### DIFF
--- a/pkg/js/pubspec.yaml
+++ b/pkg/js/pubspec.yaml
@@ -8,6 +8,9 @@ analyzer:
   errors:
     export_internal_library: ignore
 
+topics:
+ - interop
+ 
 environment:
   sdk: ^3.1.0
 


### PR DESCRIPTION
Topics help users on pub.dev discover packages and related packages.

You can see a list of [topics here](https://pub.dev/topics).
You can also make your own topics.

Topics are added to pubspec.yaml as follows:

```topics:
 - my-topic
 - some-other-topic
```

See also: https://dart.dev/tools/pub/pubspec#topics