### PR TITLE
dartdev: Add empty project template

### DIFF
--- a/pkg/dartdev/lib/src/templates.dart
+++ b/pkg/dartdev/lib/src/templates.dart
@@ -11,6 +11,7 @@ import 'package:path/path.dart' as p;
 import 'templates/cli.dart';
 import 'templates/console.dart';
 import 'templates/console_simple.dart';
+import 'templates/empty.dart';
 import 'templates/package.dart';
 import 'templates/server_shelf.dart';
 import 'templates/web.dart';
@@ -24,6 +25,7 @@ final List<Generator> generators = [
   PackageGenerator(),
   ServerShelfGenerator(),
   WebGenerator(),
+  EmptyGenerator(),
   // Deprecated generators:
   ConsoleSimpleGenerator(),
 ];

--- a/pkg/dartdev/lib/src/templates/empty.dart
+++ b/pkg/dartdev/lib/src/templates/empty.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, the Dart project authors. Please see the AUTHORS file
+// Copyright (c) 2024, the Dart project authors. Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/pkg/dartdev/lib/src/templates/empty.dart
+++ b/pkg/dartdev/lib/src/templates/empty.dart
@@ -1,0 +1,57 @@
+// Copyright (c) 2021, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import '../templates.dart';
+import 'common.dart' as common;
+
+/// A generator for an empty Dart project.
+class EmptyGenerator extends DefaultGenerator {
+  EmptyGenerator()
+      : super(
+          'empty',
+          'Empty Project',
+          'An empty Dart project',
+          categories: const ['dart'],
+          alternateId: 'empty-project',
+        ) {
+    addFile('.gitignore', _gitignore);
+    addFile('analysis_options.yaml', common.analysisOptions);
+    addFile('pubspec.yaml', _pubspec);
+  }
+
+  @override
+  String getInstallInstructions(
+    String directory, {
+    String? scriptPath,
+  }) =>
+      super.getInstallInstructions(directory);
+}
+
+final String _gitignore = '''
+# https://dart.dev/guides/libraries/private-files
+# Created by `dart pub`
+.dart_tool/
+
+# Avoid committing pubspec.lock for library packages; see
+# https://dart.dev/guides/libraries/private-files#pubspeclock.
+pubspec.lock
+''';
+
+final String _pubspec = '''
+name: __projectName__
+description: A starting point for Dart libraries or applications.
+version: 1.0.0
+# repository: https://github.com/my_org/my_repo
+
+environment:
+  ${common.sdkConstraint}
+
+# Add regular dependencies here.
+dependencies:
+  # path: ^1.8.0
+
+dev_dependencies:
+  lints: ^4.0.0
+  test: ^1.24.0
+''';

--- a/pkg/dartdev/lib/src/templates/empty.dart
+++ b/pkg/dartdev/lib/src/templates/empty.dart
@@ -47,7 +47,6 @@ version: 1.0.0
 environment:
   ${common.sdkConstraint}
 
-# Add regular dependencies here.
 dependencies:
   # path: ^1.8.0
 


### PR DESCRIPTION
As I am currently working on an OpenAPI code generator I was looking for a way to create a barebones dart project without any boilerplate. Therefore I propose to add an `empty` template only adding a minimal configuration.

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.