### PR TITLE
docs: add notice linking to analysis_server_plugin

### DIFF
--- a/pkg/analyzer_plugin/README.md
+++ b/pkg/analyzer_plugin/README.md
@@ -3,7 +3,7 @@
 
 A framework for building plugins for the analysis server.
 
-> **Notice:**  
+> **WARNING!**  
 > This package is for **legacy support** and is **not recommended** for new plugin development.  
 >  
 > For modern plugin implementations, use the [`analysis_server_plugin`](https://pub.dev/packages/analysis_server_plugin) package instead.  

--- a/pkg/analyzer_plugin/README.md
+++ b/pkg/analyzer_plugin/README.md
@@ -2,6 +2,10 @@
 [![package publisher](https://img.shields.io/pub/publisher/analyzer_plugin.svg)](https://pub.dev/packages/analyzer_plugin/publisher)
 
 A framework for building plugins for the analysis server.
+**Notice:**  
+This package is for **legacy support** and is **not recommended** for new plugin development.  
+For modern plugin implementations, use the [`analysis_server_plugin`](https://pub.dev/packages/analysis_server_plugin) package instead.  
+See its documentation for the latest architecture and examples.
 
 ## Usage
 

--- a/pkg/analyzer_plugin/README.md
+++ b/pkg/analyzer_plugin/README.md
@@ -2,7 +2,9 @@
 [![package publisher](https://img.shields.io/pub/publisher/analyzer_plugin.svg)](https://pub.dev/packages/analyzer_plugin/publisher)
 
 A framework for building plugins for the analysis server.
+
 **Notice:**  
+
 This package is for **legacy support** and is **not recommended** for new plugin development.  
 For modern plugin implementations, use the [`analysis_server_plugin`](https://pub.dev/packages/analysis_server_plugin) package instead.  
 See its documentation for the latest architecture and examples.

--- a/pkg/analyzer_plugin/README.md
+++ b/pkg/analyzer_plugin/README.md
@@ -3,11 +3,12 @@
 
 A framework for building plugins for the analysis server.
 
-**Notice:**  
-
-This package is for **legacy support** and is **not recommended** for new plugin development.  
-For modern plugin implementations, use the [`analysis_server_plugin`](https://pub.dev/packages/analysis_server_plugin) package instead.  
-See its documentation for the latest architecture and examples.
+> **Notice:**  
+> This package is for **legacy support** and is **not recommended** for new plugin development.  
+>  
+> For modern plugin implementations, use the [`analysis_server_plugin`](https://pub.dev/packages/analysis_server_plugin) package instead.  
+>  
+> See its documentation for the latest architecture and examples.
 
 ## Usage
 


### PR DESCRIPTION
**Title:**
Fixes #61817 
`docs: add notice linking to analysis_server_plugin`

**Description:**
This pull request updates the `pkg/analyzer_plugin/README.md` file to include a note directing users to the `analysis_server_plugin` package.
The change clarifies where plugin developers should look for the maintained implementation and helps avoid confusion when exploring the analyzer plugin system.

**Why:**
Developers exploring the analyzer plugin system often miss the fact that the maintained plugin implementation has moved to `analysis_server_plugin`.
This update improves documentation clarity and developer onboarding.

**Related issue:**
Fixes [[dart-lang/sdk#61817](https://github.com/dart-lang/sdk/issues/61817)](https://github.com/dart-lang/sdk/issues/61817)

---

- [x ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
