### PR TITLE
Fix typo in ArgumentError documentation

### DIFF
--- a/sdk/lib/core/errors.dart
+++ b/sdk/lib/core/errors.dart
@@ -155,7 +155,7 @@ class TypeError extends Error {}
 /// error to be throw, and avoid calling with those.
 ///
 /// It's almost always a good idea to provide the unacceptable value
-/// as part of the error, to help the user figure out what vent wrong,
+/// as part of the error, to help the user figure out what went wrong,
 /// so the [ArgumentError.value] constructor is the preferred constructor.
 /// Use [ArgumentError.new] only when the value cannot be provided for some
 /// reason.


### PR DESCRIPTION
- This PR fixes small typo in documentation of ArgumentError class changing misspelled word "vent" to word "went"

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
