### PR TITLE
[vm] Update `dartvm` usage text

### DIFF
--- a/runtime/bin/common_options.h
+++ b/runtime/bin/common_options.h
@@ -20,7 +20,7 @@ static void _PrintVersion() {
 // clang-format off
 static void _PrintUsage() {
   Syslog::Print(
-      "Usage: dart [<vm-flags>] <dart-script-file> [<script-arguments>]\n"
+      "Usage: dartvm [<vm-flags>] <dart-script-file> [<script-arguments>]\n"
       "\n"
       "Executes the Dart script <dart-script-file> with "
       "the given list of <script-arguments>.\n"


### PR DESCRIPTION
As of https://github.com/dart-lang/sdk/commit/ab44b20ab84cc0e9d71fb209c5beca1be7076a4f, the previous `dart` executable has been split into separate `dart` and `dartvm` executables.

This PR fixes a cosmetic issue where in the usage text of `dartvm` executable it still refers itself as `dart`.