### PR TITLE
docs: `Iterable.reduce` throws when empty

### DIFF
--- a/sdk/lib/core/iterable.dart
+++ b/sdk/lib/core/iterable.dart
@@ -369,8 +369,7 @@ abstract mixin class Iterable<E> {
   /// final result = numbers.reduce((value, element) => value + element);
   /// print(result); // 17.5
   /// ```
-  /// If the iterable has no elements it will throw a state error.
-  /// Consider using [fold] if the collection may be empty.
+  /// Consider using [fold] if the iterable may be empty.
   E reduce(E combine(E value, E element)) {
     Iterator<E> iterator = this.iterator;
     if (!iterator.moveNext()) {

--- a/sdk/lib/core/iterable.dart
+++ b/sdk/lib/core/iterable.dart
@@ -369,6 +369,8 @@ abstract mixin class Iterable<E> {
   /// final result = numbers.reduce((value, element) => value + element);
   /// print(result); // 17.5
   /// ```
+  /// If the iterable has no elements it will throw a state error.
+  /// Consider using [fold] if the collection may be empty.
   E reduce(E combine(E value, E element)) {
     Iterator<E> iterator = this.iterator;
     if (!iterator.moveNext()) {

--- a/sdk/lib/core/iterable.dart
+++ b/sdk/lib/core/iterable.dart
@@ -369,7 +369,7 @@ abstract mixin class Iterable<E> {
   /// final result = numbers.reduce((value, element) => value + element);
   /// print(result); // 17.5
   /// ```
-  /// Consider using [fold] if the iterable may be empty.
+  /// Consider using [fold] if the iterable can be empty.
   E reduce(E combine(E value, E element)) {
     Iterator<E> iterator = this.iterator;
     if (!iterator.moveNext()) {


### PR DESCRIPTION
Added documentation to describe the behavior when `Iterable.reduce` is called when it is an empty collection. It's also noted that one may consider using `fold` in that case.

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
