### PR TITLE
fix(stdio): Correct error message for Line Terminator

### DIFF
--- a/sdk/lib/io/stdio.dart
+++ b/sdk/lib/io/stdio.dart
@@ -402,7 +402,7 @@ class _StdSink implements IOSink {
       throw ArgumentError.value(
         lineTerminator,
         "lineTerminator",
-        r'invalid line terminator, must be one of "\r" or "\r\n"',
+        r'invalid line terminator, must be one of "\n" or "\r\n"',
       );
     }
   }


### PR DESCRIPTION
Context: https://api.flutter.dev/flutter/dart-io/Platform/lineTerminator.html

With reference to the documentation and logic of [`lineTerminator`][ref] setter, the current `ArgumentError` message is misleading:

```dart
r'invalid line terminator, must be one of "\r" or "\r\n"'
```

This fix contains just one change: the solo `"\r"` is corrected to `"\n"`.


  [ref]: https://github.com/dart-lang/sdk/blob/main/sdk/lib/io/stdio.dart#L394

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
