### PR TITLE
chore: add actual vs. expected in error logging message

### DIFF
--- a/pkg/analysis_server/lib/src/g3/fixes.dart
+++ b/pkg/analysis_server/lib/src/g3/fixes.dart
@@ -192,7 +192,17 @@ class LintFixTesterWithSingleFix {
       fileEdit.edits,
     );
     if (actualFixedContent != fixedContent) {
-      throw StateError('Not expected content:\n$actualFixedContent');
+      throw StateError('''
+Expected the following content:
+```
+$fixedContent
+```
+
+but this was applied instead.
+```
+$actualFixedContent
+```
+''');
     }
   }
 


### PR DESCRIPTION
Having a more verbose error message comparing the actual versus the expected message helps when you're debugging the lint. Especially since the analyzed code is a raw string, so it doesn't have intellisense to point out when you've made a typo.