### PR TITLE
Use of late final for list, String name added, Changed loop to for in [Clean Code and type Safety]

### DIFF
--- a/benchmarks/ForLoop/dart/ForLoop.dart
+++ b/benchmarks/ForLoop/dart/ForLoop.dart
@@ -5,10 +5,12 @@
 import 'package:benchmark_harness/benchmark_harness.dart';
 
 class IterationBenchmark extends BenchmarkBase {
-  List<int> list = List.generate(1000, (i) => i);
-  var r = 0;
+ 
+  late final List<int> list = List.generate(1000, (i) => i); 
+  int r = 0;
+  
   void fn(int i) => r = 123 * i;
-  IterationBenchmark(name) : super(name);
+  IterationBenchmark(String name) : super(name);
 }
 
 class ForLoop extends IterationBenchmark {
@@ -16,8 +18,8 @@ class ForLoop extends IterationBenchmark {
 
   @override
   void run() {
-    for (var i = 0; i < list.length; i++) {
-      fn(list[i]);
+    for (final i in list) { 
+      fn(i);
     }
   }
 }


### PR DESCRIPTION
Use of `late final `for` List<>`:
This ensures that list is only initialized when accessed for the first time, avoiding unnecessary memory allocation if it isn't used. Marking it final indicates that it will not be reassigned.

Specified Type for` r`: 
Replacing var with int makes the code more explicit and ensures type safety. This can prevent potential bugs if r is used with operations expecting an integer.

Changed Loop to `for-in`:

A for-in loop is more concise and improves readability when iterating through collections. It avoids manual indexing (`i < list.length() `), reducing the chance of off-by-one errors.
