### PR TITLE
Document stable support for hooks in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,16 @@ instead.
 [writing an analyzer plugin]: https://github.com/dart-lang/sdk/blob/main/pkg/analysis_server_plugin/doc/writing_a_plugin.md
 [using analyzer plugins]: https://github.com/dart-lang/sdk/blob/main/pkg/analysis_server_plugin/doc/using_plugins.md
 
+#### Hooks
+
+Support for **hooks** -- formerly know as _native assets_ -- are now stable.
+
+You can currently use hooks to do things such as compile or download native assets
+(code written in other languages that are compiled into machine code), 
+and then call these assets from the Dart code of a package.
+
+For more details see the [hooks documentation](https://dart.dev/tools/hooks).
+
 #### Dart CLI and Dart VM
 
 - The Dart CLI and Dart VM have been split into two separate executables.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,7 +139,7 @@ instead.
 Support for **hooks** -- formerly know as _native assets_ -- are now stable.
 
 You can currently use hooks to do things such as compile or download native assets
-(code written in other languages that are compiled into machine code), 
+(code written in other languages that are compiled into machine code),
 and then call these assets from the Dart code of a package.
 
 For more details see the [hooks documentation](https://dart.dev/tools/hooks).


### PR DESCRIPTION
Added stable support for hooks, previously known as native assets, allowing compilation and downloading of native assets for Dart packages.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
