### PR TITLE
fix(proxy): correct userinfo validation logic

### DIFF
--- a/sdk/lib/_http/http_impl.dart
+++ b/sdk/lib/_http/http_impl.dart
@@ -3746,7 +3746,7 @@ class _ProxyConfiguration {
             String userinfo = proxy.substring(0, at).trim();
             proxy = proxy.substring(at + 1).trim();
             int colon = userinfo.indexOf(":");
-            if (colon == -1 || colon == 0 || colon == proxy.length - 1) {
+            if (colon == -1 || colon == 0 || colon == userinfo.length - 1) {
               throw HttpException("Invalid proxy configuration $configuration");
             }
             username = userinfo.substring(0, colon).trim();


### PR DESCRIPTION
fix(proxy): correct userinfo validation logic

- Fix incorrect length check by using userinfo.length instead of proxy.length
- When `export http_proxy=http://aaaaaaaaaaaaa:1234567891234567@localhost:8088`, this error was triggered and incorrect validation logic was found
---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
