### PR TITLE
add modeOctalString to FileStat for compatibility with Posix tools

### DIFF
--- a/sdk/lib/io/file_system_entity.dart
+++ b/sdk/lib/io/file_system_entity.dart
@@ -213,6 +213,17 @@ FileStat: type $type
   }
 }
 
+/// The mode value as a Unix octal string.
+String modeOctalString() {
+    var permissions = mode & 0xFFF;
+    var result = [];
+    result
+      ..add((permissions >> 6) & 0x7)
+      ..add((permissions >> 3) & 0x7)
+      ..add(permissions & 0x7);
+    return result.join();
+}
+
 /// The common superclass of [File], [Directory], and [Link].
 ///
 /// [FileSystemEntity] objects are returned from directory listing


### PR DESCRIPTION

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

add modeOctalString to FileStat for compatibility with Posix tools