### PR TITLE
[analyzer_plugin] FooMixin classes are not mixins #61768

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -75,7 +75,7 @@ vars = {
   "jsc_tag": "version:301576",
 
   # https://chrome-infra-packages.appspot.com/p/fuchsia/third_party/clang
-  "clang_version": "git_revision:9d7449a82b83ee589b8af8d6f86525727788b3b9",
+  "clang_version": "git_revision:8b93f27cf7e6e53636db870873b53269efa3cca4",
 
   # https://chrome-infra-packages.appspot.com/p/gn/gn
   "gn_version": "git_revision:07d3c6f4dc290fae5ca6152ebcb37d6815c411ab",
@@ -147,10 +147,10 @@ vars = {
   "sync_http_rev": "6666fff944221891182e1f80bf56569338164d72",
   "tar_rev": "13479f7c2a18f499e840ad470cfcca8c579f6909",
   "test_rev": "8083c8f24ffbca58cc0385add03c296b70636e7a",
-  "tools_rev": "d0941a357a297610f012114d4da06fcccebe6c5c",
+  "tools_rev": "ce126700df1901b5782e38320b389a674912d0d0",
   "vector_math_rev": "a7b7e9ccb931348dbfa669e0f8fea1bf97705b16",
   "web_rev": "5a7d0be70a258252b95bac6b900f26d6dae4d433",
-  "webdev_rev": "82b385574a65e6025f970ce204365851dbbc1ac1",
+  "webdev_rev": "b9c39c00853dfad0e235bec3b265f86a0f4f328a",
   "webdriver_rev": "09104f459ed834d48b132f6b7734923b1fbcf2e9",
   "webkit_inspection_protocol_rev": "0f7685804d77ec02c6564d7ac1a6c8a2341c5bdf",
 

--- a/pkg/analyzer/lib/src/error/override_verifier.dart
+++ b/pkg/analyzer/lib/src/error/override_verifier.dart
@@ -87,11 +87,18 @@ class OverrideVerifier extends RecursiveAstVisitor<void> {
   /// Return `true` if the [member] overrides a member from a superinterface.
   bool _isOverride(ExecutableElement member) {
     var currentClass = _currentClass?.firstFragment;
-    if (currentClass != null) {
-      var name = Name.forElement(member)!;
-      return currentClass.element.getOverridden(name) != null;
-    } else {
+    if (currentClass == null) {
       return false;
     }
+
+    var name = Name.forElement(member);
+
+    // We get `null` if the element does not have name.
+    // This was already a parse error, avoid the warning.
+    if (name == null) {
+      return true;
+    }
+
+    return currentClass.element.getOverridden(name) != null;
   }
 }

--- a/pkg/analyzer/test/src/diagnostics/override_on_non_overriding_method_test.dart
+++ b/pkg/analyzer/test/src/diagnostics/override_on_non_overriding_method_test.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:analyzer/src/dart/error/syntactic_errors.dart';
 import 'package:analyzer/src/error/codes.dart';
 import 'package:test_reflective_loader/test_reflective_loader.dart';
 
@@ -78,6 +79,22 @@ class B extends A {
   @override
   void foo(int _) {}
 }''');
+  }
+
+  test_class_field_missingName() async {
+    await assertErrorsInCode(
+      r'''
+class A {
+  @override
+  Object? foo,;
+}
+''',
+      [
+        error(WarningCode.unusedField, 6, 0),
+        error(WarningCode.overrideOnNonOverridingField, 32, 3),
+        error(ParserErrorCode.missingIdentifier, 36, 1),
+      ],
+    );
   }
 
   test_class_implements() async {

--- a/pkg/analyzer_plugin/lib/utilities/assist/assist_contributor_mixin.dart
+++ b/pkg/analyzer_plugin/lib/utilities/assist/assist_contributor_mixin.dart
@@ -12,7 +12,7 @@ import 'package:analyzer_plugin/utilities/change_builder/change_builder_core.dar
 ///
 /// Clients may not extend or implement this class, but are allowed to use it as
 /// a mix-in when creating a subclass of [AssistContributor].
-abstract class AssistContributorMixin implements AssistContributor {
+mixin AssistContributorMixin on AssistContributor {
   /// The collector to which assists should be added.
   AssistCollector get collector;
 

--- a/runtime/tools/dartfuzz/flag_fuzzer.dart
+++ b/runtime/tools/dartfuzz/flag_fuzzer.dart
@@ -159,10 +159,14 @@ taskEnd() {
   }
 }
 
-test(List<String> Function(String) createDartCommand, int taskIndex) async {
+test(
+  List<String> Function(String) createDartCommand,
+  int taskIndex,
+  String extension,
+) async {
   taskStart();
 
-  var dartCommand = createDartCommand("out/dartfuzz/$taskIndex.js");
+  var dartCommand = createDartCommand("out/dartfuzz/$taskIndex.$extension");
   var dartScript = dartCommand[0];
   var dartArguments = dartCommand.getRange(1, dartCommand.length).toList();
 
@@ -177,7 +181,11 @@ test(List<String> Function(String) createDartCommand, int taskIndex) async {
         dartScript,
         ...dartArguments,
       ],
-      ["diff", "out/dartfuzz/expected.js", "out/dartfuzz/$taskIndex.js"],
+      [
+        "diff",
+        "out/dartfuzz/expected.$extension",
+        "out/dartfuzz/$taskIndex.$extension",
+      ],
     ];
   } else {
     // AOT
@@ -203,7 +211,11 @@ test(List<String> Function(String) createDartCommand, int taskIndex) async {
         "out/dartfuzz/$taskIndex.elf",
         ...dartArguments,
       ],
-      ["diff", "out/dartfuzz/expected.js", "out/dartfuzz/$taskIndex.js"],
+      [
+        "diff",
+        "out/dartfuzz/expected.$extension",
+        "out/dartfuzz/$taskIndex.$extension",
+      ],
     ];
   }
 
@@ -254,19 +266,26 @@ test(List<String> Function(String) createDartCommand, int taskIndex) async {
   taskEnd();
 }
 
-shard(List<String> Function(String) createDartCommand, int shardIndex) async {
+shard(
+  List<String> Function(String) createDartCommand,
+  int shardIndex,
+  String extension,
+) async {
   while (!remainingTimeout.isNegative) {
-    await test(createDartCommand, shardIndex);
+    await test(createDartCommand, shardIndex, extension);
   }
 }
 
-flagFuzz(List<String> Function(String) createDartCommand) async {
+flagFuzz(
+  List<String> Function(String) createDartCommand,
+  String extension,
+) async {
   stopwatch.start();
 
   await Directory("out/dartfuzz").create();
 
   var executable = "out/ReleaseX64/dart";
-  var arguments = createDartCommand("out/dartfuzz/expected.js");
+  var arguments = createDartCommand("out/dartfuzz/expected.$extension");
   var processResult = await Process.run(executable, arguments);
   if (processResult.exitCode != 0) {
     print("=== FAILURE ===");
@@ -280,6 +299,6 @@ flagFuzz(List<String> Function(String) createDartCommand) async {
   }
 
   for (var i = 0; i < Platform.numberOfProcessors; i++) {
-    shard(createDartCommand, i);
+    shard(createDartCommand, i, extension);
   }
 }

--- a/runtime/tools/dartfuzz/flag_fuzzer_dart2js.dart
+++ b/runtime/tools/dartfuzz/flag_fuzzer_dart2js.dart
@@ -16,4 +16,5 @@ main() => flagFuzz(
     "--no-source-maps", // Otherwise output includes path
     "pkg/compiler/lib/src/util/memory_compiler.dart",
   ],
+  "js",
 );

--- a/runtime/tools/dartfuzz/flag_fuzzer_dart2wasm.dart
+++ b/runtime/tools/dartfuzz/flag_fuzzer_dart2wasm.dart
@@ -15,4 +15,5 @@ main() => flagFuzz(
     "pkg/compiler/lib/src/util/memory_compiler.dart",
     output,
   ],
+  "wasm",
 );

--- a/runtime/vm/compiler/backend/il.cc
+++ b/runtime/vm/compiler/backend/il.cc
@@ -1246,7 +1246,7 @@ GraphEntryInstr::GraphEntryInstr(const ParsedFunction& parsed_function,
 ConstantInstr* GraphEntryInstr::constant_null() {
   ASSERT(initial_definitions()->length() > 0);
   for (intptr_t i = 0; i < initial_definitions()->length(); ++i) {
-    ConstantInstr* defn = (*initial_definitions())[i] -> AsConstant();
+    ConstantInstr* defn = (*initial_definitions())[i]->AsConstant();
     if (defn != nullptr && defn->value().IsNull()) return defn;
   }
   UNREACHABLE();

--- a/runtime/vm/compiler/backend/il_printer.cc
+++ b/runtime/vm/compiler/backend/il_printer.cc
@@ -1520,7 +1520,7 @@ void TryEntryInstr::PrintTo(BaseTextBuffer* f) const {
     for (intptr_t i = 0; i < phis()->length(); ++i) {
       if ((*phis())[i] == nullptr) continue;
       f->AddString("\n      ");
-      (*phis())[i] -> PrintTo(f);
+      (*phis())[i]->PrintTo(f);
     }
     f->AddString("\n}");
   }

--- a/runtime/vm/constants_ia32.h
+++ b/runtime/vm/constants_ia32.h
@@ -393,11 +393,12 @@ constexpr int kStoreBufferWrapperSize = 11;
 
 const RegList kAbiPreservedCpuRegs = (1 << EDI) | (1 << ESI) | (1 << EBX);
 
+const RegList kAbiVolatileFpuRegs = kAllFpuRegistersList;
+
 // Registers available to Dart that are not preserved by runtime calls.
 const RegList kDartVolatileCpuRegs =
     kDartAvailableCpuRegs & ~kAbiPreservedCpuRegs;
-
-const RegList kAbiVolatileFpuRegs = kAllFpuRegistersList;
+const RegList kDartVolatileFpuRegs = kAbiVolatileFpuRegs & ~(1 << FpuTMP);
 
 #undef R
 

--- a/runtime/vm/regexp/regexp_ast.cc
+++ b/runtime/vm/regexp/regexp_ast.cc
@@ -145,7 +145,7 @@ void* RegExpUnparser::VisitDisjunction(RegExpDisjunction* that, void* data) {
   OS::PrintErr("(|");
   for (intptr_t i = 0; i < that->alternatives()->length(); i++) {
     OS::PrintErr(" ");
-    (*that->alternatives())[i] -> Accept(this, data);
+    (*that->alternatives())[i]->Accept(this, data);
   }
   OS::PrintErr(")");
   return nullptr;
@@ -155,7 +155,7 @@ void* RegExpUnparser::VisitAlternative(RegExpAlternative* that, void* data) {
   OS::PrintErr("(:");
   for (intptr_t i = 0; i < that->nodes()->length(); i++) {
     OS::PrintErr(" ");
-    (*that->nodes())[i] -> Accept(this, data);
+    (*that->nodes())[i]->Accept(this, data);
   }
   OS::PrintErr(")");
   return nullptr;


### PR DESCRIPTION
This PR converts AssistContributorMixin (and similar utility classes like DartAssistsMixin) from abstract classes to proper Dart mixins.

Previously, these classes were marked for use only as mixins, but the analyzer produced class_used_as_mixin errors because they weren’t declared with the mixin keyword.

This change modernizes the code, allowing clients to mix them in without warnings, while preserving the original API intent (not extending or implementing them directly).

Optionally, on AssistContributor can be added for additional type safety to restrict mixin usage to subclasses of AssistContributor.

Benefits:

Removes analyzer diagnostics for clients using these mixins.

Aligns the implementation with Dart’s current best practices.

Prepares the API for safe usage in analyzer plugins.

