### PR TITLE
Make ConnectionTask constructor public

### DIFF
--- a/sdk/lib/_internal/vm/bin/socket_patch.dart
+++ b/sdk/lib/_internal/vm/bin/socket_patch.dart
@@ -1927,7 +1927,7 @@ class _RawSocket extends Stream<RawSocketEvent>
         }
         return _RawSocket(nativeSocket);
       });
-      return ConnectionTask<_RawSocket>._(raw, nativeTask._onCancel);
+      return ConnectionTask<_RawSocket>(raw, nativeTask._onCancel);
     });
   }
 
@@ -2146,7 +2146,7 @@ class Socket {
         .then((rawTask) {
       Future<Socket> socket =
           rawTask.socket.then((rawSocket) => new _Socket(rawSocket));
-      return new ConnectionTask<Socket>._(socket, rawTask._onCancel);
+      return new ConnectionTask<Socket>(socket, rawTask._onCancel);
     });
   }
 }

--- a/sdk/lib/io/secure_socket.dart
+++ b/sdk/lib/io/secure_socket.dart
@@ -82,7 +82,7 @@ abstract interface class SecureSocket implements Socket {
         .then((rawState) {
       Future<SecureSocket> socket =
           rawState.socket.then((rawSocket) => new SecureSocket._(rawSocket));
-      return new ConnectionTask<SecureSocket>._(socket, rawState._onCancel);
+      return new ConnectionTask<SecureSocket>(socket, rawState._onCancel);
     });
   }
 
@@ -305,7 +305,7 @@ abstract interface class RawSecureSocket implements RawSocket {
             keyLog: keyLog,
             supportedProtocols: supportedProtocols);
       });
-      return new ConnectionTask<RawSecureSocket>._(socket, rawState._onCancel);
+      return new ConnectionTask<RawSecureSocket>(socket, rawState._onCancel);
     });
   }
 

--- a/sdk/lib/io/socket.dart
+++ b/sdk/lib/io/socket.dart
@@ -539,7 +539,11 @@ final class ConnectionTask<S> {
   final Future<S> socket;
   final void Function() _onCancel;
 
+  @Deprecated("Use public constructor instead.")
   ConnectionTask._(Future<S> this.socket, void Function() onCancel)
+      : _onCancel = onCancel;
+
+  ConnectionTask(Future<S> this.socket, void Function() onCancel)
       : _onCancel = onCancel;
 
   /// Cancels the connection attempt.


### PR DESCRIPTION
Something to deal with #55562.

I also changed call to constructor in few places to use public constructor.

I think there also should be no worries about `ConnectionTask` actually being `CancelableOperation`. [comment](https://github.com/dart-lang/sdk/issues/55562#issuecomment-2099414124)
No one should use ConnectionTask outside of Socket and if they do it isn't a problem.
And if later there will be `CancelableOperation` class with same functianality, nothing stops us from adding ``extends CancelableOperation`` to `ConnectionTask`.