### PR TITLE
Detect Windows edition via WMI

### DIFF
--- a/runtime/bin/platform_win.cc
+++ b/runtime/bin/platform_win.cc
@@ -7,7 +7,10 @@
 
 #include "bin/platform.h"
 
+#include <Wbemidl.h>
+#include <comdef.h>
 #include <crtdbg.h>
+#include <string>
 
 #include "bin/console.h"
 #include "bin/file.h"
@@ -19,9 +22,6 @@
 #include "bin/thread.h"
 #include "bin/utils.h"
 #include "bin/utils_win.h"
-#include <comdef.h>
-#include <Wbemidl.h>
-#include <string>
 
 #pragma comment(lib, "wbemuuid.lib")
 
@@ -189,7 +189,7 @@ const char* getEdition() {
 
   IWbemLocator* pLoc = nullptr;
   hres = CoCreateInstance(CLSID_WbemLocator, 0, CLSCTX_INPROC_SERVER,
-                          IID_IWbemLocator, (LPVOID*)&pLoc);
+                          IID_IWbemLocator, reinterpret_cast<LPVOID*>(&pLoc));
   if (FAILED(hres)) {
     CoUninitialize();
     return nullptr;
@@ -270,7 +270,8 @@ const char* getEdition() {
 }
 
 const char* Platform::OperatingSystemVersion() {
-  // Get the product name, e.g. "Windows 11 Home" via WMI and fallback to the ProductName on error.
+  // Get the product name, e.g. "Windows 11 Home" via WMI and fallback to the
+  // ProductName on error.
   const char* name = getEdition();
   if (name == nullptr && !GetCurrentVersionString(L"ProductName", &name)) {
     return nullptr;

--- a/runtime/bin/platform_win.cc
+++ b/runtime/bin/platform_win.cc
@@ -245,22 +245,22 @@ static const char* GetEdition() {
 
   VARIANT caption;
   hres = query_results->Get(L"Caption", 0, &caption, 0, 0);
-  wchar_t* edition;
-
-  if (SUCCEEDED(hres)) {
-    // We got an edition, skip Microsoft prefix and convert to UTF8.
-    edition = caption.bstrVal;
-    static const wchar_t kMicrosoftPrefix[] = L"Microsoft ";
-    static constexpr size_t kMicrosoftPrefixLen =
-        ARRAY_SIZE(kMicrosoftPrefix) - 1;
-    if (wcsncmp(edition, kMicrosoftPrefix, kMicrosoftPrefixLen) == 0) {
-      edition += kMicrosoftPrefixLen;
-    }
-
-    VariantClear(&caption);
+  if (FAILED(hres)) {
+    return nullptr;
   }
 
-  return StringUtilsWin::WideToUtf8(edition);
+  // We got an edition, skip Microsoft prefix and convert to UTF8.
+  wchar_t* edition = caption.bstrVal;
+  static const wchar_t kMicrosoftPrefix[] = L"Microsoft ";
+  static constexpr size_t kMicrosoftPrefixLen =
+      ARRAY_SIZE(kMicrosoftPrefix) - 1;
+  if (wcsncmp(edition, kMicrosoftPrefix, kMicrosoftPrefixLen) == 0) {
+    edition += kMicrosoftPrefixLen;
+  }
+
+  char* result = StringUtilsWin::WideToUtf8(edition);
+  VariantClear(&caption);
+  return result;
 }
 
 const char* Platform::OperatingSystemVersion() {

--- a/runtime/bin/platform_win.cc
+++ b/runtime/bin/platform_win.cc
@@ -7,9 +7,9 @@
 
 #include "bin/platform.h"
 
-#include <Wbemidl.h>
 #include <comdef.h>
 #include <crtdbg.h>
+#include <wbemidl.h>
 #include <wrl/client.h>
 #undef interface
 #include <string>


### PR DESCRIPTION
This PR resolves #55351 the Windows edition will now retrieved from the WMI

For now I want to check if I can get the build green.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<!--details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details-->