### PR TITLE
[vm] postpone creation of handles for show/hide lists

### DIFF
--- a/runtime/vm/kernel_loader.cc
+++ b/runtime/vm/kernel_loader.cc
@@ -1174,13 +1174,13 @@ void KernelLoader::LoadLibraryImportsAndExports(Library* library,
       }
     }
 
-    if (show_list.Length() > 0) {
+    if (!show_list.IsNull() && show_list.Length() > 0) {
       show_names = Array::MakeFixedLength(show_list);
     } else {
       show_names = Array::null();
     }
 
-    if (hide_list.Length() > 0) {
+    if (!hide_list.IsNull() && hide_list.Length() > 0) {
       hide_names = Array::MakeFixedLength(hide_list);
     } else {
       hide_names = Array::null();

--- a/runtime/vm/kernel_loader.cc
+++ b/runtime/vm/kernel_loader.cc
@@ -1124,8 +1124,6 @@ void KernelLoader::FinishTopLevelClassLoading(
 
 void KernelLoader::LoadLibraryImportsAndExports(Library* library,
                                                 const Class& toplevel_class) {
-  GrowableObjectArray& show_list = GrowableObjectArray::Handle(Z);
-  GrowableObjectArray& hide_list = GrowableObjectArray::Handle(Z);
   Array& show_names = Array::Handle(Z);
   Array& hide_names = Array::Handle(Z);
   Namespace& ns = Namespace::Handle(Z);
@@ -1153,8 +1151,8 @@ void KernelLoader::LoadLibraryImportsAndExports(Library* library,
     }
 
     // Prepare show and hide lists.
-    show_list = GrowableObjectArray::New(Heap::kOld);
-    hide_list = GrowableObjectArray::New(Heap::kOld);
+    GrowableObjectArray& show_list = GrowableObjectArray::Handle(Z);
+    GrowableObjectArray& hide_list = GrowableObjectArray::Handle(Z);
     const intptr_t combinator_count = helper_.ReadListLength();
     for (intptr_t c = 0; c < combinator_count; ++c) {
       uint8_t flags = helper_.ReadFlags();
@@ -1163,8 +1161,14 @@ void KernelLoader::LoadLibraryImportsAndExports(Library* library,
         String& show_hide_name =
             H.DartSymbolObfuscate(helper_.ReadStringReference());
         if ((flags & LibraryDependencyHelper::Show) != 0) {
+          if (show_list.IsNull()) {
+            show_list = GrowableObjectArray::New(Heap::kOld);
+          }
           show_list.Add(show_hide_name, Heap::kOld);
         } else {
+          if (hide_list.IsNull()) {
+            hide_list = GrowableObjectArray::New(Heap::kOld);
+          }
           hide_list.Add(show_hide_name, Heap::kOld);
         }
       }


### PR DESCRIPTION
fixes: #60470

for some reason it fixes deallocation of empty show/hide lists

before (ends with out of memory):
<img width="1489" alt="image" src="https://github.com/user-attachments/assets/430bf42b-53c4-437e-8f25-f535749d9bd0" />


after:
<img width="1450" alt="image" src="https://github.com/user-attachments/assets/07e5ab5c-7c87-4ae4-8eca-a4ce3f198236" />

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
