### PR TITLE
Fix missing `success-responses` anchor

### DIFF
--- a/pkg/dtd_impl/dtd_protocol.md
+++ b/pkg/dtd_impl/dtd_protocol.md
@@ -905,7 +905,7 @@ code | message | meaning
 142 | Permission denied | Permission has been denied for the requested action.
 143 | File scheme expected on uri | The uri parameter should be passed as a uri with a file scheme.
 
- Success Responses
+### Success Responses
 
 Methods that respond with `Success` do so with the following RPC.
 


### PR DESCRIPTION
Success Responses section was not set as header, so all anchors reference it wasn't working.
