### PR TITLE
[infra] Remove ia32 from alpine sysroot script

### DIFF
--- a/build/linux/alpine_sysroot_scripts/README.md
+++ b/build/linux/alpine_sysroot_scripts/README.md
@@ -2,6 +2,8 @@
 
 This directory contains a script for community contributed alpine linux sysroot support.
 
+To build the dart-sdk on alpine linux, please checkout the community maintained project https://github.com/dart-musl/dart.
+
 On Alpine Linux, run the script directly:
 
 ``` sh
@@ -12,8 +14,8 @@ By default, the script installs sysroots for the following architectures:
 
 - `aarch64`
 - `armv7`
+- `riscv64`
 - `x86_64`
-- `x86`
 
 To install sysroots for specific architectures, you can run:
 

--- a/build/linux/alpine_sysroot_scripts/install-sysroot.sh
+++ b/build/linux/alpine_sysroot_scripts/install-sysroot.sh
@@ -21,7 +21,7 @@ SCRIPT="$(readlink -f -- "$0")"
 WORKDIR="$(dirname -- "$(dirname -- "$(dirname -- "$(dirname -- "$SCRIPT")")")")"
 
 if test $# -eq 0; then
-  set aarch64 armv7 x86_64 x86 riscv64
+  set aarch64 armv7 riscv64 x86_64
 fi
 
 echo "$@" | xargs -n 1 -- sh -xc 'apk add --root "$1/buildtools/sysroot/alpine-linux-$2" --repositories-file /etc/apk/repositories --allow-untrusted --arch "$2" --no-cache --no-scripts --initdb -- build-base linux-headers' -- "$WORKDIR"


### PR DESCRIPTION
Dart 3.8.0 is released and now for the community maintained dart-musl project we no longer build any ia32 variants, therefore updating the sysroot script to remove the ia32 system installation.