### PR TITLE
[vm/ffi] Migrate static_checks tests from legacy multitest format

### DIFF
--- a/tests/ffi/static_checks/regress_44986_test.dart
+++ b/tests/ffi/static_checks/regress_44986_test.dart
@@ -10,8 +10,10 @@ import "dart:ffi";
 final class S2 extends Struct {
   external Pointer<Int8> notEmpty;
 
-  external Null s; //# 01: compile-time error
-}
+  external Null s;
+//              ^
+// [analyzer] COMPILE_TIME_ERROR.INVALID_FIELD_TYPE_IN_STRUCT
+// [cfe] Field 's' contains type 'Null', which is not a valid type in a struct.
 
 void main() {
   S2? s2;

--- a/tests/ffi/static_checks/regress_44986_test.dart
+++ b/tests/ffi/static_checks/regress_44986_test.dart
@@ -14,6 +14,7 @@ final class S2 extends Struct {
 //              ^
 // [analyzer] COMPILE_TIME_ERROR.INVALID_FIELD_TYPE_IN_STRUCT
 // [cfe] Field 's' contains type 'Null', which is not a valid type in a struct.
+}
 
 void main() {
   S2? s2;

--- a/tests/ffi/static_checks/regress_46085_test.dart
+++ b/tests/ffi/static_checks/regress_46085_test.dart
@@ -10,11 +10,17 @@ import "dart:ffi";
 final class MyStruct extends Struct {
   external Pointer<Int8> notEmpty;
 
-  @Array.multi([]) //# 01: compile-time error
-  external Array<Int16> a0; //# 01: compile-time error
+  @Array.multi([])
+  external Array<Int16> a0;
+//                      ^^
+// [analyzer] COMPILE_TIME_ERROR.EMPTY_ARRAY_ANNOTATION
+// [cfe] Array dimensions cannot be empty.
 
-  @Array.multi([1]) //# 02: compile-time error
-  external Array<Array<Int16>> a1; //# 02: compile-time error
+  @Array.multi([1])
+  external Array<Array<Int16>> a1;
+//               ^^^^^^^^^^^^^^^
+// [analyzer] COMPILE_TIME_ERROR.NESTED_ARRAY_UNSUPPORTED
+// [cfe] Nested arrays are not supported.
 }
 
 void main() {

--- a/tests/ffi/static_checks/regress_47673_2_test.dart
+++ b/tests/ffi/static_checks/regress_47673_2_test.dart
@@ -14,8 +14,11 @@ final class A extends Struct {
   external Array<Int8> a;
 
   // This should not crash the FFI transform.
-  @Array.multi([16]) //# 1: compile-time error
-  external Array<Unknown> b; //# 1: compile-time error
+  @Array.multi([16])
+  external Array<Unknown> b;
+//               ^^^^^^^
+// [analyzer] COMPILE_TIME_ERROR.UNDEFINED_CLASS
+// [cfe] Type 'Unknown' not found.
 }
 
 main() {}

--- a/tests/ffi/static_checks/regress_51041_test.dart
+++ b/tests/ffi/static_checks/regress_51041_test.dart
@@ -12,7 +12,10 @@ import 'package:ffi/ffi.dart';
 final class Foo extends Struct {
   @Int32()
   external int // Force `?` to newline.
-      ? //# 1: compile-time error
+      ?
+//    ^
+// [analyzer] COMPILE_TIME_ERROR.NULLABLE_TYPE_IN_STRUCT
+// [cfe] Struct fields cannot be nullable.
       x;
 }
 

--- a/tests/ffi/static_checks/vmspecific_function_callbacks_negative_test.dart
+++ b/tests/ffi/static_checks/vmspecific_function_callbacks_negative_test.dart
@@ -13,11 +13,26 @@ final testLibrary = DynamicLibrary.process();
 
 // Correct type of exceptionalReturn argument to Pointer.fromFunction.
 double testExceptionalReturn() {
-  Pointer.fromFunction<Double Function()>(returnVoid, null); //# 59: compile-time error
-  Pointer.fromFunction<Void Function()>(returnVoid, 0); //# 60: compile-time error
-  Pointer.fromFunction<Double Function()>(testExceptionalReturn, "abc"); //# 61: compile-time error
-  Pointer.fromFunction<Double Function()>(testExceptionalReturn, 0); //# 62: compile-time error
-  Pointer.fromFunction<Double Function()>(testExceptionalReturn); //# 63: compile-time error
+  Pointer.fromFunction<Double Function()>(returnVoid, null);
+//                                         ^^^^^^^^^^
+// [analyzer] COMPILE_TIME_ERROR.ARGUMENT_TYPE_NOT_ASSIGNABLE
+// [cfe] The argument type 'void Function()' can't be assigned to the parameter type 'double Function()'.
+  Pointer.fromFunction<Void Function()>(returnVoid, 0);
+//                                                   ^
+// [analyzer] COMPILE_TIME_ERROR.ARGUMENT_TYPE_NOT_ASSIGNABLE
+// [cfe] The argument type 'int' can't be assigned to the parameter type 'void'.
+  Pointer.fromFunction<Double Function()>(testExceptionalReturn, "abc");
+//                                                               ^^^^^
+// [analyzer] COMPILE_TIME_ERROR.ARGUMENT_TYPE_NOT_ASSIGNABLE
+// [cfe] The argument type 'String' can't be assigned to the parameter type 'double'.
+  Pointer.fromFunction<Double Function()>(testExceptionalReturn, 0);
+//                                                               ^
+// [analyzer] COMPILE_TIME_ERROR.ARGUMENT_TYPE_NOT_ASSIGNABLE
+// [cfe] The argument type 'int' can't be assigned to the parameter type 'double'.
+  Pointer.fromFunction<Double Function()>(testExceptionalReturn);
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+// [analyzer] COMPILE_TIME_ERROR.MISSING_REQUIRED_ARGUMENT
+// [cfe] Required argument 'exceptionalReturn' must be provided.
 
   return 0.0; // not used
 }

--- a/tests/ffi/static_checks/vmspecific_static_checks_varargs_test.dart
+++ b/tests/ffi/static_checks/vmspecific_static_checks_varargs_test.dart
@@ -15,12 +15,18 @@ void main() {
   final ffiTestFunctions = DynamicLibrary.process();
 
   // Error: a named record field.
-  print(ffiTestFunctions.lookupFunction< //# 1: compile-time error
-    Void Function(Pointer<Utf8>, VarArgs<(Int32, Int32, {Int32 foo})>), //# 1: compile-time error
-    void Function(Pointer<Utf8>, int, int)>('PassObjectToC')); //# 1: compile-time error
+  print(ffiTestFunctions.lookupFunction<
+    Void Function(Pointer<Utf8>, VarArgs<(Int32, Int32, {Int32 foo})>),
+//                                                      ^^^^^^^^^^^
+// [analyzer] COMPILE_TIME_ERROR.VARARGS_CANNOT_HAVE_NAMED_FIELDS
+// [cfe] VarArgs cannot have named arguments.
+    void Function(Pointer<Utf8>, int, int)>('PassObjectToC'));
 
   // Error: VarArgs not last.
-  print(ffiTestFunctions.lookupFunction< //# 2: compile-time error
-    Void Function(Pointer<Utf8>, VarArgs<(Int32, Int32)>, Int32), //# 2: compile-time error
-    void Function(Pointer<Utf8>, int, int, int)>('PassObjectToC')); //# 2: compile-time error
+  print(ffiTestFunctions.lookupFunction<
+    Void Function(Pointer<Utf8>, VarArgs<(Int32, Int32)>, Int32),
+//                               ^^^^^^^^^^^^^^^^^^^^^^^
+// [analyzer] COMPILE_TIME_ERROR.VARARGS_MUST_BE_LAST_PARAMETER
+// [cfe] VarArgs must be the last parameter.
+    void Function(Pointer<Utf8>, int, int, int)>('PassObjectToC'));
 }

--- a/tests/ffi/static_checks/vmspecific_variance_function_checks_test.dart
+++ b/tests/ffi/static_checks/vmspecific_variance_function_checks_test.dart
@@ -28,24 +28,33 @@ final DynamicLibrary ffiTestFunctions =
 
 final p1 =
     ffiTestFunctions.lookup<NativeFunction<Int64PointerParamOp>>(paramOpName);
-final nonInvariantBinding1 = //# 1:  compile-time error
-    p1.asFunction<NaTyPointerParamOpDart>(); //# 1:  continued
+final nonInvariantBinding1 =
+    p1.asFunction<NaTyPointerParamOpDart>();
+//    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+// [analyzer] COMPILE_TIME_ERROR.MUST_BE_A_SUBTYPE
+// [cfe] Expected type 'void Function(Pointer<Int64>)' to be 'void Function(Pointer<NativeType>)'.
 
 final p2 =
     ffiTestFunctions.lookup<NativeFunction<NaTyPointerReturnOp>>(returnOpName);
-final nonInvariantBinding2 = //# 2:  compile-time error
-    p2.asFunction<Int64PointerReturnOp>(); //# 2:  continued
+final nonInvariantBinding2 =
+    p2.asFunction<Int64PointerReturnOp>();
+//    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+// [analyzer] COMPILE_TIME_ERROR.MUST_BE_A_SUBTYPE
+// [cfe] Expected type 'Pointer<Int64> Function()' to be 'Pointer<NativeType> Function()'.
 
 final p3 = Pointer<
     NativeFunction<
         Pointer<NativeFunction<Pointer<NativeType> Function()>>
             Function()>>.fromAddress(0x1234);
-final f3 = p3 //# 10:  compile-time error
-    .asFunction< //# 10:  continued
-        Pointer< //# 10:  continued
-                NativeFunction< //# 10:  continued
-                    Pointer<Int8> Function()>> //# 10:  continued
-            Function()>(); //# 10:  continued
+final f3 = p3
+    .asFunction<
+        Pointer<
+                NativeFunction<
+                    Pointer<Int8> Function()>>
+            Function()>();
+//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+// [analyzer] COMPILE_TIME_ERROR.MUST_BE_A_SUBTYPE
+// [cfe] Expected type 'Pointer<NativeFunction<Pointer<Int8> Function()>> Function()' to be 'Pointer<NativeFunction<Pointer<NativeType> Function()>> Function()'.
 
 // ===========================================================
 // Test check on callbacks from native to Dart (fromFunction).
@@ -59,11 +68,17 @@ Pointer<NativeType> naTyPointerReturnOp() {
   return Pointer.fromAddress(0x13370000);
 }
 
-final implicitDowncast1 = //# 3:  compile-time error
-    Pointer.fromFunction<NaTyPointerParamOp>(//# 3:  continued
-        naTyPointerParamOp); //# 3:  continued
-final implicitDowncast2 = //# 4:  compile-time error
-    Pointer.fromFunction<Int64PointerReturnOp>(//# 4:  continued
-        naTyPointerReturnOp); //# 4:  continued
+final implicitDowncast1 =
+    Pointer.fromFunction<NaTyPointerParamOp>(
+        naTyPointerParamOp);
+//      ^^^^^^^^^^^^^^^^^^
+// [analyzer] COMPILE_TIME_ERROR.ARGUMENT_TYPE_NOT_ASSIGNABLE
+// [cfe] The argument type 'void Function(Pointer<Int64>)' can't be assigned to the parameter type 'void Function(Pointer<NativeType>)'.
+final implicitDowncast2 =
+    Pointer.fromFunction<Int64PointerReturnOp>(
+        naTyPointerReturnOp);
+//      ^^^^^^^^^^^^^^^^^^^
+// [analyzer] COMPILE_TIME_ERROR.ARGUMENT_TYPE_NOT_ASSIGNABLE
+// [cfe] The argument type 'Pointer<NativeType> Function()' can't be assigned to the parameter type 'Pointer<Int64> Function()'.
 
 void main() {}


### PR DESCRIPTION
## Summary
Migrate FFI static_checks test files from legacy multitest format to modern static error test format using `[cfe]` and `[analyzer]` expectations.

## Changes Made
- **regress_44986_test.dart**: Convert Null field type error
- **regress_46085_test.dart**: Convert Array annotation errors  
- **regress_47673_2_test.dart**: Convert unknown type error
- **regress_51041_test.dart**: Convert nullable struct field error
- **vmspecific_function_callbacks_negative_test.dart**: Convert callback type errors
- **vmspecific_static_checks_varargs_test.dart**: Convert VarArgs errors
- **vmspecific_variance_function_checks_test.dart**: Convert type variance errors

## Test Plan
Converted multitest markers like `//# 01: compile-time error` to modern static error expectations with precise error locations and messages for both analyzer and CFE.

Fixes https://github.com/dart-lang/sdk/issues/60212