### PR TITLE
Remove TODO block from analyze_snapshot_api_impl.cc

### DIFF
--- a/runtime/vm/analyze_snapshot_api_impl.cc
+++ b/runtime/vm/analyze_snapshot_api_impl.cc
@@ -344,18 +344,6 @@ void SnapshotAnalyzer::DumpMetadata() {
   js_.CloseObject();
 }
 
-// TODO(#47924): Add processing of the entires in the dispatch table.
-// Below is an example skeleton
-// void DumpDispatchTable(dart::Thread* thread) {
-//   auto dispatch = thread->isolate_group()->dispatch_table();
-//   auto length = dispatch->length();
-// We must unbias the array entries so we don't crash on null access.
-//   auto entries = dispatch->ArrayOrigin() - DispatchTable::kOriginElement;
-//   for (intptr_t i = 0; i < length; i++) {
-//     OS::Print("0x%lx at %ld\n", entries[i], i);
-//   }
-// }
-
 void SnapshotAnalyzer::DumpSnapshotInformation(char** buffer,
                                                intptr_t* buffer_length) {
   thread_ = Thread::Current();


### PR DESCRIPTION
I've not seen blocks like this in other parts of the Dart code I presume we can remove this and just track the work via an issue instead.
