### PR TITLE
Modify error message for const (ASSIGNMENT_TO_CONST)

### DIFF
--- a/pkg/analyzer/lib/src/error/codes.g.dart
+++ b/pkg/analyzer/lib/src/error/codes.g.dart
@@ -156,7 +156,7 @@ class CompileTimeErrorCode extends ErrorCode {
   ///  No parameters.
   static const CompileTimeErrorCode ASSIGNMENT_TO_CONST = CompileTimeErrorCode(
     'ASSIGNMENT_TO_CONST',
-    "Constant variables can't be assigned a value.",
+    "Constant variables can't be assigned a value after initialization.",
     correctionMessage:
         "Try removing the assignment, or remove the modifier 'const' from the "
         "variable.",

--- a/pkg/analyzer/messages.yaml
+++ b/pkg/analyzer/messages.yaml
@@ -788,7 +788,7 @@ CompileTimeErrorCode:
       }
       ```
   ASSIGNMENT_TO_CONST:
-    problemMessage: "Constant variables can't be assigned a value."
+    problemMessage: "Constant variables can't be re-assigned a value."
     correctionMessage: "Try removing the assignment, or remove the modifier 'const' from the variable."
     hasPublishedDocs: true
     comment: No parameters.

--- a/pkg/analyzer/messages.yaml
+++ b/pkg/analyzer/messages.yaml
@@ -788,7 +788,7 @@ CompileTimeErrorCode:
       }
       ```
   ASSIGNMENT_TO_CONST:
-    problemMessage: "Constant variables can't be re-assigned a value."
+    problemMessage: "Constant variables can't be assigned a value after initialization."
     correctionMessage: "Try removing the assignment, or remove the modifier 'const' from the variable."
     hasPublishedDocs: true
     comment: No parameters.


### PR DESCRIPTION
Dart says `Constant variables can't be assigned a value.`, when you try to reassign a value to a const variable.

I feel a better error description should have been `Constant variables can't be re-assigned a value.`
This is because we are trying to re-assign it not assign it at this point. The assignment has already been done.

Thanks.

<img width="904" alt="Screenshot 2024-10-24 at 12 27 37" src="https://github.com/user-attachments/assets/596e38fb-0e5c-4b20-9206-b2328469ee9c">
