### PR TITLE
Replace link to non-existent language versioning document with current dev docs on subject

### DIFF
--- a/tools/experimental_features.yaml
+++ b/tools/experimental_features.yaml
@@ -48,8 +48,7 @@
 #
 #    A version less than this version may be specified in a .packages file
 #    or in a library language version override (e.g. // @dart = 2.1)
-#    to disable this feature. For more on library language version override, see
-#    https://github.com/dart-lang/language/blob/master/accepted/future-releases/language-versioning/language-versioning.md
+#    to disable this feature.
 #
 # 3. expired: (optional boolean)
 #    If true, then the experiment can no longer be enabled by specifying the

--- a/tools/experimental_features.yaml
+++ b/tools/experimental_features.yaml
@@ -49,7 +49,7 @@
 #    A version less than this version may be specified in a .packages file
 #    or in a library language version override (e.g. // @dart = 2.1)
 #    to disable this feature. For more on library language version override, see
-#    https://dart.dev/resources/language/evolution#per-library-language-version-selection
+#    https://dart.dev/to/language-version-override
 #
 # 3. expired: (optional boolean)
 #    If true, then the experiment can no longer be enabled by specifying the

--- a/tools/experimental_features.yaml
+++ b/tools/experimental_features.yaml
@@ -48,7 +48,8 @@
 #
 #    A version less than this version may be specified in a .packages file
 #    or in a library language version override (e.g. // @dart = 2.1)
-#    to disable this feature.
+#    to disable this feature. For more on library language version override, see
+#    https://dart.dev/resources/language/evolution#per-library-language-version-selection
 #
 # 3. expired: (optional boolean)
 #    If true, then the experiment can no longer be enabled by specifying the


### PR DESCRIPTION
This PR removes a link to a language versioning document that no longer exists and replaces it with a link to the current language versioning documentation.
