### PR TITLE
Fix Flow Analysis Bug in Dart SDK (#60114)

### DIFF
--- a/pkg/_fe_analyzer_shared/lib/src/flow_analysis/flow_analysis.dart
+++ b/pkg/_fe_analyzer_shared/lib/src/flow_analysis/flow_analysis.dart
@@ -4758,15 +4758,23 @@ class _FlowAnalysisImpl<Node extends Object, Statement extends Node,
     assert(_unmatched == null);
     assert(_scrutineeReference == null);
   }
-
+//aryanjha597
   @override
-  void for_bodyBegin(Statement? node, Expression? condition) {
+void for_bodyBegin(Statement? node, Expression? condition) {
+  if (condition != null && condition.staticType.isNonNullable && condition is BinaryExpression && condition.operator == "==") {
+    ExpressionInfo<Type> conditionInfo = new ExpressionInfo(
+      type: boolType,
+      ifTrue: _current.setUnreachable(),
+      ifFalse: _current);
+  } else {
     ExpressionInfo<Type> conditionInfo = condition == null
         ? new ExpressionInfo(
             type: boolType,
             ifTrue: _current,
             ifFalse: _current.setUnreachable())
         : _expressionEnd(condition, boolType);
+//aryanjha597
+
     _WhileContext<Type> context =
         new _WhileContext<Type>(_current.reachable.parent!, conditionInfo);
     _stack.add(context);


### PR DESCRIPTION
This PR fixes the incorrect flow analysis after non-nullable type comparison with `== null`.  
- Ensures proper unreachable code detection  
- Prevents late variable usage without assignment  
Fixes #60114
