### PR TITLE
fix: Fix avoid_renaming_method_parameters to not consider wildcards as renames

### DIFF
--- a/pkg/linter/CHANGELOG.md
+++ b/pkg/linter/CHANGELOG.md
@@ -22,6 +22,7 @@
       'b';
       '';
   ```
+- update `avoid_renaming_method_parameters` to ignore wildcard renames
 
 # 3.4.0
 

--- a/pkg/linter/lib/src/rules/avoid_renaming_method_parameters.dart
+++ b/pkg/linter/lib/src/rules/avoid_renaming_method_parameters.dart
@@ -74,6 +74,8 @@ class AvoidRenamingMethodParameters extends LintRule {
 }
 
 class _Visitor extends SimpleAstVisitor<void> {
+  static final RegExp _wildcardRegExp = RegExp(r'^_+$');
+
   final LintRule rule;
 
   _Visitor(this.rule);
@@ -124,9 +126,18 @@ class _Visitor extends SimpleAstVisitor<void> {
     var count = math.min(parameters.length, parentParameters.length);
     for (var i = 0; i < count; i++) {
       if (parentParameters.length <= i) break;
+
       var paramIdentifier = parameters[i].name;
-      if (paramIdentifier != null &&
-          paramIdentifier.lexeme != parentParameters[i].name) {
+      if (paramIdentifier == null) {
+        continue;
+      }
+
+      var paramLexeme = paramIdentifier.lexeme;
+      if (_wildcardRegExp.hasMatch(paramLexeme)) {
+        continue; // wildcard identifier
+      }
+
+      if (paramLexeme != parentParameters[i].name) {
         rule.reportLintForToken(paramIdentifier,
             arguments: [paramIdentifier.lexeme, parentParameters[i].name]);
       }

--- a/pkg/linter/lib/src/rules/avoid_renaming_method_parameters.dart
+++ b/pkg/linter/lib/src/rules/avoid_renaming_method_parameters.dart
@@ -4,6 +4,7 @@
 
 import 'dart:math' as math;
 
+import 'package:analyzer/dart/analysis/features.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/element.dart';
@@ -68,17 +69,20 @@ class AvoidRenamingMethodParameters extends LintRule {
       NodeLintRegistry registry, LinterContext context) {
     if (!context.isInLibDir) return;
 
-    var visitor = _Visitor(this);
+    var visitor = _Visitor(this, context.libraryElement);
     registry.addMethodDeclaration(this, visitor);
   }
 }
 
 class _Visitor extends SimpleAstVisitor<void> {
-  static final RegExp _wildcardRegExp = RegExp(r'^_+$');
+  /// Whether the `wildcard_variables` feature is enabled.
+  final bool _wildCardVariablesEnabled;
 
   final LintRule rule;
 
-  _Visitor(this.rule);
+  _Visitor(this.rule, LibraryElement? library)
+      : _wildCardVariablesEnabled =
+            library?.featureSet.isEnabled(Feature.wildcard_variables) ?? false;
 
   @override
   void visitMethodDeclaration(MethodDeclaration node) {
@@ -133,7 +137,7 @@ class _Visitor extends SimpleAstVisitor<void> {
       }
 
       var paramLexeme = paramIdentifier.lexeme;
-      if (_wildcardRegExp.hasMatch(paramLexeme)) {
+      if (_wildCardVariablesEnabled && paramLexeme == '_') {
         continue; // wildcard identifier
       }
 

--- a/pkg/linter/test/rules/avoid_renaming_method_parameters_test.dart
+++ b/pkg/linter/test/rules/avoid_renaming_method_parameters_test.dart
@@ -212,4 +212,30 @@ class B extends A {
       lint(77, 1),
     ]);
   }
+
+  test_renameWithNonWildcardButUnderscoresAround() async {
+    await assertDiagnostics(r'''
+class A {
+  void m(int p) {}
+}
+class B extends A {
+  void m(_p_) {}
+}
+''', [
+      lint(60, 3),
+    ]);
+  }
+
+  test_renameWithNonWildcardButUnderscoreBefore() async {
+    await assertDiagnostics(r'''
+class A {
+  void m(int a, int b) {}
+}
+class B extends A {
+  void m(_, _b) {}
+}
+''', [
+      lint(70, 2),
+    ]);
+  }
 }

--- a/pkg/linter/test/rules/avoid_renaming_method_parameters_test.dart
+++ b/pkg/linter/test/rules/avoid_renaming_method_parameters_test.dart
@@ -184,7 +184,7 @@ class A {
   void m(int a, int b) {}
 }
 class B extends A {
-  void m(_, __) {}
+  void m(_, _) {}
 }
 ''');
   }
@@ -195,7 +195,7 @@ class A {
   void m(int a, int b, int c) {}
 }
 class B extends A {
-  void m(_, b, __) {}
+  void m(_, b, _) {}
 }
 ''');
   }
@@ -206,7 +206,7 @@ class A {
   void m(int a, int b, int c) {}
 }
 class B extends A {
-  void m(_, c, __) {}
+  void m(_, c, _) {}
 }
 ''', [
       lint(77, 1),

--- a/pkg/linter/test/rules/avoid_renaming_method_parameters_test.dart
+++ b/pkg/linter/test/rules/avoid_renaming_method_parameters_test.dart
@@ -166,4 +166,50 @@ class B extends A {
 }
 ''');
   }
+
+  test_renameWithWildcard() async {
+    await assertNoDiagnostics(r'''
+class A {
+  void m(int p) {}
+}
+class B extends A {
+  void m(_) {}
+}
+''');
+  }
+
+  test_renameWithMultipleWildcard() async {
+    await assertNoDiagnostics(r'''
+class A {
+  void m(int a, int b) {}
+}
+class B extends A {
+  void m(_, __) {}
+}
+''');
+  }
+
+  test_renameWithWildcardMixed() async {
+    await assertNoDiagnostics(r'''
+class A {
+  void m(int a, int b, int c) {}
+}
+class B extends A {
+  void m(_, b, __) {}
+}
+''');
+  }
+
+  test_renameWithWildcardMixedFails() async {
+    await assertDiagnostics(r'''
+class A {
+  void m(int a, int b, int c) {}
+}
+class B extends A {
+  void m(_, c, __) {}
+}
+''', [
+      lint(77, 1),
+    ]);
+  }
 }

--- a/pkg/linter/test/rules/avoid_renaming_method_parameters_test.dart
+++ b/pkg/linter/test/rules/avoid_renaming_method_parameters_test.dart
@@ -156,18 +156,18 @@ class B extends A {
 ''');
   }
 
-  test_zeroParameters() async {
+  test_wildcard_allowed() async {
     await assertNoDiagnostics(r'''
 class A {
-  void m() {}
+  void m(int p) {}
 }
 class B extends A {
-  void m() {}
+  void m(_) {}
 }
 ''');
   }
 
-  test_renameWithWildcardDisabled() async {
+  test_wildcard_featureDisabledFails() async {
     await assertDiagnostics(r'''
 // @dart = 3.4
 // (pre wildcard-variables)
@@ -183,29 +183,7 @@ class B extends A {
     ]);
   }
 
-  test_renameWithWildcard() async {
-    await assertNoDiagnostics(r'''
-class A {
-  void m(int p) {}
-}
-class B extends A {
-  void m(_) {}
-}
-''');
-  }
-
-  test_renameWithMultipleWildcard() async {
-    await assertNoDiagnostics(r'''
-class A {
-  void m(int a, int b) {}
-}
-class B extends A {
-  void m(_, _) {}
-}
-''');
-  }
-
-  test_renameWithWildcardMixed() async {
+  test_wildcard_mixed() async {
     await assertNoDiagnostics(r'''
 class A {
   void m(int a, int b, int c) {}
@@ -216,7 +194,7 @@ class B extends A {
 ''');
   }
 
-  test_renameWithWildcardMixedFails() async {
+  test_wildcard_mixedFails() async {
     await assertDiagnostics(r'''
 class A {
   void m(int a, int b, int c) {}
@@ -229,7 +207,31 @@ class B extends A {
     ]);
   }
 
-  test_renameWithNonWildcardButUnderscoresAround() async {
+  test_wildcard_multipleWildcards() async {
+    await assertNoDiagnostics(r'''
+class A {
+  void m(int a, int b) {}
+}
+class B extends A {
+  void m(_, _) {}
+}
+''');
+  }
+
+  test_wildcard_nonWildcardButUnderscoreBefore() async {
+    await assertDiagnostics(r'''
+class A {
+  void m(int a, int b) {}
+}
+class B extends A {
+  void m(_, _b) {}
+}
+''', [
+      lint(70, 2),
+    ]);
+  }
+
+  test_wildcard_nonWildcardButUnderscoresAround() async {
     await assertDiagnostics(r'''
 class A {
   void m(int p) {}
@@ -242,16 +244,14 @@ class B extends A {
     ]);
   }
 
-  test_renameWithNonWildcardButUnderscoreBefore() async {
-    await assertDiagnostics(r'''
+  test_zeroParameters() async {
+    await assertNoDiagnostics(r'''
 class A {
-  void m(int a, int b) {}
+  void m() {}
 }
 class B extends A {
-  void m(_, _b) {}
+  void m() {}
 }
-''', [
-      lint(70, 2),
-    ]);
+''');
   }
 }

--- a/pkg/linter/test/rules/avoid_renaming_method_parameters_test.dart
+++ b/pkg/linter/test/rules/avoid_renaming_method_parameters_test.dart
@@ -167,6 +167,22 @@ class B extends A {
 ''');
   }
 
+  test_renameWithWildcardDisabled() async {
+    await assertDiagnostics(r'''
+// @dart = 3.4
+// (pre wildcard-variables)
+
+class A {
+  void m(int p) {}
+}
+class B extends A {
+  void m(_) {}
+}
+''', [
+      lint(104, 1),
+    ]);
+  }
+
   test_renameWithWildcard() async {
     await assertNoDiagnostics(r'''
 class A {


### PR DESCRIPTION
Fix `avoid_renaming_method_parameters` to not consider wildcards as renames.

Dart allows us to use wildcard as parameters we don't care about when overriding.
However, the `avoid_renaming_method_parameters` rule would treat these as "renames", causing lint violations.
This would completely negate the purpose of the wildcard parameter in the first place, so I believe the rule should be amended to consider wildcards as legitimate.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
