### PR TITLE
`KeywordToken`: Change `keyword` field to a getter over `type`

### DIFF
--- a/pkg/_fe_analyzer_shared/lib/src/scanner/token.dart
+++ b/pkg/_fe_analyzer_shared/lib/src/scanner/token.dart
@@ -482,8 +482,7 @@ class KeywordToken extends SimpleToken {
    * Initialize a newly created token to represent the given [keyword] at the
    * given [offset].
    */
-  KeywordToken(Keyword keyword, int offset, [CommentToken? precedingComment])
-      : super(keyword, offset, precedingComment);
+  KeywordToken(super.keyword, super.offset, [super.precedingComment]);
 
   @override
   bool get isIdentifier => keyword.isPseudo || keyword.isBuiltIn;

--- a/pkg/_fe_analyzer_shared/lib/src/scanner/token.dart
+++ b/pkg/_fe_analyzer_shared/lib/src/scanner/token.dart
@@ -476,13 +476,13 @@ class Keyword extends TokenType {
  */
 class KeywordToken extends SimpleToken {
   @override
-  final Keyword keyword;
+  Keyword get keyword => type as Keyword;
 
   /**
    * Initialize a newly created token to represent the given [keyword] at the
    * given [offset].
    */
-  KeywordToken(this.keyword, int offset, [CommentToken? precedingComment])
+  KeywordToken(Keyword keyword, int offset, [CommentToken? precedingComment])
       : super(keyword, offset, precedingComment);
 
   @override


### PR DESCRIPTION
Reduce `KeywordToken` memory usage by changing the `keyword` field to a getter over `type as Keyword`.

---

- [✅] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
