### PR TITLE
Add `-Wnewline-eof` to match Flutter

### DIFF
--- a/runtime/BUILD.gn
+++ b/runtime/BUILD.gn
@@ -243,7 +243,7 @@ config("dart_config") {
     }
   } else {
     cflags = [
-      "-Wnewline-eof", # Flutter compiles with this (to match Fuchsia).
+      "-Wnewline-eof",  # Flutter compiles with this (to match Fuchsia).
       "-Wno-unused-parameter",
       "-Wno-unused-private-field",
       "-Wnon-virtual-dtor",

--- a/runtime/BUILD.gn
+++ b/runtime/BUILD.gn
@@ -243,6 +243,7 @@ config("dart_config") {
     }
   } else {
     cflags = [
+      "-Wnewline-eof", # Flutter compiles with this (to match Fuchsia).
       "-Wno-unused-parameter",
       "-Wno-unused-private-field",
       "-Wnon-virtual-dtor",


### PR DESCRIPTION
I'm not sure this is the right place to add this flag, but I couldn't find a better one.

Fixes https://github.com/dart-lang/sdk/issues/60403.