### PR TITLE
feat: make remove widget work for slivers

### DIFF
--- a/pkg/analysis_server/lib/src/services/correction/dart/flutter_remove_widget.dart
+++ b/pkg/analysis_server/lib/src/services/correction/dart/flutter_remove_widget.dart
@@ -62,6 +62,8 @@ class FlutterRemoveWidget extends ResolvedCorrectionProducer {
     }
     else if (widgetCreation.sliverArgument case var sliverArgument?) {
       await _removeSingle(builder, widgetCreation, sliverArgument.expression);
+    } else {
+      await _removeSingleWhenInList(builder, widgetCreation);
     }
   }
 
@@ -133,6 +135,21 @@ class FlutterRemoveWidget extends ResolvedCorrectionProducer {
         indentNew,
       );
       builder.addSimpleReplacement(range.node(widgetCreation), childText);
+    });
+  }
+
+  Future<void> _removeSingleWhenInList(
+    ChangeBuilder builder,
+    InstanceCreationExpression widgetCreation,
+  ) async {
+    // We can only remove the widget when this widget is in list.
+    var widgetParentNode = widgetCreation.parent;
+    if (widgetParentNode is! ListLiteral) {
+      return;
+    }
+
+    await builder.addDartFileEdit(file, (builder) {
+      builder.addDeletion(range.nodeInList(widgetParentNode.elements, widgetCreation));
     });
   }
 }

