### PR TITLE
[Json] add datetime support

### DIFF
--- a/pkg/json/CHANGELOG.md
+++ b/pkg/json/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.20.3
+
+- Add support for DateTime
+
 # 0.20.2
 
 - Fix generated code syntax error when defining fields containing the dollar sign `$` by using raw strings.

--- a/pkg/json/lib/json.dart
+++ b/pkg/json/lib/json.dart
@@ -378,6 +378,16 @@ mixin _FromJson on _Shared {
             ' as ',
             type.code,
           ]);
+        case 'DateTime':
+          return RawCode.fromParts([
+            if (nullCheck != null) nullCheck,
+            await builder.resolveIdentifier(_dartCore, 'DateTime'),
+            '.parse(',
+            jsonReference, 
+            ' as ',
+            introspectionData.stringCode,
+            ')'
+            ]);
       }
     }
 
@@ -624,6 +634,8 @@ mixin _ToJson on _Shared {
           ]);
         case 'int' || 'double' || 'num' || 'String' || 'bool':
           return valueReference;
+        case 'DateTime':
+          return RawCode.fromParts([valueReference, '.toIso8601String()']);
       }
     }
 

--- a/pkg/json/pubspec.yaml
+++ b/pkg/json/pubspec.yaml
@@ -5,7 +5,7 @@ description: >
   `toJson` encoding method.
 
 repository: https://github.com/dart-lang/sdk/tree/main/pkg/json
-version: 0.20.2
+version: 0.20.3
 environment:
   sdk: ^3.6.0-edge
 dependencies:

--- a/pkg/json/test/json_codable_test.dart
+++ b/pkg/json/test/json_codable_test.dart
@@ -10,12 +10,14 @@ import 'package:test/test.dart';
 void main() {
   group('Can encode and decode', () {
     test('non-nullable fields', () {
+      print(DateTime.now().toIso8601String());
       var json = {
         'boolField': true,
         'stringField': 'hello',
         'intField': 10,
         'doubleField': 12.5,
         'numField': 11,
+        'dateTimeField': '2024-11-11T03:42:29.108308',
         'listOfSerializableField': [
           {'x': 1},
         ],
@@ -104,6 +106,7 @@ void main() {
       expect(b.nullableListOfSerializableField, null);
       expect(b.nullableMapOfSerializableField, null);
       expect(b.nullableSetOfSerializableField, null);
+      expect(b.nullableDateTimeField, null);
 
       expect(b.toJson(), isEmpty);
     });
@@ -228,6 +231,8 @@ class A {
   final Set<C> setOfSerializableField;
 
   final Map<String, C> mapOfSerializableField;
+
+  final DateTime dateTimeField;
 }
 
 @JsonCodable()
@@ -247,6 +252,8 @@ class B {
   final Set<C>? nullableSetOfSerializableField;
 
   final Map<String, C>? nullableMapOfSerializableField;
+
+  final DateTime? nullableDateTimeField;
 }
 
 @JsonCodable()

--- a/pkg/json/test/json_codable_test.dart
+++ b/pkg/json/test/json_codable_test.dart
@@ -10,7 +10,6 @@ import 'package:test/test.dart';
 void main() {
   group('Can encode and decode', () {
     test('non-nullable fields', () {
-      print(DateTime.now().toIso8601String());
       var json = {
         'boolField': true,
         'stringField': 'hello',

--- a/pkg/json/test/json_codable_test.dart
+++ b/pkg/json/test/json_codable_test.dart
@@ -7,6 +7,8 @@
 import 'package:json/json.dart';
 import 'package:test/test.dart';
 
+//
+
 void main() {
   group('Can encode and decode', () {
     test('non-nullable fields', () {


### PR DESCRIPTION
Solves #56175

`toIso` and `parse` were used for serialization and deserialization.

---

- [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
