### PR TITLE
[vm] Compile binaryen on C++17

### DIFF
--- a/third_party/binaryen/BUILD.gn
+++ b/third_party/binaryen/BUILD.gn
@@ -127,6 +127,7 @@ source_set("binaryen_sources") {
   include_dirs += [ "$target_gen_dir" ]
 
   configs += [
+    "//build/config/compiler:cxx_version_17",
     "//build/config/compiler:enable_exceptions",
     ":binaryen_flags",
   ]
@@ -148,6 +149,7 @@ template("wasm_tool") {
     forward_variables_from(invoker, "*")
 
     configs += [
+      "//build/config/compiler:cxx_version_17",
       "//build/config/compiler:enable_exceptions",
       ":binaryen_flags",
     ]


### PR DESCRIPTION
Binaryen's README mentions that it currently requires C++17: https://github.com/WebAssembly/binaryen#:~:text=A%20C%2B%2B17%20compiler%20is%20required.

Closes #57074.
