### PR TITLE
Fixed 'order' node typo in split_constraints documentation

### DIFF
--- a/pkg/compiler/doc/split_constraints.md
+++ b/pkg/compiler/doc/split_constraints.md
@@ -61,7 +61,7 @@ For example:
 **foo.dart:**
 
 ```dart
-import ‘...’ deferred as baz;
+import '...' deferred as baz;
 ```
 
 **constraints.yaml:**
@@ -93,8 +93,8 @@ For example:
 **foo.dart:**
 
 ```dart
-import ‘...’ deferred as step1;
-import ‘...’ deferred as step2;
+import '...' deferred as step1;
+import '...' deferred as step2;
 
 do() {
   step1.loadLibrary().then((_) { step2.loadLibrary().then(...) } );
@@ -147,8 +147,8 @@ For example:
 **foo.dart**:
 
 ```dart
-import ‘...’ deferred as step1a;
-import ‘...’ deferred as step1b;
+import '...' deferred as step1a;
+import '...' deferred as step1b;
 
 do() {
   if (...) {
@@ -189,9 +189,9 @@ For example:
 
 **foo.dart:**
 
-```dart`
-import ‘...’ deferred as step1a;
-import ‘...’ deferred as step1b;
+```dart
+import '...' deferred as step1a;
+import '...' deferred as step1b;
 
 do() {
   if (...) {
@@ -224,8 +224,8 @@ For example:
 
 **foo.dart:**
 ```dart
-import ‘...’ deferred as step1a;
-import ‘...’ deferred as step1b;
+import '...' deferred as step1a;
+import '...' deferred as step1b;
 
 do() {
   ...
@@ -251,10 +251,10 @@ combinations of deferred imports.
 **foo.dart**:
 
 ```dart
-import ‘...’ as deferred S1;
-import ‘...’ as deferred S2a;
-import ‘...’ as deferred S2b;
-import ‘...’ as deferred S3;
+import '...' as deferred S1;
+import '...' as deferred S2a;
+import '...' as deferred S2b;
+import '...' as deferred S3;
 
 main() {
   S1.loadLibrary().then((_) {

--- a/pkg/compiler/doc/split_constraints.md
+++ b/pkg/compiler/doc/split_constraints.md
@@ -105,7 +105,7 @@ do() {
 
 ```yaml
   ...
-   - type: order
+   - type: relative_order
      predecessor: step1
      successor: step2
   ...
@@ -289,10 +289,10 @@ main() {
   - type: $COMBINER_TYPE
     name: s2
     nodes: [ s2a, s2b ]
-  - type: order
+  - type: relative_order
     predecessor: s1
     successor: s2
-  - type: order
+  - type: relative_order
     predecessor: s2
     successor: s3
 ```


### PR DESCRIPTION
Fixed a typo within the `split_constraints` documentation that was recently added

Running the examples resulted in failed compilation, but based on the [parser source code](https://github.com/dart-lang/sdk/blob/a78235cf01aa46cecfcf7a77848dfa458ac6a674/pkg/compiler/lib/src/deferred_load/program_split_constraints/parser.dart#L54C15-L54C29) it seems as though `order` should actually be `relative_order`

With these changes, the split_constraints concept works as expected

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
