### PR TITLE
`SimpleToken.matchesAny`: avoid multiple accesses to getter `type`

### DIFF
--- a/pkg/_fe_analyzer_shared/lib/src/scanner/token.dart
+++ b/pkg/_fe_analyzer_shared/lib/src/scanner/token.dart
@@ -656,8 +656,10 @@ class SimpleToken implements Token {
 
   @override
   bool matchesAny(List<TokenType> types) {
-    for (TokenType type in types) {
-      if (this.type == type) {
+    // [type] is a getter that accesses [_tokenTypesByIndex]:
+    TokenType type = this.type;
+    for (TokenType t in types) {
+      if (type == t) {
         return true;
       }
     }


### PR DESCRIPTION
`type` is a getter that computes type index and accesses `_tokenTypesByIndex`, so multiple calls to `type` should be avoided when possible.

---

- [✅] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
