### PR TITLE
[core/lib]: remove redundant null check

### DIFF
--- a/sdk/lib/core/list.dart
+++ b/sdk/lib/core/list.dart
@@ -284,10 +284,7 @@ abstract interface class List<E> implements Iterable<E>, _ListIterable<E> {
   ]) {
     start ??= 0;
     end = RangeError.checkValidRange(start, end, source.length);
-    if (end == null) {
-      // TODO(dart-lang/language#440): Remove when promotion works.
-      throw "unreachable";
-    }
+
     int length = end - start;
     if (target.length < at + length) {
       throw ArgumentError.value(


### PR DESCRIPTION
This PR removes an unnecessary null check from `copyRange` method found inside `list/core/list.dart`.

As the leftover comment dictates that it should be removed when promotion works and references the following [issue](https://github.com/dart-lang/language/issues/440) from language repo. Since the issues has been closed and the main points have been addressed and `RangeError.checkValidRange` method returns an `int` and instead throws in-case of invalid bounds.

I believe we can safely remove this check.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
