### PR TITLE
Revised Building.md and improved Building-Dart-SDK-for-ARM-or-RISC-V.md

### DIFF
--- a/docs/Building-Dart-SDK-for-ARM-or-RISC-V.md
+++ b/docs/Building-Dart-SDK-for-ARM-or-RISC-V.md
@@ -86,5 +86,9 @@ export QEMU_LD_PREFIX=/usr/riscv64-linux-gnu
   --tasks 8 \
   lib
 ```
+
 If you have configured QEMU for RISCV64, you can merge steps 3 and 4 into a single command (omitting some print parameters):
-> ./tools/test.py -r vm -m release -a riscv64 --use-qemu lib
+
+```bash
+./tools/test.py -r vm -m release -a riscv64 --use-qemu lib
+```

--- a/docs/Building-Dart-SDK-for-ARM-or-RISC-V.md
+++ b/docs/Building-Dart-SDK-for-ARM-or-RISC-V.md
@@ -66,10 +66,10 @@ $ ./tools/linux_dist_support/create_debian_packages.py -a {ia32, x64, arm, arm64
 
 # Testing
 
-In addition to cross-compiling the Dart SDK, test items can also be cross-compiled. Even without the corresponding hardware, you can quickly verify if the source code modifications you made are correct. Below is a simple method for development on the riscv64 platform for your reference.
+In addition to cross-compiling the Dart SDK, test items can also be cross-compiled. Even without the corresponding hardware, you can quickly verify if the source code modifications you made are correct. Below is a simple method for development on the RISCV64 platform for your reference.
 
-Cross-compile the test items on x86_64 Linux to riscv64 and perform correctness check:
-1. Follow the steps above to cross-compile the riscv64 sdk.
+Cross-compile the test items on X64 Linux to RISCV64 and perform correctness check:
+1. Follow the steps above to cross-compile the RISCV64 sdk.
 2. Cross-compile the test items by running: `./tools/build.py --mode release --arch riscv64 most run_ffi_unit_tests`.
 3. Install the necessary QEMU dependencies: `sudo apt install qemu-user qemu-user-static qemu-system`.
 4. Run the test items, e.g., `tests/lib`:
@@ -86,3 +86,5 @@ export QEMU_LD_PREFIX=/usr/riscv64-linux-gnu
   --tasks 8 \
   lib
 ```
+If you have configured QEMU for RISCV64, you can merge steps 3 and 4 into a single command (omitting some print parameters):
+> ./tools/test.py -r vm -m release -a riscv64 --use-qemu lib

--- a/docs/Building.md
+++ b/docs/Building.md
@@ -219,7 +219,7 @@ Dart2JS example:
   language
 ```
 
-In the above examples: `--progress` is used to style the progress bar in terminal; `--time` is used to print time information; `--tasks` is used to set the number of parallel tasks; you can use `. /tools/test.py --help` for more details.
+In the above examples: `--progress` is used to style the progress bar in terminal; `--time` is used to print time information; `--tasks` is used to set the number of parallel tasks; you can use `./tools/test.py --help` for more details.
 
 ## Troubleshooting and tips for browser tests
 To debug a browser test failure, you must start a local http server to serve the test.  This is made easy with a helper script in dart/tools/testing.  The error report from test.py gives the command line to start the server in a message that reads:


### PR DESCRIPTION
1. Removed an extra space (Building.md).
2. Updated the system name to be consistent with the previous text.
> For example, change `x86_64` to `X64`.
3. Improved the content based on suggestions from the previous [review](https://dart-review.googlesource.com/c/sdk/+/410446?tab=comments).
> Before I could test `--use-qemu` parameter, the [PR](https://github.com/dart-lang/sdk/pull/60167) had already been merged and closed. Therefore, I created a new PR to implement the requested changes based on the review comments.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
