### PR TITLE
remove 'the' typo

### DIFF
--- a/sdk/lib/async/stream.dart
+++ b/sdk/lib/async/stream.dart
@@ -1611,7 +1611,7 @@ abstract mixin class Stream<T> {
   /// If [equals] throws, the data event is replaced by an error event
   /// containing the thrown error. The behavior is equivalent to the
   /// original stream emitting the error event, and it doesn't change
-  /// the what the most recently emitted data event is.
+  /// what the most recently emitted data event is.
   ///
   /// The returned stream is a broadcast stream if this stream is.
   /// If a broadcast stream is listened to more than once, each subscription


### PR DESCRIPTION
removes a small typo in stream.dart where 'the' is mentioned twice

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
