### PR TITLE
`Event.message`: accept `String` or `Function` to avoid `String` interpolation.

### DIFF
--- a/pkg/_fe_analyzer_shared/lib/src/type_inference/shared_inference_log.dart
+++ b/pkg/_fe_analyzer_shared/lib/src/type_inference/shared_inference_log.dart
@@ -702,9 +702,11 @@ abstract class SharedInferenceLogWriterImpl<Type extends SharedType<Type>,
         method: 'recordGeneratedConstraint',
         arguments: [parameter, constraint],
         expectedKind: StateKind.constraintGeneration);
-    String constraintText =
-        constraint.toString().replaceAll('<type>', parameter.toString());
-    addEvent(new Event(message: () => 'ADDED CONSTRAINT $constraintText'));
+    addEvent(new Event(message: () {
+      String constraintText =
+          constraint.toString().replaceAll('<type>', parameter.toString());
+      return 'ADDED CONSTRAINT $constraintText';
+    }));
   }
 
   @override
@@ -734,13 +736,13 @@ abstract class SharedInferenceLogWriterImpl<Type extends SharedType<Type>,
         method: 'recordPreliminaryTypes',
         arguments: [types],
         expectedKind: StateKind.genericInference);
-    List<Object> typeFormals = (state as GenericInferenceState).typeFormals;
-    List<String> typeAssignments = [
-      for (int i = 0; i < types.length; i++) '${typeFormals[i]}=${types[i]}'
-    ];
-    addEvent(new Event(
-        message: () =>
-            'PRELIMINARY GENERIC TYPES ${typeAssignments.join(', ')}'));
+    addEvent(new Event(message: () {
+      List<Object> typeFormals = (state as GenericInferenceState).typeFormals;
+      List<String> typeAssignments = [
+        for (int i = 0; i < types.length; i++) '${typeFormals[i]}=${types[i]}'
+      ];
+      return 'PRELIMINARY GENERIC TYPES ${typeAssignments.join(', ')}';
+    }));
   }
 
   @override


### PR DESCRIPTION
Since `Event` is a logging object, its construction should not allocate new `String` objects or perform `String` interpolation.

This also:

- Helps GC and reduces heap limit while analyzing a project/directory.

- Avoids calls to `describe`:
https://github.com/dart-lang/sdk/blob/4954a032c50a66d568affdd09e0b9409dce180c9/pkg/_fe_analyzer_shared/lib/src/type_inference/shared_inference_log.dart#L37



---

- [✅] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