--- a/pkg/analysis_server/lib/src/services/correction/dart/flutter_remove_widget.dart
+++ b/pkg/analysis_server/lib/src/services/correction/dart/flutter_remove_widget.dart
@@ -37,7 +37,7 @@ class FlutterRemoveWidget extends ResolvedCorrectionProducer {
   @override
   Future<void> compute(ChangeBuilder builder) async {
     var widgetCreation = node.findInstanceCreationExpression;
-    if (widgetCreation == null) {
+    if (widgetCreation == null || !widgetCreation.isWidgetCreation) {
       return;
     }
 

--- a/pkg/analysis_server/lib/src/services/correction/dart/flutter_remove_widget.dart
+++ b/pkg/analysis_server/lib/src/services/correction/dart/flutter_remove_widget.dart
@@ -41,25 +41,18 @@ class FlutterRemoveWidget extends ResolvedCorrectionProducer {
       return;
     }
 
-    // Prepare possible arguments.
-    late var childrenArgument = widgetCreation.childrenArgument;
-    late var childArgument = widgetCreation.childArgument;
-    late var builderArgument = widgetCreation.builderArgument;
-    late var sliverArgument = widgetCreation.sliverArgument;
-    late var sliversArgument = widgetCreation.sliversArgument;
-
-    if (childrenArgument != null) {
+    if (widgetCreation.childrenArgument case var childrenArgument?) {
       var childrenExpression = childrenArgument.expression;
       if (childrenExpression is ListLiteral &&
           childrenExpression.elements.isNotEmpty) {
         await _removeChildren(
             builder, widgetCreation, childrenExpression.elements);
       }
-    } else if (childArgument != null) {
+    } else if (widgetCreation.childArgument case var childArgument?) {
       await _removeSingle(builder, widgetCreation, childArgument.expression);
-    } else if (builderArgument != null) {
+    } else if (widgetCreation.builderArgument case var builderArgument?) {
       await _removeBuilder(builder, widgetCreation, builderArgument);
-    } else if (sliversArgument != null) {
+    } else if (widgetCreation.sliversArgument case var sliversArgument?) {
       var sliversExpression = sliversArgument.expression;
       if (sliversExpression is ListLiteral &&
           sliversExpression.elements.isNotEmpty) {
@@ -67,7 +60,7 @@ class FlutterRemoveWidget extends ResolvedCorrectionProducer {
             builder, widgetCreation, sliversExpression.elements);
       }
     }
-    else if (sliverArgument != null) {
+    else if (widgetCreation.sliverArgument case var sliverArgument?) {
       await _removeSingle(builder, widgetCreation, sliverArgument.expression);
     }
   }

--- a/pkg/analysis_server/lib/src/services/correction/dart/flutter_remove_widget.dart
+++ b/pkg/analysis_server/lib/src/services/correction/dart/flutter_remove_widget.dart
@@ -59,8 +59,7 @@ class FlutterRemoveWidget extends ResolvedCorrectionProducer {
         await _removeChildren(
             builder, widgetCreation, sliversExpression.elements);
       }
-    }
-    else if (widgetCreation.sliverArgument case var sliverArgument?) {
+    } else if (widgetCreation.sliverArgument case var sliverArgument?) {
       await _removeSingle(builder, widgetCreation, sliverArgument.expression);
     } else {
       await _removeSingleWhenInList(builder, widgetCreation);
@@ -149,7 +148,9 @@ class FlutterRemoveWidget extends ResolvedCorrectionProducer {
     }
 
     await builder.addDartFileEdit(file, (builder) {
-      builder.addDeletion(range.nodeInList(widgetParentNode.elements, widgetCreation));
+      builder.addDeletion(
+        range.nodeInList(widgetParentNode.elements, widgetCreation),
+      );
     });
   }
 }

--- a/pkg/analysis_server/lib/src/services/correction/dart/flutter_remove_widget.dart
+++ b/pkg/analysis_server/lib/src/services/correction/dart/flutter_remove_widget.dart
@@ -41,8 +41,13 @@ class FlutterRemoveWidget extends ResolvedCorrectionProducer {
       return;
     }
 
-    // Prepare the list of our children.
-    var childrenArgument = widgetCreation.childrenArgument;
+    // Prepare possible arguments.
+    late var childrenArgument = widgetCreation.childrenArgument;
+    late var childArgument = widgetCreation.childArgument;
+    late var builderArgument = widgetCreation.builderArgument;
+    late var sliverArgument = widgetCreation.sliverArgument;
+    late var sliversArgument = widgetCreation.sliversArgument;
+
     if (childrenArgument != null) {
       var childrenExpression = childrenArgument.expression;
       if (childrenExpression is ListLiteral &&
@@ -50,16 +55,20 @@ class FlutterRemoveWidget extends ResolvedCorrectionProducer {
         await _removeChildren(
             builder, widgetCreation, childrenExpression.elements);
       }
-    } else {
-      var childArgument = widgetCreation.childArgument;
-      if (childArgument != null) {
-        await _removeSingle(builder, widgetCreation, childArgument.expression);
-      } else {
-        var builderArgument = widgetCreation.builderArgument;
-        if (builderArgument != null) {
-          await _removeBuilder(builder, widgetCreation, builderArgument);
-        }
+    } else if (childArgument != null) {
+      await _removeSingle(builder, widgetCreation, childArgument.expression);
+    } else if (builderArgument != null) {
+      await _removeBuilder(builder, widgetCreation, builderArgument);
+    } else if (sliversArgument != null) {
+      var sliversExpression = sliversArgument.expression;
+      if (sliversExpression is ListLiteral &&
+          sliversExpression.elements.isNotEmpty) {
+        await _removeChildren(
+            builder, widgetCreation, sliversExpression.elements);
       }
+    }
+    else if (sliverArgument != null) {
+      await _removeSingle(builder, widgetCreation, sliverArgument.expression);
     }
   }
 

--- a/pkg/analysis_server/lib/src/utilities/extensions/flutter.dart
+++ b/pkg/analysis_server/lib/src/utilities/extensions/flutter.dart
@@ -376,7 +376,6 @@ extension InstanceCreationExpressionExtension on InstanceCreationExpression {
       .whereType<NamedExpression>()
       .firstWhereOrNull((argument) => argument.isSliversArgument);
 
-
   /// The presentation for this node.
   String? get widgetPresentationText {
     var element =

--- a/pkg/analysis_server/lib/src/utilities/extensions/flutter.dart
+++ b/pkg/analysis_server/lib/src/utilities/extensions/flutter.dart
@@ -350,18 +350,6 @@ extension InstanceCreationExpressionExtension on InstanceCreationExpression {
       .whereType<NamedExpression>()
       .firstWhereOrNull((argument) => argument.isChildrenArgument);
 
-  /// The named expression representing the `sliver` argument, or `null` if there
-  /// is none.
-  NamedExpression? get sliverArgument => argumentList.arguments
-      .whereType<NamedExpression>()
-      .firstWhereOrNull((argument) => argument.isSliverArgument);
-
-  /// The named expression representing the `slivers` argument, or `null` if
-  /// there is none.
-  NamedExpression? get sliversArgument => argumentList.arguments
-      .whereType<NamedExpression>()
-      .firstWhereOrNull((argument) => argument.isSliversArgument);
-
   bool get isExactlyAlignCreation => staticType.isExactWidgetTypeAlign;
 
   bool get isExactlyContainerCreation => staticType.isExactWidgetTypeContainer;
@@ -375,6 +363,19 @@ extension InstanceCreationExpressionExtension on InstanceCreationExpression {
         constructorName.staticElement?.enclosingElement3.augmented.declaration;
     return element.isWidget;
   }
+
+  /// The named expression representing the `sliver` argument, or `null` if there
+  /// is none.
+  NamedExpression? get sliverArgument => argumentList.arguments
+      .whereType<NamedExpression>()
+      .firstWhereOrNull((argument) => argument.isSliverArgument);
+
+  /// The named expression representing the `slivers` argument, or `null` if
+  /// there is none.
+  NamedExpression? get sliversArgument => argumentList.arguments
+      .whereType<NamedExpression>()
+      .firstWhereOrNull((argument) => argument.isSliversArgument);
+
 
   /// The presentation for this node.
   String? get widgetPresentationText {

--- a/pkg/analysis_server/lib/src/utilities/extensions/flutter.dart
+++ b/pkg/analysis_server/lib/src/utilities/extensions/flutter.dart
@@ -317,6 +317,18 @@ extension ExpressionExtension on Expression {
     var self = this;
     return self is NamedExpression && self.name.label.name == 'children';
   }
+
+  /// Whether this is the `sliver` argument.
+  bool get isSliverArgument {
+    var self = this;
+    return self is NamedExpression && self.name.label.name == 'sliver';
+  }
+
+  /// Whether this is the `slivers` argument.
+  bool get isSliversArgument {
+    var self = this;
+    return self is NamedExpression && self.name.label.name == 'slivers';
+  }
 }
 
 extension InstanceCreationExpressionExtension on InstanceCreationExpression {
@@ -337,6 +349,18 @@ extension InstanceCreationExpressionExtension on InstanceCreationExpression {
   NamedExpression? get childrenArgument => argumentList.arguments
       .whereType<NamedExpression>()
       .firstWhereOrNull((argument) => argument.isChildrenArgument);
+
+  /// The named expression representing the `sliver` argument, or `null` if there
+  /// is none.
+  NamedExpression? get sliverArgument => argumentList.arguments
+      .whereType<NamedExpression>()
+      .firstWhereOrNull((argument) => argument.isSliverArgument);
+
+  /// The named expression representing the `slivers` argument, or `null` if
+  /// there is none.
+  NamedExpression? get sliversArgument => argumentList.arguments
+      .whereType<NamedExpression>()
+      .firstWhereOrNull((argument) => argument.isSliversArgument);
 
   bool get isExactlyAlignCreation => staticType.isExactWidgetTypeAlign;
 

--- a/pkg/analysis_server/test/src/services/correction/assist/flutter_remove_widget_test.dart
+++ b/pkg/analysis_server/test/src/services/correction/assist/flutter_remove_widget_test.dart
@@ -33,138 +33,6 @@ class FlutterRemoveWidgetTest extends AssistProcessorTest {
     );
   }
 
-  Future<void> test_doesNotRemoveWidgetWithoutArgumentWhenNotInList() async {
-    await resolveTestCode('''
-import 'package:flutter/material.dart';
-void f() {
-  /*caret*/Container();
-}
-''');
-    await assertNoAssist();
-  }
-
-  Future<void> test_removeWidgetWithoutArgumentWhenInList() async {
-    await resolveTestCode('''
-import 'package:flutter/material.dart';
-void f() {
-  Column(
-    children: [
-      /*caret*/Container(),
-    ],
-  );
-}
-''');
-    await assertHasAssist('''
-import 'package:flutter/material.dart';
-void f() {
-  Column(
-    children: [
-      
-    ],
-  );
-}
-''');
-  }
-
-  Future<void> test_removeWidgetWithoutArgumentWhenInListSliver() async {
-    await resolveTestCode('''
-import 'package:flutter/material.dart';
-void f() {
-  CustomScrollView(
-    slivers: [
-      /*caret*/SliverToBoxAdapter(),
-    ],
-  );
-}
-''');
-    await assertHasAssist('''
-import 'package:flutter/material.dart';
-void f() {
-  CustomScrollView(
-    slivers: [
-      
-    ],
-  );
-}
-''');
-  }
-
-  Future<void> test_does_not_work_for_non_widgets_child() async {
-    await resolveTestCode('''
-import 'package:flutter/material.dart';
-
-class NotAWidget {
-  final int child;
-
-  NotAWidget({required this.child});
-}
-
-void f() {
-  /*caret*/NotAWidget(
-    child: 42,
-  );
-}
-''');
-    await assertNoAssist();
-  }
-
-  Future<void> test_does_not_work_for_non_widgets_children() async {
-    await resolveTestCode('''
-import 'package:flutter/material.dart';
-
-class NotAWidget {
-  final List<int> children;
-
-  NotAWidget({required this.children});
-}
-
-void f() {
-  /*caret*/NotAWidget(
-    children: [42],
-  );
-}
-''');
-    await assertNoAssist();
-  }
-
-  Future<void> test_does_not_work_for_non_widgets_sliver() async {
-    await resolveTestCode('''
-import 'package:flutter/material.dart';
-
-class NotAWidget {
-  final int sliver;
-
-  NotAWidget({required this.sliver});
-}
-
-void f() {
-  /*caret*/NotAWidget(
-    sliver: 42,
-  );
-}
-''');
-    await assertNoAssist();
-  }
-
-  Future<void> test_does_not_work_for_non_widgets_slivers() async {
-    await resolveTestCode('''
-import 'package:flutter/material.dart';
-
-class NotAWidget {
-  final List<int> slivers;
-
-  NotAWidget({required this.slivers});
-}
-
-void f() {
-  /*caret*/NotAWidget(
-    slivers: [42],
-  );
-}
-''');
-    await assertNoAssist();
-  }
-
   Future<void> test_builder_blockFunctionBody() async {
     await resolveTestCode('''
 import 'package:flutter/material.dart';
@@ -264,42 +132,6 @@ void f() {
 ''');
   }
 
-  Future<void> test_sliver_childIntoChild_multiLine() async {
-    await resolveTestCode('''
-import 'package:flutter/material.dart';
-void f() {
-  CustomScrollView(
-    slivers: [
-      SliverPadding(
-        padding: const EdgeInsets.all(8.0),
-        sliver: /*caret*/DecoratedSliver(
-          decoration: BoxDecoration(),
-          sliver: SliverToBoxAdapter(
-            child: Text('foo'),
-          ),
-        ),
-      ),
-    ],
-  );
-}
-''');
-    await assertHasAssist('''
-import 'package:flutter/material.dart';
-void f() {
-  CustomScrollView(
-    slivers: [
-      SliverPadding(
-        padding: const EdgeInsets.all(8.0),
-        sliver: SliverToBoxAdapter(
-          child: Text('foo'),
-        ),
-      ),
-    ],
-  );
-}
-''');
-  }
-
   Future<void> test_childIntoChild_singleLine() async {
     await resolveTestCode('''
 import 'package:flutter/material.dart';
@@ -360,42 +192,6 @@ void f() {
 ''');
   }
 
-  Future<void> test_sliver_childIntoChildren() async {
-    await resolveTestCode('''
-import 'package:flutter/material.dart';
-void f() {
-  CustomScrollView(
-    slivers: [
-      SliverToBoxAdapter(child: Text('foo')),
-      /*caret*/DecoratedSliver(
-        decoration: BoxDecoration(),
-        sliver: SliverPadding(
-          padding: const EdgeInsets.all(8.0),
-          sliver: SliverToBoxAdapter(child: Text('bar')),
-        ),
-      ),
-      SliverToBoxAdapter(child: Text('baz')),
-    ],
-  );
-}
-''');
-    await assertHasAssist('''
-import 'package:flutter/material.dart';
-void f() {
-  CustomScrollView(
-    slivers: [
-      SliverToBoxAdapter(child: Text('foo')),
-      SliverPadding(
-        padding: const EdgeInsets.all(8.0),
-        sliver: SliverToBoxAdapter(child: Text('bar')),
-      ),
-      SliverToBoxAdapter(child: Text('baz')),
-    ],
-  );
-}
-''');
-  }
-
   Future<void> test_childrenMultipleIntoChild() async {
     await resolveTestCode('''
 import 'package:flutter/material.dart';
@@ -405,23 +201,6 @@ void f() {
       children: [
         Text('aaa'),
         Text('bbb'),
-      ],
-    ),
-  );
-}
-''');
-    await assertNoAssist();
-  }
-
-  Future<void> test_sliver_childrenMultipleIntoChild() async {
-    await resolveTestCode('''
-import 'package:flutter/material.dart';
-void f() {
-  Center(
-    child: /*caret*/CustomScrollView(
-      slivers: [
-        SliverToBoxAdapter(child: Text('aaa')),
-        SliverToBoxAdapter(child: Text('bbb')),
       ],
     ),
   );
@@ -453,29 +232,6 @@ void f() {
 ''');
   }
 
-  Future<void> test_sliver_childrenOneIntoChild() async {
-    await resolveTestCode('''
-import 'package:flutter/material.dart';
-void f() {
-  Center(
-    child: /*caret*/CustomScrollView(
-      slivers: [
-        SliverToBoxAdapter(child: Text('foo')),
-      ],
-    ),
-  );
-}
-''');
-    await assertHasAssist('''
-import 'package:flutter/material.dart';
-void f() {
-  Center(
-    child: SliverToBoxAdapter(child: Text('foo')),
-  );
-}
-''');
-  }
-
   Future<void> test_childrenOneIntoReturn() async {
     await resolveTestCode('''
 import 'package:flutter/material.dart';
@@ -495,23 +251,90 @@ Widget f() {
 ''');
   }
 
-  Future<void> test_sliver_childrenOneIntoReturn() async {
+  Future<void> test_does_not_work_for_non_widgets_child() async {
     await resolveTestCode('''
 import 'package:flutter/material.dart';
-Widget f() {
-  return /*caret*/CustomScrollView(
-    slivers: [
-      SliverToBoxAdapter(child: Text('foo')),
-    ],
+
+class NotAWidget {
+  final int child;
+
+  NotAWidget({required this.child});
+}
+
+void f() {
+  /*caret*/NotAWidget(
+    child: 42,
   );
 }
 ''');
-    await assertHasAssist('''
+    await assertNoAssist();
+  }
+
+  Future<void> test_does_not_work_for_non_widgets_children() async {
+    await resolveTestCode('''
 import 'package:flutter/material.dart';
-Widget f() {
-  return SliverToBoxAdapter(child: Text('foo'));
+
+class NotAWidget {
+  final List<int> children;
+
+  NotAWidget({required this.children});
+}
+
+void f() {
+  /*caret*/NotAWidget(
+    children: [42],
+  );
 }
 ''');
+    await assertNoAssist();
+  }
+
+  Future<void> test_does_not_work_for_non_widgets_sliver() async {
+    await resolveTestCode('''
+import 'package:flutter/material.dart';
+
+class NotAWidget {
+  final int sliver;
+
+  NotAWidget({required this.sliver});
+}
+
+void f() {
+  /*caret*/NotAWidget(
+    sliver: 42,
+  );
+}
+''');
+    await assertNoAssist();
+  }
+
+  Future<void> test_does_not_work_for_non_widgets_slivers() async {
+    await resolveTestCode('''
+import 'package:flutter/material.dart';
+
+class NotAWidget {
+  final List<int> slivers;
+
+  NotAWidget({required this.slivers});
+}
+
+void f() {
+  /*caret*/NotAWidget(
+    slivers: [42],
+  );
+}
+''');
+    await assertNoAssist();
+  }
+
+  Future<void> test_doesNotRemoveWidgetWithoutArgumentWhenNotInList() async {
+    await resolveTestCode('''
+import 'package:flutter/material.dart';
+void f() {
+  /*caret*/Container();
+}
+''');
+    await assertNoAssist();
   }
 
   Future<void> test_intoChildren() async {
@@ -563,6 +386,229 @@ void f() {
       Text('fff'),
     ],
   );
+}
+''');
+  }
+
+  Future<void> test_prefixedConstructor_onConstructor() async {
+    await resolveTestCode('''
+import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' as m;
+void f() {
+  Center(
+    child: m./*caret*/Center(
+      child: Text(''),
+    ),
+  );
+}
+''');
+    await assertHasAssist('''
+import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' as m;
+void f() {
+  Center(
+    child: Text(''),
+  );
+}
+''');
+  }
+
+  Future<void> test_prefixedConstructor_onPrefix() async {
+    await resolveTestCode('''
+import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' as m;
+void f() {
+  Center(
+    child: /*caret*/m.Center(
+      child: Text(''),
+    ),
+  );
+}
+''');
+    await assertHasAssist('''
+import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' as m;
+void f() {
+  Center(
+    child: Text(''),
+  );
+}
+''');
+  }
+
+  Future<void> test_removeWidgetWithoutArgumentWhenInList() async {
+    await resolveTestCode('''
+import 'package:flutter/material.dart';
+void f() {
+  Column(
+    children: [
+      /*caret*/Container(),
+    ],
+  );
+}
+''');
+    await assertHasAssist('''
+import 'package:flutter/material.dart';
+void f() {
+  Column(
+    children: [
+      
+    ],
+  );
+}
+''');
+  }
+
+  Future<void> test_removeWidgetWithoutArgumentWhenInListSliver() async {
+    await resolveTestCode('''
+import 'package:flutter/material.dart';
+void f() {
+  CustomScrollView(
+    slivers: [
+      /*caret*/SliverToBoxAdapter(),
+    ],
+  );
+}
+''');
+    await assertHasAssist('''
+import 'package:flutter/material.dart';
+void f() {
+  CustomScrollView(
+    slivers: [
+      
+    ],
+  );
+}
+''');
+  }
+
+  Future<void> test_sliver_childIntoChild_multiLine() async {
+    await resolveTestCode('''
+import 'package:flutter/material.dart';
+void f() {
+  CustomScrollView(
+    slivers: [
+      SliverPadding(
+        padding: const EdgeInsets.all(8.0),
+        sliver: /*caret*/DecoratedSliver(
+          decoration: BoxDecoration(),
+          sliver: SliverToBoxAdapter(
+            child: Text('foo'),
+          ),
+        ),
+      ),
+    ],
+  );
+}
+''');
+    await assertHasAssist('''
+import 'package:flutter/material.dart';
+void f() {
+  CustomScrollView(
+    slivers: [
+      SliverPadding(
+        padding: const EdgeInsets.all(8.0),
+        sliver: SliverToBoxAdapter(
+          child: Text('foo'),
+        ),
+      ),
+    ],
+  );
+}
+''');
+  }
+
+  Future<void> test_sliver_childIntoChildren() async {
+    await resolveTestCode('''
+import 'package:flutter/material.dart';
+void f() {
+  CustomScrollView(
+    slivers: [
+      SliverToBoxAdapter(child: Text('foo')),
+      /*caret*/DecoratedSliver(
+        decoration: BoxDecoration(),
+        sliver: SliverPadding(
+          padding: const EdgeInsets.all(8.0),
+          sliver: SliverToBoxAdapter(child: Text('bar')),
+        ),
+      ),
+      SliverToBoxAdapter(child: Text('baz')),
+    ],
+  );
+}
+''');
+    await assertHasAssist('''
+import 'package:flutter/material.dart';
+void f() {
+  CustomScrollView(
+    slivers: [
+      SliverToBoxAdapter(child: Text('foo')),
+      SliverPadding(
+        padding: const EdgeInsets.all(8.0),
+        sliver: SliverToBoxAdapter(child: Text('bar')),
+      ),
+      SliverToBoxAdapter(child: Text('baz')),
+    ],
+  );
+}
+''');
+  }
+
+  Future<void> test_sliver_childrenMultipleIntoChild() async {
+    await resolveTestCode('''
+import 'package:flutter/material.dart';
+void f() {
+  Center(
+    child: /*caret*/CustomScrollView(
+      slivers: [
+        SliverToBoxAdapter(child: Text('aaa')),
+        SliverToBoxAdapter(child: Text('bbb')),
+      ],
+    ),
+  );
+}
+''');
+    await assertNoAssist();
+  }
+
+  Future<void> test_sliver_childrenOneIntoChild() async {
+    await resolveTestCode('''
+import 'package:flutter/material.dart';
+void f() {
+  Center(
+    child: /*caret*/CustomScrollView(
+      slivers: [
+        SliverToBoxAdapter(child: Text('foo')),
+      ],
+    ),
+  );
+}
+''');
+    await assertHasAssist('''
+import 'package:flutter/material.dart';
+void f() {
+  Center(
+    child: SliverToBoxAdapter(child: Text('foo')),
+  );
+}
+''');
+  }
+
+  Future<void> test_sliver_childrenOneIntoReturn() async {
+    await resolveTestCode('''
+import 'package:flutter/material.dart';
+Widget f() {
+  return /*caret*/CustomScrollView(
+    slivers: [
+      SliverToBoxAdapter(child: Text('foo')),
+    ],
+  );
+}
+''');
+    await assertHasAssist('''
+import 'package:flutter/material.dart';
+Widget f() {
+  return SliverToBoxAdapter(child: Text('foo'));
 }
 ''');
   }
@@ -620,29 +666,6 @@ void f() {
 ''');
   }
 
-  Future<void> test_prefixedConstructor_onConstructor() async {
-    await resolveTestCode('''
-import 'package:flutter/material.dart';
-import 'package:flutter/material.dart' as m;
-void f() {
-  Center(
-    child: m./*caret*/Center(
-      child: Text(''),
-    ),
-  );
-}
-''');
-    await assertHasAssist('''
-import 'package:flutter/material.dart';
-import 'package:flutter/material.dart' as m;
-void f() {
-  Center(
-    child: Text(''),
-  );
-}
-''');
-  }
-
   Future<void> test_sliver_prefixedConstructor_onConstructor() async {
     await resolveTestCode('''
 import 'package:flutter/material.dart';
@@ -663,29 +686,6 @@ void f() {
   SliverPadding(
     padding: const EdgeInsets.all(8.0),
     sliver: Text(''),
-  );
-}
-''');
-  }
-
-  Future<void> test_prefixedConstructor_onPrefix() async {
-    await resolveTestCode('''
-import 'package:flutter/material.dart';
-import 'package:flutter/material.dart' as m;
-void f() {
-  Center(
-    child: /*caret*/m.Center(
-      child: Text(''),
-    ),
-  );
-}
-''');
-    await assertHasAssist('''
-import 'package:flutter/material.dart';
-import 'package:flutter/material.dart' as m;
-void f() {
-  Center(
-    child: Text(''),
   );
 }
 ''');

--- a/pkg/analysis_server/test/src/services/correction/assist/flutter_remove_widget_test.dart
+++ b/pkg/analysis_server/test/src/services/correction/assist/flutter_remove_widget_test.dart
@@ -33,6 +33,62 @@ class FlutterRemoveWidgetTest extends AssistProcessorTest {
     );
   }
 
+  Future<void> test_doesNotRemoveWidgetWithoutArgumentWhenNotInList() async {
+    await resolveTestCode('''
+import 'package:flutter/material.dart';
+void f() {
+  /*caret*/Container();
+}
+''');
+    await assertNoAssist();
+  }
+
+  Future<void> test_removeWidgetWithoutArgumentWhenInList() async {
+    await resolveTestCode('''
+import 'package:flutter/material.dart';
+void f() {
+  Column(
+    children: [
+      /*caret*/Container(),
+    ],
+  );
+}
+''');
+    await assertHasAssist('''
+import 'package:flutter/material.dart';
+void f() {
+  Column(
+    children: [
+      
+    ],
+  );
+}
+''');
+  }
+
+  Future<void> test_removeWidgetWithoutArgumentWhenInListSliver() async {
+    await resolveTestCode('''
+import 'package:flutter/material.dart';
+void f() {
+  CustomScrollView(
+    slivers: [
+      /*caret*/SliverToBoxAdapter(),
+    ],
+  );
+}
+''');
+    await assertHasAssist('''
+import 'package:flutter/material.dart';
+void f() {
+  CustomScrollView(
+    slivers: [
+      
+    ],
+  );
+}
+''');
+  }
+
   Future<void> test_does_not_work_for_non_widgets_child() async {
     await resolveTestCode('''
 import 'package:flutter/material.dart';

--- a/pkg/analysis_server/test/src/services/correction/assist/flutter_remove_widget_test.dart
+++ b/pkg/analysis_server/test/src/services/correction/assist/flutter_remove_widget_test.dart
@@ -108,7 +108,7 @@ void f() {
     await assertNoAssist();
   }
 
-    Future<void> test_does_not_work_for_non_widgets_children() async {
+  Future<void> test_does_not_work_for_non_widgets_children() async {
     await resolveTestCode('''
 import 'package:flutter/material.dart';
 
@@ -146,7 +146,7 @@ void f() {
     await assertNoAssist();
   }
 
-    Future<void> test_does_not_work_for_non_widgets_slivers() async {
+  Future<void> test_does_not_work_for_non_widgets_slivers() async {
     await resolveTestCode('''
 import 'package:flutter/material.dart';
 

--- a/pkg/analysis_server/test/src/services/correction/assist/flutter_remove_widget_test.dart
+++ b/pkg/analysis_server/test/src/services/correction/assist/flutter_remove_widget_test.dart
@@ -12,7 +12,6 @@ import 'package:test_reflective_loader/test_reflective_loader.dart';
 import '../fix/fix_processor.dart';
 import 'assist_processor.dart';
 
-
 void main() {
   defineReflectiveSuite(() {
     defineReflectiveTests(FlutterRemoveWidgetTest);
@@ -32,6 +31,82 @@ class FlutterRemoveWidgetTest extends AssistProcessorTest {
     writeTestPackageConfig(
       flutter: true,
     );
+  }
+
+  Future<void> test_does_not_work_for_non_widgets_child() async {
+    await resolveTestCode('''
+import 'package:flutter/material.dart';
+
+class NotAWidget {
+  final int child;
+
+  NotAWidget({required this.child});
+}
+
+void f() {
+  /*caret*/NotAWidget(
+    child: 42,
+  );
+}
+''');
+    await assertNoAssist();
+  }
+
+    Future<void> test_does_not_work_for_non_widgets_children() async {
+    await resolveTestCode('''
+import 'package:flutter/material.dart';
+
+class NotAWidget {
+  final List<int> children;
+
+  NotAWidget({required this.children});
+}
+
+void f() {
+  /*caret*/NotAWidget(
+    children: [42],
+  );
+}
+''');
+    await assertNoAssist();
+  }
+
+  Future<void> test_does_not_work_for_non_widgets_sliver() async {
+    await resolveTestCode('''
+import 'package:flutter/material.dart';
+
+class NotAWidget {
+  final int sliver;
+
+  NotAWidget({required this.sliver});
+}
+
+void f() {
+  /*caret*/NotAWidget(
+    sliver: 42,
+  );
+}
+''');
+    await assertNoAssist();
+  }
+
+    Future<void> test_does_not_work_for_non_widgets_slivers() async {
+    await resolveTestCode('''
+import 'package:flutter/material.dart';
+
+class NotAWidget {
+  final List<int> slivers;
+
+  NotAWidget({required this.slivers});
+}
+
+void f() {
+  /*caret*/NotAWidget(
+    slivers: [42],
+  );
+}
+''');
+    await assertNoAssist();
   }
 
   Future<void> test_builder_blockFunctionBody() async {
@@ -436,7 +511,7 @@ void f() {
 ''');
   }
 
-    Future<void> test_sliver_intoChildren() async {
+  Future<void> test_sliver_intoChildren() async {
     await resolveTestCode('''
 import 'package:flutter/material.dart';
 void f() {

--- a/pkg/analyzer_utilities/lib/test/mock_packages/package_content/flutter/lib/src/widgets/basic.dart
+++ b/pkg/analyzer_utilities/lib/test/mock_packages/package_content/flutter/lib/src/widgets/basic.dart
@@ -189,3 +189,41 @@ class Builder extends StatelessWidget {
 
   const Builder({Key? key, @required this.builder});
 }
+
+class ScrollView extends StatelessWidget {
+  const ScrollView({Key? key});
+}
+
+class CustomScrollView extends ScrollView {
+  CustomScrollView({List<Widget> slivers = const <Widget>[]});
+}
+
+class SliverPadding extends SingleChildRenderObjectWidget {
+  SliverPadding({
+    Key? key,
+    required EdgeInsetsGeometry padding,
+    Widget? sliver,
+  });
+}
+
+class DecoratedSliver extends SingleChildRenderObjectWidget {
+  DecoratedSliver({
+    Key? key,
+    required Decoration decoration,
+    Widget? sliver,
+  });
+}
+
+class SliverToBoxAdapter extends SingleChildRenderObjectWidget {
+  SliverToBoxAdapter({
+    Key? key,
+    Widget? child,
+  });
+}
+
+class SliverList extends StatelessWidget {
+  SliverList.list({
+    Key? key,
+    List<Widget> children,
+  });
+}


### PR DESCRIPTION
Adds option to use `Remove this widget` also on Sliver widgets (with `sliver` and `slivers` argument). 
Fixes #56637

Also adds ability to remove widget without `child`/`children`/`sliver`/`slivers`/`builder` arguments, if the widget is in a list.
Fixes #56390

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
