### PR TITLE
Update issue-triage.yml

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -19,7 +19,14 @@ permissions:
 jobs:
   triage_issues:
     runs-on: ubuntu-latest
+
+    # Don't fail the workflow if there's an error below (for example, if we
+    # have problems modifying an issue's labels) as that would send a failure
+    # email to the user who created the issue.
+    continue-on-error: true
+
     if: ${{ github.repository_owner == 'dart-lang' }}
+
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:


### PR DESCRIPTION
Don't fail the issue triage workflow on any service issues (portions of github down, trouble reaching gemini, ...); that would send a failure email to the issue's author.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
