### PR TITLE
Add tests covering more cases for Uri.resolve

### DIFF
--- a/tests/corelib/uri_test.dart
+++ b/tests/corelib/uri_test.dart
@@ -131,12 +131,47 @@ void testUriPerRFCs() {
   // Additional tests (not from RFC 3986).
   testResolve("http://a/b/g;p/h;s", "../g;p/h;s");
 
+  base = Uri.parse("http://a?q");
+  testResolve("http://a?p", "?p");
+  testResolve("http://a/b/c", "b/c");
+
+  base = Uri.parse("foo:/a/b?q");
+  testResolve("foo:/a/b?p", "?p");
+  testResolve("foo:/c", "../c");
+  testResolve("foo:/a/c", "c");
+  testResolve("foo:/c", "../../c");
+  testResolve("foo:/c", "/c");
+
   // Test non-URI base (no scheme, no authority, relative path).
   base = Uri.parse("a/b/c?_#_");
   testResolve("a/b/g?q#f", "g?q#f");
   testResolve("../", "../../..");
+  testResolve("./", "../..");
   testResolve("a/b/", ".");
   testResolve("c", "../../c");
+  testResolve("//foo/a", "//foo/a");
+  testResolve("a/b/c?_#f", "#f");
+  testResolve("a/b/c?q", "?q");
+  testResolve("a/b/c?q#c", "?q#c");
+  testResolve("a/b/c?_", "");
+  testResolve("/a", "/a");
+  testResolve("/b", "/a/../../b");
+
+  base = Uri.parse("/a/b?_#_");
+  testResolve("/a/c", "c");
+  testResolve("/c", "../../c");
+
+  base = Uri.parse("//foo/a");
+  testResolve("//foo/b", "b");
+  testResolve("//foo/", "..");
+  testResolve("//foo/c", "../c");
+  testResolve("s:/a/b", "s:/a/b");
+  testResolve("//bar/b", "//bar/b");
+
+  base = Uri.parse("?_#_");
+  testResolve("?q", "?q");
+  testResolve("?_#f", "#f");
+  testResolve("a/b", "a/b");
 
   base = Uri.parse("s:a/b");
   testResolve("s:/c", "../c");


### PR DESCRIPTION
As part of the scssphp project (which is a PHP port of dart-sass), I had to implement the `Uri.resolve` API of Dart in PHP (as this API does not implement only the RFC3986 resolution but more cases). My initial work used a testsuite ported from the Dart SDK tests but collecting code coverage on my PHP code revealed that those tests were far from covering all non-RFC3986 cases. It missed several cases:

- schemeless base URIs (for which the resolution is derived from the RFC3986 behavior)
- base URIs with a scheme but not authority
- base URIs with an empty path
- base URIs being an absolute path
- base URIs with only a query string
- base URIs being a relative path, resolving a reference that is _not_ a relative path

This is adding tests covering all those cases.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
