### PR TITLE
Add credentials for bearer token authentication

### DIFF
--- a/sdk/lib/_http/http.dart
+++ b/sdk/lib/_http/http.dart
@@ -2065,6 +2065,13 @@ abstract final class HttpClientBasicCredentials
       _HttpClientBasicCredentials(username, password);
 }
 
+/// Represents credentials for bearer token authentication.
+abstract final class HttpClientBearerCredentials
+    implements HttpClientCredentials {
+  factory HttpClientBearerCredentials(String token) =>
+      _HttpClientBearerCredentials(token);
+}
+
 /// Represents credentials for digest authentication. Digest
 /// authentication is only supported for servers using the MD5
 /// algorithm and quality of protection (qop) of either "none" or

--- a/sdk/lib/_http/http_impl.dart
+++ b/sdk/lib/_http/http_impl.dart
@@ -4046,6 +4046,8 @@ final class _HttpClientBearerCredentials extends _HttpClientCredentials
   String token;
 
   _HttpClientBearerCredentials(this.token) {
+    // verify token according to RFC-6750 section 2.1
+    // https://www.rfc-editor.org/rfc/rfc6750.html#section-2.1
     if (RegExp(r'[^0-9A-Za-z\-._~+/=]').hasMatch(token)) {
       throw ArgumentError.value(token, "token", "Invalid characters");
     }

--- a/sdk/lib/io/io.dart
+++ b/sdk/lib/io/io.dart
@@ -228,6 +228,7 @@ export 'dart:_http'
         HttpClientResponseCompressionState,
         HttpClientCredentials,
         HttpClientBasicCredentials,
+        HttpClientBearerCredentials,
         HttpClientDigestCredentials,
         HttpConnectionInfo,
         RedirectInfo,

--- a/tests/standalone/io/http_auth_bearer_test.dart
+++ b/tests/standalone/io/http_auth_bearer_test.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
@@ -21,7 +21,8 @@ class Server {
       // commas between the arguments
       if (request.uri.path == "/malformedAuthenticate") {
         response.statusCode = HttpStatus.unauthorized;
-        response.headers.set(HttpHeaders.wwwAuthenticateHeader, "Bearer realm=\"realm\" error=\"invalid_token\"");
+        response.headers.set(HttpHeaders.wwwAuthenticateHeader,
+            "Bearer realm=\"realm\" error=\"invalid_token\"");
         response.close();
         return;
       }
@@ -127,7 +128,7 @@ void testBearerWithAuthenticateCallback() async {
   final server = await Server().start();
   final client = HttpClient();
 
-  final callbacks = <String>{}
+  final callbacks = <String>{};
 
   client.authenticate = (url, scheme, realm) async {
     Expect.equals("Bearer", scheme);

--- a/tests/standalone/io/http_auth_bearer_test.dart
+++ b/tests/standalone/io/http_auth_bearer_test.dart
@@ -63,12 +63,11 @@ class Server {
 void testValidBearerTokens() {
   HttpClientBearerCredentials("977ce44bc56dc5000c9d2c329e682547");
   HttpClientBearerCredentials("dGVzdHRlc3R0ZXN0dGVzdA==");
-  HttpClientBearerCredentials("dGVzdHRl_3R0ZXN-dGVzdA==");
-  HttpClientBearerCredentials("dGVzdHRl/3R0ZXN+dGVzdA==");
+  HttpClientBearerCredentials("mF_9.B5f-4.1JqM");
 }
 
 void testInvalidBearerTokens() {
-  Expect.throws(() => HttpClientBearerCredentials("§(&%)"));
+  Expect.throws(() => HttpClientBearerCredentials("#(&%)"));
   Expect.throws(() => HttpClientBearerCredentials("áéîöü"));
   Expect.throws(() => HttpClientBearerCredentials("あいうえお"));
   Expect.throws(() => HttpClientBearerCredentials("     "));

--- a/tests/standalone/io/http_auth_bearer_test.dart
+++ b/tests/standalone/io/http_auth_bearer_test.dart
@@ -10,7 +10,6 @@ import "package:expect/async_helper.dart";
 import "package:expect/expect.dart";
 
 class Server {
-
   late HttpServer server;
 
   Future<Server> start() async {
@@ -18,7 +17,8 @@ class Server {
     server.listen((request) {
       final response = request.response;
 
-      // WARNING: this authenticate header is malformed because of missing commas between the arguments
+      // WARNING: this authenticate header is malformed because of missing
+      // commas between the arguments
       if (request.uri.path == "/malformedAuthenticate") {
         response.statusCode = HttpStatus.unauthorized;
         response.headers.set(HttpHeaders.wwwAuthenticateHeader, "Bearer realm=\"realm\" error=\"invalid_token\"");
@@ -26,22 +26,27 @@ class Server {
         return;
       }
 
-      // NOTE: see https://www.rfc-editor.org/rfc/rfc6750.html#section-3 regarding the authenticate response header field
+      // NOTE: see RFC6750 section 3 regarding the authenticate response header
+      // field
+      // https://www.rfc-editor.org/rfc/rfc6750.html#section-3
       if (request.headers[HttpHeaders.authorizationHeader] != null) {
         final token = base64.encode(utf8.encode(request.uri.path.substring(1)));
-        Expect.equals(1, request.headers[HttpHeaders.authorizationHeader]!.length);
-        final authorizationHeaderParts = request.headers[HttpHeaders.authorizationHeader]![0].split(" ");
+        Expect.equals(
+            1, request.headers[HttpHeaders.authorizationHeader]!.length);
+        final authorizationHeaderParts =
+            request.headers[HttpHeaders.authorizationHeader]![0].split(" ");
         Expect.equals("Bearer", authorizationHeaderParts[0]);
         if (token != authorizationHeaderParts[1]) {
           response.statusCode = HttpStatus.unauthorized;
-          response.headers.set(HttpHeaders.wwwAuthenticateHeader, "Bearer realm=\"realm\", error=\"invalid_token\"");
+          response.headers.set(HttpHeaders.wwwAuthenticateHeader,
+              "Bearer realm=\"realm\", error=\"invalid_token\"");
         }
       } else {
         response.statusCode = HttpStatus.unauthorized;
-        response.headers.set(HttpHeaders.wwwAuthenticateHeader, "Bearer realm=\"realm\"");
+        response.headers
+            .set(HttpHeaders.wwwAuthenticateHeader, "Bearer realm=\"realm\"");
       }
       response.close();
-
     });
     return this;
   }
@@ -53,7 +58,6 @@ class Server {
   String get host => server.address.address;
 
   int get port => server.port;
-
 }
 
 void testValidBearerTokens() {
@@ -104,7 +108,10 @@ void testBearerWithCredentials() async {
 
   for (int i = 0; i < 5; i++) {
     final token = base64.encode(utf8.encode("test$i"));
-    client.addCredentials(Uri.parse("http://${server.host}:${server.port}/test$i"), "realm", HttpClientBearerCredentials(token));
+    client.addCredentials(
+        Uri.parse("http://${server.host}:${server.port}/test$i"),
+        "realm",
+        HttpClientBearerCredentials(token));
   }
 
   await Future.wait([
@@ -150,7 +157,8 @@ void testBearerWithAuthenticateCallback() async {
 void testMalformedAuthenticateHeaderWithoutCredentials() async {
   final server = await Server().start();
   final client = HttpClient();
-  final uri = Uri.parse("http://${server.host}:${server.port}/malformedAuthenticate");
+  final uri =
+      Uri.parse("http://${server.host}:${server.port}/malformedAuthenticate");
 
   // the request should resolve normally if no authentication is configured
   final request = await client.getUrl(uri);
@@ -163,7 +171,8 @@ void testMalformedAuthenticateHeaderWithoutCredentials() async {
 void testMalformedAuthenticateHeaderWithCredentials() async {
   final server = await Server().start();
   final client = HttpClient();
-  final uri = Uri.parse("http://${server.host}:${server.port}/malformedAuthenticate");
+  final uri =
+      Uri.parse("http://${server.host}:${server.port}/malformedAuthenticate");
   final token = base64.encode(utf8.encode("test"));
 
   // the request should throw an exception if credentials have been added
@@ -180,7 +189,8 @@ void testMalformedAuthenticateHeaderWithCredentials() async {
 void testMalformedAuthenticateHeaderWithAuthenticateCallback() async {
   final server = await Server().start();
   final client = HttpClient();
-  final uri = Uri.parse("http://${server.host}:${server.port}/malformedAuthenticate");
+  final uri =
+      Uri.parse("http://${server.host}:${server.port}/malformedAuthenticate");
 
   // the request should throw an exception if the authenticate handler is set
   client.authenticate = (url, scheme, realm) async => false;
@@ -198,11 +208,13 @@ void testLocalServerBearer() async {
 
   client.authenticate = (url, scheme, realm) async {
     final token = base64.encode(utf8.encode("test"));
-    client.addCredentials(Uri.parse("http://127.0.0.1/bearer"), "test", HttpClientBearerCredentials(token));
+    client.addCredentials(Uri.parse("http://127.0.0.1/bearer"), "test",
+        HttpClientBearerCredentials(token));
     return true;
   };
 
-  final request = await client.getUrl(Uri.parse("http://127.0.0.1/bearer/test"));
+  final request =
+      await client.getUrl(Uri.parse("http://127.0.0.1/bearer/test"));
   final response = await request.close();
   Expect.equals(HttpStatus.ok, response.statusCode);
   await response.drain();

--- a/tests/standalone/io/http_auth_bearer_test.dart
+++ b/tests/standalone/io/http_auth_bearer_test.dart
@@ -1,0 +1,221 @@
+// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import "package:expect/async_helper.dart";
+import "package:expect/expect.dart";
+
+class Server {
+
+  late HttpServer server;
+
+  Future<Server> start() async {
+    server = await HttpServer.bind(InternetAddress.loopbackIPv4.address, 0);
+    server.listen((request) {
+      final response = request.response;
+
+      if (request.uri.path == "/malformedAuthenticate") {
+        // see https://www.rfc-editor.org/rfc/rfc6750.html#section-3
+        if (request.headers[HttpHeaders.authorizationHeader] != null) {
+          response.statusCode = HttpStatus.unauthorized;
+          response.headers.set(HttpHeaders.wwwAuthenticateHeader, "Bearer realm=\"realm\", error=\"invalid_token\"");
+        } else {
+          response.statusCode = HttpStatus.unauthorized;
+          response.headers.set(HttpHeaders.wwwAuthenticateHeader, "Bearer realm=\"realm\"");
+        }
+        response.close();
+        return;
+      }
+
+      if (request.headers[HttpHeaders.authorizationHeader] != null) {
+        final token = request.uri.path.substring(1);
+        Expect.equals(1, request.headers[HttpHeaders.authorizationHeader]!.length);
+        final authorizationHeaderParts = request.headers[HttpHeaders.authorizationHeader]![0].split(" ");
+        Expect.equals("Bearer", authorizationHeaderParts[0]);
+        if (token != authorizationHeaderParts[1]) {
+          response.statusCode = HttpStatus.unauthorized;
+          response.headers.set(HttpHeaders.wwwAuthenticateHeader, "Bearer realm=\"realm\", error=\"invalid_token\"");
+        }
+      } else {
+        response.statusCode = HttpStatus.unauthorized;
+        response.headers.set(HttpHeaders.wwwAuthenticateHeader, "Bearer realm=\"realm\"");
+      }
+      response.close();
+
+    });
+    return this;
+  }
+
+  void shutdown() {
+    server.close();
+  }
+
+  String get host => server.address.address;
+
+  int get port => server.port;
+
+}
+
+void testInvalidBearerCredentials() {
+  Expect.throws(() => HttpClientBearerCredentials("§(&$)"));
+  Expect.throws(() => HttpClientBearerCredentials("áéîöü"));
+  Expect.throws(() => HttpClientBearerCredentials("あいうえお"));
+  Expect.throws(() => HttpClientBearerCredentials("     "));
+}
+
+void testBearerNoCredentials() async {
+  final server = await Server().start();
+  final client = HttpClient();
+
+  Future makeRequest(Uri url) async {
+    final request = await client.getUrl(url);
+    final response = await request.close();
+    Expect.equals(HttpStatus.unauthorized, response.statusCode);
+    return response.drain();
+  }
+
+  await Future.wait([
+    for (int i = 0; i < 5; i++) ...[
+      makeRequest(Uri.parse("http://${server.host}:${server.port}/test$i")),
+    ],
+  ]);
+
+  server.shutdown();
+  client.close();
+}
+
+void testBearerCredentials() async {
+  final server = await Server().start();
+  final client = HttpClient();
+
+  Future makeRequest(Uri url) async {
+    final request = await client.getUrl(url);
+    final response = await request.close();
+    Expect.equals(HttpStatus.ok, response.statusCode);
+    return response.drain();
+  }
+
+  for (int i = 0; i < 5; i++) {
+    final token = base64.encode(utf8.encode("test$i"));
+    client.addCredentials(Uri.parse("http://${server.host}:${server.port}/test$i"), "realm", HttpClientBearerCredentials(token));
+  }
+
+  await Future.wait([
+    for (int i = 0; i < 5; i++) ...[
+      makeRequest(Uri.parse("http://${server.host}:${server.port}/test$i")),
+    ],
+  ]);
+
+  server.shutdown();
+  client.close();
+}
+
+void testBearerAuthenticateCallback() async {
+  final server = await Server().start();
+  final client = HttpClient();
+
+  client.authenticate = (url, scheme, realm) async {
+    Expect.equals("Bearer", scheme);
+    Expect.equals("realm", realm);
+    String token = url.path.substring(1);
+    await Future.delayed(const Duration(milliseconds: 10));
+    client.addCredentials(url, realm!, new HttpClientBearerCredentials(token));
+    return true;
+  };
+
+  Future makeRequest(Uri url) async {
+    final request = await client.getUrl(url);
+    final response = await request.close();
+    Expect.equals(HttpStatus.ok, response.statusCode);
+    return response.drain();
+  }
+
+  await Future.wait([
+    for (int i = 0; i < 5; i++) ...[
+      makeRequest(Uri.parse("http://${server.host}:${server.port}/test$i")),
+    ],
+  ]);
+
+  server.shutdown();
+  client.close();
+}
+
+void testMalformedAuthenticateHeaderNoAuthHandler() async {
+  final server = await Server().start();
+  final client = HttpClient();
+  final uri = Uri.parse("http://${server.host}:${server.port}/malformedAuthenticate");
+
+  // Request should resolve normally if no authentication is configured
+  final request = await client.getUrl(uri);
+  final response = await request.close();
+
+  server.shutdown();
+  client.close();
+}
+
+void testMalformedAuthenticateHeaderWithAuthHandler() async {
+  final server = await Server().start();
+  final client = HttpClient();
+  final uri = Uri.parse("http://${server.host}:${server.port}/malformedAuthenticate");
+
+  // Request should throw an exception if the authenticate handler is set
+  client.authenticate = (url, scheme, realm) async => false;
+  await asyncExpectThrows<HttpException>(() async {
+    final request = await client.getUrl(uri);
+    final response = await request.close();
+  });
+
+  server.shutdown();
+  client.close();
+}
+
+void testMalformedAuthenticateHeaderWithCredentials() async {
+  final server = await Server().start();
+  final client = HttpClient();
+  final uri = Uri.parse("http://${server.host}:${server.port}/malformedAuthenticate");
+  final token = base64.encode(utf8.encode("token"));
+
+  // Request should throw an exception if credentials have been added
+  client.addCredentials(uri, "realm", HttpClientBearerCredentials(token));
+  await asyncExpectThrows<HttpException>(() async {
+    final request = await client.getUrl(uri);
+    final response = await request.close();
+  });
+
+  server.shutdown();
+  client.close();
+}
+
+void testLocalServerBearer() async {
+  final client = HttpClient();
+
+  client.authenticate = (url, scheme, realm) async {
+    final token = base64.encode(utf8.encode("test"));
+    client.addCredentials(Uri.parse("http://127.0.0.1/bearer"), "test", HttpClientBearerCredentials(token));
+    return true;
+  };
+
+  final request = await client.getUrl(Uri.parse("http://127.0.0.1/bearer/test"));
+  final response = await request.close();
+  Expect.equals(HttpStatus.ok, response.statusCode);
+  await response.drain();
+
+  client.close();
+}
+
+main() {
+  testInvalidBearerCredentials();
+  testBearerNoCredentials();
+  testBearerCredentials();
+  testBearerAuthenticateCallback();
+  testMalformedAuthenticateHeaderNoAuthHandler();
+  testMalformedAuthenticateHeaderWithAuthHandler();
+  testMalformedAuthenticateHeaderWithCredentials();
+  // These tests are not normally run. They can be used for locally
+  // testing with another web server (e.g. Apache).
+  //testLocalServerBearer();
+}

--- a/tests/standalone/io/http_auth_test.dart
+++ b/tests/standalone/io/http_auth_test.dart
@@ -235,7 +235,7 @@ void testMalformedAuthenticateHeaderWithAuthHandler() {
     // Request should throw an exception if the authenticate handler is set
     client.authenticate = (url, scheme, realm) async => false;
     await asyncExpectThrows<HttpException>(
-      client.getUrl(uri).then((request) => request.close()));
+        client.getUrl(uri).then((request) => request.close()));
 
     server.shutdown();
     client.close();
@@ -252,7 +252,7 @@ void testMalformedAuthenticateHeaderWithCredentials() {
     client.addCredentials(
         uri, 'realm', HttpClientBasicCredentials('dart', 'password'));
     await asyncExpectThrows<HttpException>(
-      client.getUrl(uri).then((request) => request.close()));
+        client.getUrl(uri).then((request) => request.close()));
 
     server.shutdown();
     client.close();
@@ -284,11 +284,13 @@ void testLocalServerBearer() async {
 
   client.authenticate = (url, scheme, realm) async {
     final token = base64.encode(utf8.encode("test"));
-    client.addCredentials(Uri.parse("http://127.0.0.1/bearer"), "test", HttpClientBearerCredentials(token));
+    client.addCredentials(Uri.parse("http://127.0.0.1/bearer"), "test",
+        HttpClientBearerCredentials(token));
     return true;
   };
 
-  final request = await client.getUrl(Uri.parse("http://127.0.0.1/bearer/test"));
+  final request =
+      await client.getUrl(Uri.parse("http://127.0.0.1/bearer/test"));
   final response = await request.close();
   Expect.equals(HttpStatus.ok, response.statusCode);
   await response.drain();

--- a/tests/standalone/io/http_auth_test.dart
+++ b/tests/standalone/io/http_auth_test.dart
@@ -279,6 +279,23 @@ void testLocalServerBasic() {
   });
 }
 
+void testLocalServerBearer() async {
+  final client = HttpClient();
+
+  client.authenticate = (url, scheme, realm) async {
+    final token = base64.encode(utf8.encode("test"));
+    client.addCredentials(Uri.parse("http://127.0.0.1/bearer"), "test", HttpClientBearerCredentials(token));
+    return true;
+  };
+
+  final request = await client.getUrl(Uri.parse("http://127.0.0.1/bearer/test"));
+  final response = await request.close();
+  Expect.equals(HttpStatus.ok, response.statusCode);
+  await response.drain();
+
+  client.close();
+}
+
 void testLocalServerDigest() {
   HttpClient client = new HttpClient();
 
@@ -311,5 +328,6 @@ main() {
   // These teste are not normally run. They can be used for locally
   // testing with another web server (e.g. Apache).
   //testLocalServerBasic();
+  //testLocalServerBearer();
   //testLocalServerDigest();
 }


### PR DESCRIPTION
I recently needed _bearer_ authentication for a proxy, however, the current HTTP implementation only offered credentials for _basic_ and _digest_ authentication.

It applies to the [Authorization](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization) and [Proxy-Authorization](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Proxy-Authorization) headers.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication#authentication_schemes

**Implementation Details**

The token provided to the HttpClientBearerCredentials is checked for valid characters according to [RFC 6750](https://datatracker.ietf.org/doc/html/rfc6750).

It is possible to provide any string as token by applying base64Encode in conjunction with utf8.encode first. I was considering making a factory method that automates this, but then I felt it would just complicate things, as bearer tokens are most often randomly generated anyway.

**Tests**

Sorry, but I didn't provide any tests here.