### PR TITLE
Migrate third-party-deps-scan to new workflow location

### DIFF
--- a/.github/workflows/third-party-deps-scan.yml
+++ b/.github/workflows/third-party-deps-scan.yml
@@ -13,11 +13,11 @@ permissions: read-all
 
 jobs:
   extract-deps:
-    name: Extract Dependencies
+    name: Extract dependencies
     runs-on: 'ubuntu-24.04'
     if: ${{ (github.repository == 'dart-lang/sdk' && github.event_name == 'push') || github.event.label.name == 'vulnerability scan' }}
     permissions:
-      # Needed to upload the SARIF results to code-scanning dashboard.
+      # Needed to upload the SARIF results to the code-scanning dashboard.
       security-events: write
       contents: read
     steps:
@@ -25,16 +25,16 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
-      - name: "setup python"
+      - name: "Set up python"
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
-          python-version: '3.13.3' # install the python version needed
-      - name: "extract deps, find commit hash, pass to osv-scanner"
+          python-version: '3.13.3' # Install the python version needed.
+      - name: "Extract deps, find commit hash, pass to osv-scanner"
         run: python .github/extract_deps.py --output osv-lockfile-${{github.sha}}.json
-      - name: "upload osv-scanner deps"
+      - name: "Upload osv-scanner deps"
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
-          # use github.ref in name to avoid duplicated artifacts
+          # Use github.ref in name to avoid duplicated artifacts.
           name: osv-lockfile-${{github.sha}}
           path: osv-lockfile-${{github.sha}}.json
           retention-days: 2
@@ -42,15 +42,15 @@ jobs:
     name: Vulnerability scanning
     needs:
       extract-deps
-    uses: "google/osv-scanner/.github/workflows/osv-scanner-reusable.yml@main"
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@main"
     with:
-      # Download the artifact uploaded in extract-deps step
+      # Download the artifact uploaded in the extract-deps step.
       download-artifact: osv-lockfile-${{github.sha}}
       scan-args: |-
         --lockfile=osv-scanner:osv-lockfile-${{github.sha}}.json
       fail-on-vuln: false
-    # makes sure the osv-formatted vulns are uploaded
+    # Makes sure the osv-formatted vulns are uploaded.
     permissions:
-      # Needed to upload the SARIF results to code-scanning dashboard.
+      # Needed to upload the SARIF results to the code-scanning dashboard.
       security-events: write
       contents: read


### PR DESCRIPTION
The used action has moved repositories to https://github.com/google/osv-scanner-action/blob/main/.github/workflows/osv-scanner-reusable.yml, while the old workflow location has been updated to just fail.

This CL changes the SDK's workflow to use the new workflow location and makes some other minor cleanup throughout the workflow definition.