### PR TITLE
Fix documentation on `Process.run`

### DIFF
--- a/sdk/lib/io/process.dart
+++ b/sdk/lib/io/process.dart
@@ -430,7 +430,7 @@ abstract interface class Process {
   ///
   /// Returns a `Future<ProcessResult>` that completes with the
   /// result of running the process, i.e., exit code, standard out and
-  /// standard in.
+  /// standard error.
   ///
   /// The following code uses `Process.run` to grep for `main` in the
   /// file `test.dart` on Linux.
@@ -456,7 +456,7 @@ abstract interface class Process {
   /// The arguments are the same as for [Process.run].
   ///
   /// Returns a [ProcessResult] with the result of running the process,
-  /// i.e., exit code, standard out and standard in.
+  /// i.e., exit code, standard out and standard error.
   external static ProcessResult runSync(
     String executable,
     List<String> arguments, {


### PR DESCRIPTION
`ProcessResult` returns the output of the standard error stream, not standard in.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
