### PR TITLE
DAS: Fix `noop_primitive_operations` message

### DIFF
--- a/pkg/analysis_server/lib/src/services/correction/fix.dart
+++ b/pkg/analysis_server/lib/src/services/correction/fix.dart
@@ -1442,7 +1442,7 @@ abstract final class DartFixKind {
   static const removeInvocationMulti = FixKind(
     'dart.fix.remove.invocation.multi',
     DartFixKindPriority.inFile,
-    'Remove unnecessary invocations of {0} in file',
+    'Remove unnecessary invocations everywhere in file',
   );
   static const removeInitializer = FixKind(
     'dart.fix.remove.initializer',


### PR DESCRIPTION
 When applying fixes to multiple locations in a file, the quick fix menu was displaying the literal text "{0}" instead of a proper message.

 Changed the message to "Remove unnecessary invocations everywhere in file" since there's no single method name that makes sense when fixing multiple different invocations across a file.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
