### PR TITLE
Fix bug of base64 caused by incorrect number of '=' at the end

### DIFF
--- a/runtime/vm/base64.cc
+++ b/runtime/vm/base64.cc
@@ -38,7 +38,7 @@ static const char PAD = '=';
 
 uint8_t* DecodeBase64(const char* str, intptr_t* out_decoded_len) {
   intptr_t len = strlen(str);
-  if (len == 0 || (len % 4 != 0)) {
+  if (len == 0 || (len % 4 != 0) || str[len - 3] == PAD) {
     return nullptr;
   }
 


### PR DESCRIPTION
Test the `DecodeBase64` function in `runtime/vm/base64.cc`, with the decoding result being `Hello World`: 
```cpp
int main()
{
  intptr_t decoded_len;
  uint8_t *decoded_bytes = DecodeBase64("SGVsbG8gV29ybGQ=", &decoded_len);
  cout << "Length: " << decoded_len << "\nString: " << decoded_bytes << endl;
  // Length: 11
  // String: Hello World

  free(decoded_bytes);
  return 0;
}
```

Append `====` to the end of the string. This function did not return `nullptr`, and the printed result is incorrect: 
```cpp
  intptr_t decoded_len;
  // Add "====" at the end
  uint8_t *decoded_bytes = DecodeBase64("SGVsbG8gV29ybGQ=====", &decoded_len);
  cout << "Length: " << decoded_len << "\nString: " << decoded_bytes << endl;
  // Length: 10
  // String: Hello Worl
```

---

The first solution is to check whether there are more than two `=` characters at the end: 
```cpp
if ( str[len - 3] == PAD ) {
    return nullptr;
}
```
The second solution is to recalculate the string length, ignoring the extra `=`. This allows the correct output to be printed:
```cpp
// intptr_t decoded_en = ((len * 6) >> 3) - pad_length;
// uint8_t* bytes = static_cast<uint8_t*>(malloc(decoded_en));
len -= pad_length & -4;
intptr_t decoded_en = ((len * 6) >> 3) - (pad_length & 3);
uint8_t* bytes = static_cast<uint8_t*>(malloc(decoded_en));
```

In `Python`, when the number of `=` exceeds the valid limit in Base64 decoding, the output remains correct:
```python3
import base64
 
def decode(str):
    return base64.b64decode(str.encode()).decode("utf-8") 

print(decode("SGVsbG8gV29ybGQ====="))
# Hello World
```

I have submitted the first solution with relatively minor changes. If necessary, I will revise it to the second solution.


---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
