### PR TITLE
Add assist to remove the return type of functions/methods/getters

### DIFF
--- a/pkg/analysis_server/lib/src/services/correction/assist.dart
+++ b/pkg/analysis_server/lib/src/services/correction/assist.dart
@@ -57,6 +57,11 @@ abstract final class DartAssistKind {
     DartAssistKindPriority.DEFAULT,
     'Add return type',
   );
+  static const REMOVE_RETURN_TYPE = AssistKind(
+    'dart.assist.remove.returnType',
+    DartAssistKindPriority.DEFAULT,
+    'Remove return type',
+  );
   static const ADD_TYPE_ANNOTATION = AssistKind(
     'dart.assist.add.typeAnnotation',
     DartAssistKindPriority.DEFAULT,

--- a/pkg/analysis_server/lib/src/services/correction/assist_internal.dart
+++ b/pkg/analysis_server/lib/src/services/correction/assist_internal.dart
@@ -63,6 +63,7 @@ import 'package:analysis_server/src/services/correction/dart/join_if_with_inner.
 import 'package:analysis_server/src/services/correction/dart/join_if_with_outer.dart';
 import 'package:analysis_server/src/services/correction/dart/join_variable_declaration.dart';
 import 'package:analysis_server/src/services/correction/dart/remove_digit_separators.dart';
+import 'package:analysis_server/src/services/correction/dart/remove_return_type.dart';
 import 'package:analysis_server/src/services/correction/dart/remove_type_annotation.dart';
 import 'package:analysis_server/src/services/correction/dart/replace_conditional_with_if_else.dart';
 import 'package:analysis_server/src/services/correction/dart/replace_if_else_with_conditional.dart';
@@ -153,6 +154,7 @@ class AssistProcessor {
     ReplaceConditionalWithIfElse.new,
     ReplaceIfElseWithConditional.new,
     ReplaceWithVar.new,
+    RemoveReturnType.new,
     ShadowField.new,
     SortChildPropertyLast.new,
     SplitAndCondition.new,

--- a/pkg/analysis_server/lib/src/services/correction/dart/remove_return_type.dart
+++ b/pkg/analysis_server/lib/src/services/correction/dart/remove_return_type.dart
@@ -40,9 +40,6 @@ class RemoveReturnType extends ResolvedCorrectionProducer {
       if (executable.returnType == null) {
         return;
       }
-      if (executable.isSetter) {
-        return;
-      }
       insertBeforeEntity = executable.propertyKeyword ?? executable.name;
       returnType = executable.returnType;
     } else {

--- a/pkg/analysis_server/lib/src/services/correction/dart/remove_return_type.dart
+++ b/pkg/analysis_server/lib/src/services/correction/dart/remove_return_type.dart
@@ -1,0 +1,63 @@
+// Copyright (c) 2024, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analysis_server/src/services/correction/assist.dart';
+import 'package:analysis_server_plugin/edit/dart/correction_producer.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/token.dart';
+import 'package:analyzer_plugin/utilities/assist/assist.dart';
+import 'package:analyzer_plugin/utilities/change_builder/change_builder_core.dart';
+import 'package:analyzer_plugin/utilities/range_factory.dart';
+
+class RemoveReturnType extends ResolvedCorrectionProducer {
+  RemoveReturnType({required super.context});
+
+  @override
+  CorrectionApplicability get applicability =>
+      CorrectionApplicability.automatically;
+
+  @override
+  AssistKind get assistKind => DartAssistKind.REMOVE_RETURN_TYPE;
+
+  @override
+  Future<void> compute(ChangeBuilder builder) async {
+    Token? insertBeforeEntity;
+    TypeAnnotation? returnType;
+    var executable = node;
+    if (executable is MethodDeclaration && executable.name == token) {
+      if (executable.returnType == null) {
+        return;
+      }
+      if (executable.isSetter) {
+        return;
+      }
+      insertBeforeEntity = executable.operatorKeyword ??
+          executable.propertyKeyword ??
+          executable.name;
+      returnType = executable.returnType;
+    } else if (executable is FunctionDeclaration && executable.name == token) {
+      if (executable.returnType == null) {
+        return;
+      }
+      if (executable.isSetter) {
+        return;
+      }
+      insertBeforeEntity = executable.propertyKeyword ?? executable.name;
+      returnType = executable.returnType;
+    } else {
+      return;
+    }
+
+    if (returnType == null) {
+      return;
+    }
+
+    await builder.addDartFileEdit(file, (builder) {
+      builder.addDeletion(range.startOffsetEndOffset(
+        returnType!.offset,
+        insertBeforeEntity!.offset,
+      ));
+    });
+  }
+}

--- a/pkg/analysis_server/lib/src/services/correction/error_fix_status.yaml
+++ b/pkg/analysis_server/lib/src/services/correction/error_fix_status.yaml
@@ -1260,9 +1260,8 @@ CompileTimeErrorCode.NON_VOID_RETURN_FOR_OPERATOR:
   notes: |-
     Change the return type to `void`.
 CompileTimeErrorCode.NON_VOID_RETURN_FOR_SETTER:
-  status: needsFix
+  status: hasFix
   notes: |-
-    Remove the return type.
     Change the return type to `void`.
 CompileTimeErrorCode.NOT_A_TYPE:
   status: hasFix

--- a/pkg/analysis_server/lib/src/services/correction/fix.dart
+++ b/pkg/analysis_server/lib/src/services/correction/fix.dart
@@ -1347,6 +1347,16 @@ abstract final class DartFixKind {
     DartFixKindPriority.inFile,
     'Remove invalid returned values in file',
   );
+  static const REMOVE_RETURN_TYPE = FixKind(
+    'dart.fix.remove.returnType',
+    DartFixKindPriority.standard,
+    'Remove invalid return type',
+  );
+  static const REMOVE_RETURN_TYPE_MULTI = FixKind(
+    'dart.fix.remove.returnType.multi',
+    DartFixKindPriority.inFile,
+    'Remove invalid return type in file',
+  );
   static const REMOVE_THIS_EXPRESSION = FixKind(
     'dart.fix.remove.thisExpression',
     DartFixKindPriority.standard,

--- a/pkg/analysis_server/lib/src/services/correction/fix_internal.dart
+++ b/pkg/analysis_server/lib/src/services/correction/fix_internal.dart
@@ -162,6 +162,7 @@ import 'package:analysis_server/src/services/correction/dart/remove_parentheses_
 import 'package:analysis_server/src/services/correction/dart/remove_print.dart';
 import 'package:analysis_server/src/services/correction/dart/remove_question_mark.dart';
 import 'package:analysis_server/src/services/correction/dart/remove_required.dart';
+import 'package:analysis_server/src/services/correction/dart/remove_return_type.dart';
 import 'package:analysis_server/src/services/correction/dart/remove_returned_value.dart';
 import 'package:analysis_server/src/services/correction/dart/remove_this_expression.dart';
 import 'package:analysis_server/src/services/correction/dart/remove_to_list.dart';
@@ -1215,6 +1216,9 @@ final _builtInNonLintProducers = <ErrorCode, List<ProducerGenerator>>{
   CompileTimeErrorCode.NON_TYPE_AS_TYPE_ARGUMENT: [
     CreateClass.new,
     CreateMixin.new,
+  ],
+  CompileTimeErrorCode.NON_VOID_RETURN_FOR_SETTER: [
+    RemoveReturnType.new,
   ],
   CompileTimeErrorCode.NOT_A_TYPE: [
     ChangeTo.classOrMixin,

--- a/pkg/analysis_server/test/src/services/correction/assist/remove_return_type_test.dart
+++ b/pkg/analysis_server/test/src/services/correction/assist/remove_return_type_test.dart
@@ -81,14 +81,12 @@ class A {
     await resolveTestCode('''
 class A {
   dynamic /*caret*/m(p) {
-    return p;
   }
 }
 ''');
     await assertHasAssist('''
 class A {
   m(p) {
-    return p;
   }
 }
 ''');
@@ -98,14 +96,12 @@ class A {
     await resolveTestCode('''
 class A {
   void /*caret*/m() {
-    return;
   }
 }
 ''');
     await assertHasAssist('''
 class A {
   m() {
-    return;
   }
 }
 ''');
@@ -158,7 +154,6 @@ class A {
     await resolveTestCode('''
 class A {
   set /*caret*/foo(int a) {
-    if (a == 0) return;
   }
 }
 ''');
@@ -169,14 +164,12 @@ class A {
     await resolveTestCode('''
 class A {
   void set /*caret*/foo(int a) {
-    if (a == 0) return;
   }
 }
 ''');
     await assertHasAssist('''
 class A {
   set foo(int a) {
-    if (a == 0) return;
   }
 }
 ''');
@@ -225,7 +218,6 @@ get foo => 0;
   Future<void> test_topLevelFunction_setter() async {
     await resolveTestCode('''
 set /*caret*/foo(int a) {
-  if (a == 0) return;
 }
 ''');
     await assertNoAssist();
@@ -234,12 +226,10 @@ set /*caret*/foo(int a) {
   Future<void> test_topLevelFunction_setter_with_return() async {
     await resolveTestCode('''
 void set /*caret*/foo(int a) {
-  if (a == 0) return;
 }
 ''');
     await assertHasAssist('''
-set /*caret*/foo(int a) {
-  if (a == 0) return;
+set foo(int a) {
 }
 ''');
   }

--- a/pkg/analysis_server/test/src/services/correction/assist/remove_return_type_test.dart
+++ b/pkg/analysis_server/test/src/services/correction/assist/remove_return_type_test.dart
@@ -165,18 +165,21 @@ class A {
     await assertNoAssist();
   }
 
-  Future<void> test_method_setter_lint_avoidReturnTypesOnSetters() async {
-    createAnalysisOptionsFile(lints: [
-      LintNames.avoid_return_types_on_setters,
-    ]);
+  Future<void> test_method_setter_with_return() async {
     await resolveTestCode('''
 class A {
-  set /*caret*/foo(int a) {
+  void set /*caret*/foo(int a) {
     if (a == 0) return;
   }
 }
 ''');
-    await assertNoAssist();
+    await assertHasAssist('''
+class A {
+  set foo(int a) {
+    if (a == 0) return;
+  }
+}
+''');
   }
 
   Future<void> test_topLevelFunction_block() async {
@@ -228,16 +231,16 @@ set /*caret*/foo(int a) {
     await assertNoAssist();
   }
 
-  Future<void>
-      test_topLevelFunction_setter_lint_avoidReturnTypesOnSetters() async {
-    createAnalysisOptionsFile(lints: [
-      LintNames.avoid_return_types_on_setters,
-    ]);
+  Future<void> test_topLevelFunction_setter_with_return() async {
     await resolveTestCode('''
+void set /*caret*/foo(int a) {
+  if (a == 0) return;
+}
+''');
+    await assertHasAssist('''
 set /*caret*/foo(int a) {
   if (a == 0) return;
 }
 ''');
-    await assertNoAssist();
   }
 }

--- a/pkg/analysis_server/test/src/services/correction/assist/remove_return_type_test.dart
+++ b/pkg/analysis_server/test/src/services/correction/assist/remove_return_type_test.dart
@@ -1,0 +1,243 @@
+// Copyright (c) 2024, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analysis_server/src/services/correction/assist.dart';
+import 'package:analysis_server/src/services/linter/lint_names.dart';
+import 'package:analyzer_plugin/utilities/assist/assist.dart';
+import 'package:test_reflective_loader/test_reflective_loader.dart';
+
+import 'assist_processor.dart';
+
+void main() {
+  defineReflectiveSuite(() {
+    defineReflectiveTests(RemoveReturnTypeTest);
+  });
+}
+
+@reflectiveTest
+class RemoveReturnTypeTest extends AssistProcessorTest {
+  @override
+  AssistKind get kind => DartAssistKind.REMOVE_RETURN_TYPE;
+
+  Future<void> test_localFunction_block() async {
+    await resolveTestCode('''
+class A {
+  void m() {
+    String /*caret*/f() {
+      return '';
+    }
+  }
+}
+''');
+    await assertHasAssist('''
+class A {
+  void m() {
+    f() {
+      return '';
+    }
+  }
+}
+''');
+  }
+
+  Future<void> test_localFunction_expression() async {
+    await resolveTestCode('''
+class A {
+  void m() {
+    String /*caret*/f() => '';
+  }
+}
+''');
+    await assertHasAssist('''
+class A {
+  void m() {
+    f() => '';
+  }
+}
+''');
+  }
+
+  Future<void> test_method_block_noReturn() async {
+    await resolveTestCode('''
+class A {
+  /*caret*/m() {
+  }
+}
+''');
+    await assertNoAssist();
+  }
+
+  Future<void> test_method_block_noExplicitReturn() async {
+    await resolveTestCode('''
+class A {
+  /*caret*/m() => '';
+}
+''');
+    await assertNoAssist();
+  }
+
+  Future<void> test_method_block_returnDynamic() async {
+    await resolveTestCode('''
+class A {
+  dynamic /*caret*/m(p) {
+    return p;
+  }
+}
+''');
+    await assertHasAssist('''
+class A {
+  m(p) {
+    return p;
+  }
+}
+''');
+  }
+
+  Future<void> test_method_block_returnNoValue() async {
+    await resolveTestCode('''
+class A {
+  void /*caret*/m() {
+    return;
+  }
+}
+''');
+    await assertHasAssist('''
+class A {
+  m() {
+    return;
+  }
+}
+''');
+  }
+
+  Future<void> test_method_block_singleReturn() async {
+    await resolveTestCode('''
+class A {
+  String /*caret*/m() {
+    return '';
+  }
+}
+''');
+    await assertHasAssist('''
+class A {
+  m() {
+    return '';
+  }
+}
+''');
+  }
+
+  Future<void> test_method_expression() async {
+    await resolveTestCode('''
+class A {
+  String /*caret*/m() => '';
+}
+''');
+    await assertHasAssist('''
+class A {
+  m() => '';
+}
+''');
+  }
+
+  Future<void> test_method_getter() async {
+    await resolveTestCode('''
+class A {
+  int get /*caret*/foo => 0;
+}
+''');
+    await assertHasAssist('''
+class A {
+  get foo => 0;
+}
+''');
+  }
+
+  Future<void> test_method_setter() async {
+    await resolveTestCode('''
+class A {
+  set /*caret*/foo(int a) {
+    if (a == 0) return;
+  }
+}
+''');
+    await assertNoAssist();
+  }
+
+  Future<void> test_method_setter_lint_avoidReturnTypesOnSetters() async {
+    createAnalysisOptionsFile(lints: [
+      LintNames.avoid_return_types_on_setters,
+    ]);
+    await resolveTestCode('''
+class A {
+  set /*caret*/foo(int a) {
+    if (a == 0) return;
+  }
+}
+''');
+    await assertNoAssist();
+  }
+
+  Future<void> test_topLevelFunction_block() async {
+    await resolveTestCode('''
+String /*caret*/f() {
+  return '';
+}
+''');
+    await assertHasAssist('''
+f() {
+  return '';
+}
+''');
+  }
+
+  Future<void> test_topLevelFunction_expression() async {
+    await resolveTestCode('''
+String /*caret*/f() => '';
+''');
+    await assertHasAssist('''
+f() => '';
+''');
+  }
+
+  Future<void> test_topLevelFunction_expression_noAssistWithLint() async {
+    createAnalysisOptionsFile(lints: [LintNames.always_declare_return_types]);
+    verifyNoTestUnitErrors = false;
+    await resolveTestCode('''
+/*caret*/f() => '';
+''');
+    await assertNoAssist();
+  }
+
+  Future<void> test_topLevelFunction_getter() async {
+    await resolveTestCode('''
+int get /*caret*/foo => 0;
+''');
+    await assertHasAssist('''
+get foo => 0;
+''');
+  }
+
+  Future<void> test_topLevelFunction_setter() async {
+    await resolveTestCode('''
+set /*caret*/foo(int a) {
+  if (a == 0) return;
+}
+''');
+    await assertNoAssist();
+  }
+
+  Future<void>
+      test_topLevelFunction_setter_lint_avoidReturnTypesOnSetters() async {
+    createAnalysisOptionsFile(lints: [
+      LintNames.avoid_return_types_on_setters,
+    ]);
+    await resolveTestCode('''
+set /*caret*/foo(int a) {
+  if (a == 0) return;
+}
+''');
+    await assertNoAssist();
+  }
+}

--- a/pkg/analysis_server/test/src/services/correction/assist/test_all.dart
+++ b/pkg/analysis_server/test/src/services/correction/assist/test_all.dart
@@ -78,6 +78,7 @@ import 'join_if_with_inner_test.dart' as join_if_with_inner;
 import 'join_if_with_outer_test.dart' as join_if_with_outer;
 import 'join_variable_declaration_test.dart' as join_variable_declaration;
 import 'remove_digit_separators_test.dart' as remove_digit_separators;
+import 'remove_return_type_test.dart' as remove_return_type;
 import 'remove_type_annotation_test.dart' as remove_type_annotation;
 import 'replace_conditional_with_if_else_test.dart'
     as replace_conditional_with_if_else;
@@ -164,6 +165,7 @@ void main() {
     join_if_with_outer.main();
     join_variable_declaration.main();
     remove_digit_separators.main();
+    remove_return_type.main();
     remove_type_annotation.main();
     replace_conditional_with_if_else.main();
     replace_if_else_with_conditional.main();

--- a/pkg/analysis_server/test/src/services/correction/fix/remove_return_type_test.dart
+++ b/pkg/analysis_server/test/src/services/correction/fix/remove_return_type_test.dart
@@ -1,0 +1,51 @@
+// Copyright (c) 2024, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analysis_server/src/services/correction/fix.dart';
+import 'package:analyzer_plugin/utilities/fixes/fixes.dart';
+import 'package:test_reflective_loader/test_reflective_loader.dart';
+
+import 'fix_processor.dart';
+
+void main() {
+  defineReflectiveSuite(() {
+    defineReflectiveTests(RemoveReturnTypeTest);
+  });
+}
+
+@reflectiveTest
+class RemoveReturnTypeTest extends FixProcessorTest {
+  @override
+  FixKind get kind => DartFixKind.REMOVE_RETURN_TYPE;
+
+  Future<void> test_method_setter_with_return() async {
+    await resolveTestCode('''
+class A {
+  dynamic set foo(int a) {
+    if (a == 0) return;
+  }
+}
+''');
+    await assertHasFix('''
+class A {
+  set foo(int a) {
+    if (a == 0) return;
+  }
+}
+''');
+  }
+
+  Future<void> test_topLevelFunction_setter_with_return() async {
+    await resolveTestCode('''
+dynamic set foo(int a) {
+  if (a == 0) return;
+}
+''');
+    await assertHasFix('''
+set foo(int a) {
+  if (a == 0) return;
+}
+''');
+  }
+}

--- a/pkg/analysis_server/test/src/services/correction/fix/remove_return_type_test.dart
+++ b/pkg/analysis_server/test/src/services/correction/fix/remove_return_type_test.dart
@@ -11,7 +11,32 @@ import 'fix_processor.dart';
 void main() {
   defineReflectiveSuite(() {
     defineReflectiveTests(RemoveReturnTypeTest);
+    defineReflectiveTests(RemoveReturnTypeBulkTest);
   });
+}
+
+@reflectiveTest
+class RemoveReturnTypeBulkTest extends BulkFixProcessorTest {
+  Future<void> test_singleFile() async {
+    await resolveTestCode('''
+class A {
+  dynamic set foo(int a) {
+  }
+}
+
+dynamic set foo(int a) {
+}
+''');
+    await assertHasFix('''
+class A {
+  set foo(int a) {
+  }
+}
+
+set foo(int a) {
+}
+''');
+  }
 }
 
 @reflectiveTest

--- a/pkg/analysis_server/test/src/services/correction/fix/remove_return_type_test.dart
+++ b/pkg/analysis_server/test/src/services/correction/fix/remove_return_type_test.dart
@@ -23,14 +23,12 @@ class RemoveReturnTypeTest extends FixProcessorTest {
     await resolveTestCode('''
 class A {
   dynamic set foo(int a) {
-    if (a == 0) return;
   }
 }
 ''');
     await assertHasFix('''
 class A {
   set foo(int a) {
-    if (a == 0) return;
   }
 }
 ''');
@@ -39,12 +37,10 @@ class A {
   Future<void> test_topLevelFunction_setter_with_return() async {
     await resolveTestCode('''
 dynamic set foo(int a) {
-  if (a == 0) return;
 }
 ''');
     await assertHasFix('''
 set foo(int a) {
-  if (a == 0) return;
 }
 ''');
   }

--- a/pkg/analysis_server/test/src/services/correction/fix/test_all.dart
+++ b/pkg/analysis_server/test/src/services/correction/fix/test_all.dart
@@ -205,6 +205,7 @@ import 'remove_parentheses_in_getter_invocation_test.dart'
 import 'remove_print_test.dart' as remove_print;
 import 'remove_question_mark_test.dart' as remove_question_mark;
 import 'remove_required_test.dart' as remove_required;
+import 'remove_return_type_test.dart' as remove_return_type;
 import 'remove_returned_value_test.dart' as remove_returned_value;
 import 'remove_this_expression_test.dart' as remove_this_expression;
 import 'remove_type_annotation_test.dart' as remove_type_annotation;
@@ -474,6 +475,7 @@ void main() {
     remove_question_mark.main();
     remove_required.main();
     remove_returned_value.main();
+    remove_return_type.main();
     remove_this_expression.main();
     remove_type_annotation.main();
     remove_type_arguments.main();


### PR DESCRIPTION
Fixes https://github.com/dart-lang/sdk/issues/39277

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
