### PR TITLE
Support handling classDecl fromJson(String s) in JsonDecodable

### DIFF
--- a/pkg/json/lib/json.dart
+++ b/pkg/json/lib/json.dart
@@ -387,6 +387,24 @@ mixin _FromJson on _Shared {
         .firstWhereOrNull((c) => c.identifier.name == 'fromJson')
         ?.identifier;
     if (fromJson != null) {
+      // to support fromJson(String s) or others not Map
+      final fromJsonFirstParam = constructors
+          .firstWhereOrNull((c) => c.identifier.name == 'fromJson')
+          ?.positionalParameters
+          .firstOrNull;
+
+      if (fromJsonFirstParam?.type != null) {
+        return RawCode.fromParts([
+          if (nullCheck != null) nullCheck,
+          fromJson,
+          '(',
+          jsonReference,
+          ' as ',
+          fromJsonFirstParam!.type.code,
+          ')',
+        ]);
+      }
+
       return RawCode.fromParts([
         if (nullCheck != null) nullCheck,
         fromJson,


### PR DESCRIPTION
To support usage like

```dart
@JsonCodable()
class Account {
    AccountType accountType
}

class AccountType {
  static const USER = AccountType("USER");
  static const AGENT = AccountType("AGENT");

  const AccountType(this.value);

  final String value;

  factory AccountType.fromJson(String value) {
    return AccountType(value);
  }

  String toJson() {
    return value;
  }
}
```

