### PR TITLE
Fix build regression on alpine linux

### DIFF
--- a/runtime/platform/utils.h
+++ b/runtime/platform/utils.h
@@ -22,7 +22,7 @@ class CAllocUniquePtr : public std::unique_ptr<T, decltype(std::free)*> {
       : std::unique_ptr<T, decltype(std::free)*>(nullptr, std::free) {}
   explicit CAllocUniquePtr(T* value)
       : std::unique_ptr<T, decltype(std::free)*>(value, std::free) {}
-  CAllocUniquePtr& operator=(nullptr_t value) {
+  CAllocUniquePtr& operator=(std::nullptr_t value) {
     std::unique_ptr<T, decltype(std::free)*>::operator=(value);
     return *this;
   }


### PR DESCRIPTION
This PR fixes a build regression on alpine linux as shown in: https://github.com/dart-musl/dart/actions/runs/9491743736/job/26157843111

```
ninja: job failed: /usr/bin/clang++ -MMD -MF obj/runtime/bin/elf_loader.virtual_memory_posix.o.d -DNDEBUG -DTARGET_ARCH_X64 -DSUPPORT_PERFETTO -DDART_TARGET_OS_LINUX -DPRODUCT -DDART_SHARED_LIB -I../../runtime -I../.. -Igen -I../../runtime/include -m64 -march=x86-64 -msse2 -fPIE --target=x86_64-alpine-linux-musl -fcolor-diagnostics -Wall -Wextra -Wendif-labels -Wno-missing-field-initializers -Wno-unused-parameter -Wno-tautological-constant-compare -Wno-unused-but-set-variable -Wno-deprecated-non-prototype -fdebug-prefix-map=/__w/dart/dart/dart-sdk/sdk/= -no-canonical-prefixes -fvisibility=hidden --sysroot=../../buildtools/sysroot/alpine-linux-x86_64 -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -Wheader-hygiene -Wstring-conversion -O2 -fno-ident -fdata-sections -ffunction-sections -g3 -ggdb3 -Wno-unused-parameter -Wno-unused-private-field -Wnon-virtual-dtor -Wvla -Woverloaded-virtual -Wno-comments -g3 -ggdb3 -fno-rtti -fno-exceptions -Wimplicit-fallthrough -fno-strict-vtable-pointers -O2 -fvisibility=hidden -fvisibility-inlines-hidden -fno-omit-frame-pointer -std=c++17 -std=c++17 -fno-rtti -c ../../runtime/bin/virtual_memory_posix.cc -o obj/runtime/bin/elf_loader.virtual_memory_posix.o
In file included from ../../runtime/bin/virtual_memory_posix.cc:20:
../../runtime/platform/utils.h:25:30: error: unknown type name 'nullptr_t'; did you mean 'std::nullptr_t'?
   25 |   CAllocUniquePtr& operator=(nullptr_t value) {
      |                              ^~~~~~~~~
      |                              std::nullptr_t
../../buildtools/sysroot/alpine-linux-x86_64/usr/lib/gcc/x86_64-alpine-linux-musl/13.2.1/../../../../include/c++/13.2.1/x86_64-alpine-linux-musl/bits/c++config.h:312:[29](https://github.com/dart-musl/dart/actions/runs/9491743736/job/26157843111#step:10:30): note: 'std::nullptr_t' declared here
  312 |   typedef decltype(nullptr)     nullptr_t;
      |                                 ^
1 error generated.
```