### PR TITLE
`_Visitor.visitBinaryExpression`: use `const` and avoid `List` allocation.

### DIFF
--- a/pkg/linter/lib/src/rules/prefer_contains.dart
+++ b/pkg/linter/lib/src/rules/prefer_contains.dart
@@ -69,7 +69,7 @@ class _Visitor extends SimpleAstVisitor<void> {
   @override
   void visitBinaryExpression(BinaryExpression node) {
     // This lint rule is only concerned with these operators.
-    if (!node.operator.matchesAny([
+    if (!node.operator.matchesAny(const [
       TokenType.EQ_EQ,
       TokenType.BANG_EQ,
       TokenType.GT,


### PR DESCRIPTION

`visitBinaryExpression`: is a heavily accessed method and should avoid unnecessary memory allocation.

---

- [✅ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

