### PR TITLE
[vm/runtime] Call `tzset()` before `localtime_r()`.

### DIFF
--- a/runtime/vm/os_android.cc
+++ b/runtime/vm/os_android.cc
@@ -102,6 +102,9 @@ intptr_t OS::ProcessId() {
 static bool LocalTime(int64_t seconds_since_epoch, tm* tm_result) {
   time_t seconds = static_cast<time_t>(seconds_since_epoch);
   if (seconds != seconds_since_epoch) return false;
+  // No need to call tzset() before localtime_r() because bionic
+  // will handle timezone changes for us (starting from Android O).
+  // See https://android.googlesource.com/platform/bionic/+/ea87716696bf635706b6f3fa56b8a145add83aff
   struct tm* error_code = localtime_r(&seconds, tm_result);
   return error_code != nullptr;
 }

--- a/runtime/vm/os_linux.cc
+++ b/runtime/vm/os_linux.cc
@@ -418,6 +418,7 @@ intptr_t OS::ProcessId() {
 static bool LocalTime(int64_t seconds_since_epoch, tm* tm_result) {
   time_t seconds = static_cast<time_t>(seconds_since_epoch);
   if (seconds != seconds_since_epoch) return false;
+  tzset();  // Not guaranteed by POSIX to be called by `localtime_r`.
   struct tm* error_code = localtime_r(&seconds, tm_result);
   return error_code != nullptr;
 }


### PR DESCRIPTION
Relevant info in #60191 (And duplicate #61303)

POSIX doesn't guarantee that the timezone is set correctly before calling `localtime_r()`, so we need to call `tzset()` first to ensure that the timezone information is up-to-date.

As the glibc manual states:
> According to POSIX.1-2001, `localtime()` is required to behave as though `tzset(3)` was called, while `localtime_r()` does not
> have this requirement.  For portable code, `tzset(3)` should be called before `localtime_r()`.

- Thanks for your contribution! Please replace this text with a description of what this PR is changing or adding and why, list any relevant issues, and review the contribution guidelines below.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
