### PR TITLE
fix: gen_snapshot crashes if passed a non-existent file.

### DIFF
--- a/runtime/bin/gen_snapshot.cc
+++ b/runtime/bin/gen_snapshot.cc
@@ -316,8 +316,11 @@ PRINTF_ATTRIBUTE(1, 2) static void PrintErrAndExit(const char* format, ...) {
   Syslog::VPrintErr(format, args);
   va_end(args);
 
-  Dart_ExitScope();
-  Dart_ShutdownIsolate();
+  // ExitScope and ShutdownIsolate will abort() if there is no current isolate.
+  if (Dart_CurrentIsolate() != nullptr) {
+    Dart_ExitScope();
+    Dart_ShutdownIsolate();
+  }
   exit(kErrorExitCode);
 }
 


### PR DESCRIPTION
PrintErrAndExit is used from ReadFile and other functions
to exit on error, even if there hasn't yet been an Isolate
created yet.  Calling Dart_ExitScope will no current isolate
will abort, which can trigger ReportCrash on Mac and otherwise
foul up a build process instead of just returning a nice error
message on non-existent file.