### PR TITLE
[pkg:meta] Add `topics` to `pubspec.yaml`

### DIFF
--- a/pkg/meta/pubspec.yaml
+++ b/pkg/meta/pubspec.yaml
@@ -7,6 +7,9 @@ description: >-
  deduced by statically analyzing source code.
 repository: https://github.com/dart-lang/sdk/tree/main/pkg/meta
 
+topics:
+ - static-analysis
+
 environment:
   sdk: ">=2.12.0 <4.0.0"
 


### PR DESCRIPTION
Topics help users on pub.dev discover packages and related packages.

You can see a list of [topics here](https://pub.dev/topics).
You can also make your own topics.

Topics are added to pubspec.yaml as follows:

```topics:
 - my-topic
 - some-other-topic
```

See also: https://dart.dev/tools/pub/pubspec#topics