### PR TITLE
Update documentation for countdown behavior

### DIFF
--- a/sdk/lib/async/stream.dart
+++ b/sdk/lib/async/stream.dart
@@ -2002,7 +2002,7 @@ abstract mixin class Stream<T> {
   /// paused or cancelled.
   /// No new countdown is started when a countdown completes
   /// and the [onTimeout] function is called, even if events are emitted by the
-  /// [EventSink] provided by [onTimeout]. The countdown is only restarted when
+  /// [EventSink] provided to [onTimeout]. The countdown is only restarted when
   /// a new event comes from this stream.
   /// If the delay between events of this stream is multiple times
   /// [timeLimit], at most one timeout will happen between events.

--- a/sdk/lib/async/stream.dart
+++ b/sdk/lib/async/stream.dart
@@ -2001,7 +2001,9 @@ abstract mixin class Stream<T> {
   /// The countdown is stopped when listening on the returned stream is
   /// paused or cancelled.
   /// No new countdown is started when a countdown completes
-  /// and the [onTimeout] function is called, even if events are emitted.
+  /// and the [onTimeout] function is called, even if events are emitted by the
+  /// [EventSink] provided by [onTimeout]. The countdown is only restarted when
+  /// a new event comes from this stream.
   /// If the delay between events of this stream is multiple times
   /// [timeLimit], at most one timeout will happen between events.
   ///


### PR DESCRIPTION
Clarify behavior of countdown and `onTimeout` function.

The current documentation is ambiguous and sounds like once we get a timeout, no further timeouts will ever be emitted, which is not the case for the actual code we have.


- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

