### PR TITLE
Corrected Building.md and added additional content.

### DIFF
--- a/docs/Building-Dart-SDK-for-ARM-or-RISC-V.md
+++ b/docs/Building-Dart-SDK-for-ARM-or-RISC-V.md
@@ -66,13 +66,13 @@ $ ./tools/linux_dist_support/create_debian_packages.py -a {ia32, x64, arm, arm64
 
 # Testing
 
-In addition to cross-compiling the Dart SDK, test items can also be cross-compiled. Even without the corresponding hardware, you can quickly verify if the source code modifications you made are correct. Below is a simple method for development on the riscv64 platform for your reference.  
+In addition to cross-compiling the Dart SDK, test items can also be cross-compiled. Even without the corresponding hardware, you can quickly verify if the source code modifications you made are correct. Below is a simple method for development on the riscv64 platform for your reference.
 
-Cross-compile the test items on x86_64 Linux to riscv64 and perform correctness check:  
-1. Follow the steps above to cross-compile the riscv64 sdk.  
-2. Cross-compile the test items by running: `./tools/build.py --mode release --arch riscv64 most run_ffi_unit_tests`.  
-3. Install the necessary QEMU dependencies: `sudo apt install qemu-user qemu-user-static qemu-system`.  
-4. Run the test items, e.g., `tests/lib`:  
+Cross-compile the test items on x86_64 Linux to riscv64 and perform correctness check:
+1. Follow the steps above to cross-compile the riscv64 sdk.
+2. Cross-compile the test items by running: `./tools/build.py --mode release --arch riscv64 most run_ffi_unit_tests`.
+3. Install the necessary QEMU dependencies: `sudo apt install qemu-user qemu-user-static qemu-system`.
+4. Run the test items, e.g., `tests/lib`:
 
 ```bash
 export QEMU_LD_PREFIX=/usr/riscv64-linux-gnu

--- a/docs/Building-Dart-SDK-for-ARM-or-RISC-V.md
+++ b/docs/Building-Dart-SDK-for-ARM-or-RISC-V.md
@@ -63,3 +63,26 @@ You can create Debian packages targeting ARM or RISC-V as follows:
 $ ./tools/linux_dist_support/create_tarball.py
 $ ./tools/linux_dist_support/create_debian_packages.py -a {ia32, x64, arm, arm64, riscv64}
 ```
+
+# Testing
+
+In addition to cross-compiling the Dart SDK, test items can also be cross-compiled. Even without the corresponding hardware, you can quickly verify if the source code modifications you made are correct. Below is a simple method for development on the riscv64 platform for your reference.  
+
+Cross-compile the test items on x86_64 Linux to riscv64 and perform correctness check:  
+1. Follow the steps above to cross-compile the riscv64 sdk.  
+2. Cross-compile the test items by running: `./tools/build.py --mode release --arch riscv64 most run_ffi_unit_tests`.  
+3. Install the necessary QEMU dependencies: `sudo apt install qemu-user qemu-user-static qemu-system`.  
+4. Run the test items, e.g., `tests/lib`:  
+
+```bash
+export QEMU_LD_PREFIX=/usr/riscv64-linux-gnu
+
+./tools/test.py \
+  --runtime vm \
+  --progress color \
+  --arch riscv64 \
+  --mode release \
+  --time \
+  --tasks 8 \
+  lib
+```

--- a/docs/Building.md
+++ b/docs/Building.md
@@ -189,7 +189,6 @@ Dart analyzer tests example:
   --progress color \
   --arch x64 \
   --mode release \
-  --report \
   --time \
   --tasks 6 \
   language
@@ -198,13 +197,10 @@ Dart analyzer tests example:
 VM tests example:
 ```bash
 ./tools/test.py \
-  --compiler none \
   --runtime vm \
   --progress color \
   --arch x64 \
   --mode release \
-  --checked \
-  --report \
   --time \
   --tasks 6 \
   language
@@ -218,12 +214,12 @@ Dart2JS example:
   --progress color \
   --arch x64 \
   --mode release \
-  --checked \
-  --report \
   --time \
   --tasks 6 \
   language
 ```
+
+In the above examples: `--progress` is used to style the progress bar in terminal; `--time` is used to print time information; `--tasks` is used to set the number of parallel tasks; you can use `. /tools/test.py --help` for more details.  
 
 ## Troubleshooting and tips for browser tests
 To debug a browser test failure, you must start a local http server to serve the test.  This is made easy with a helper script in dart/tools/testing.  The error report from test.py gives the command line to start the server in a message that reads:

--- a/docs/Building.md
+++ b/docs/Building.md
@@ -219,7 +219,7 @@ Dart2JS example:
   language
 ```
 
-In the above examples: `--progress` is used to style the progress bar in terminal; `--time` is used to print time information; `--tasks` is used to set the number of parallel tasks; you can use `. /tools/test.py --help` for more details.  
+In the above examples: `--progress` is used to style the progress bar in terminal; `--time` is used to print time information; `--tasks` is used to set the number of parallel tasks; you can use `. /tools/test.py --help` for more details.
 
 ## Troubleshooting and tips for browser tests
 To debug a browser test failure, you must start a local http server to serve the test.  This is made easy with a helper script in dart/tools/testing.  The error report from test.py gives the command line to start the server in a message that reads:


### PR DESCRIPTION
The following error or outdated content have been fixed:
1. `none` is not an allowed value for option `--compiler`.  
2. `--report` and `--checked` are no longer in use.  

```
moluo@ubuntu:~/work/dart-sdk/sdk$ ./tools/test.py \
  --compiler none \
  --runtime vm \
  --progress color \
  --arch x64 \
  --mode release \
  --checked \
  --report \
  --time \
  --tasks 6 \
  language
"none" is not an allowed value for option "--compiler".
moluo@ubuntu:~/work/dart-sdk/sdk$ ./tools/test.py --help | grep report
moluo@ubuntu:~/work/dart-sdk/sdk$ ./tools/test.py --help | grep check
moluo@ubuntu:~/work/dart-sdk/sdk$ 
```

Added some explanations for the parameters of `test.py` in `Building.md`. Additionally, a small section on cross-compilation test-items has been added to `Building-Dart-SDK-for-ARM-or-RISC-V.md`.  

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.  

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use dart format.