### PR TITLE
[build] Don't include sanitizer AOT runtimes for musl-libc

### DIFF
--- a/sdk/BUILD.gn
+++ b/sdk/BUILD.gn
@@ -20,7 +20,7 @@ import("../utils/application_snapshot.gni")
 
 # If we're are embedded in another GN buildroot, such as Flutter, the sysroot
 # might already be imported from elsewhere.
-if (!defined(dart_sysroot)) {
+if (get_path_info(".", "abspath") == "//sdk/") {
   import("../build/config/sysroot.gni")
 }
 
@@ -388,7 +388,8 @@ copy_sanitizer_deps = []
 # and not useable outside our tree. If we're on Linux with musl-libc, the
 # sanitizers don't work. If we're are embedded in another GN buildroot, such as
 # Flutter, the sanitizer variant toolchains might not be defined.
-if (!using_sanitizer && current_os == "linux" && dart_sysroot != "alpine" &&
+if (!using_sanitizer && current_os == "linux" &&
+    !(defined(dart_sysroot) && dart_sysroot == "alpine") &&
     get_path_info(".", "abspath") == "//sdk/") {
   sanitizers = []
   if (current_cpu == "x64" || current_cpu == "arm64") {

--- a/sdk/BUILD.gn
+++ b/sdk/BUILD.gn
@@ -13,11 +13,16 @@
 # or ":copy_libraries" may delete/overwrite your addition, and the build will
 # fail.
 
-import("../build/config/sysroot.gni")
 import("../build/dart/copy_tree.gni")
 import("../build/executable_suffix.gni")
 import("../sdk_args.gni")
 import("../utils/application_snapshot.gni")
+
+# If we're are embedded in another GN buildroot, such as Flutter, the sysroot
+# might already be imported from elsewhere.
+if (!defined(dart_sysroot)) {
+  import("../build/config/sysroot.gni")
+}
 
 declare_args() {
   # Build a SDK with less stuff. It excludes dart2js, ddc, and web libraries.

--- a/sdk/BUILD.gn
+++ b/sdk/BUILD.gn
@@ -13,6 +13,7 @@
 # or ":copy_libraries" may delete/overwrite your addition, and the build will
 # fail.
 
+import("../build/config/sysroot.gni")
 import("../build/dart/copy_tree.gni")
 import("../build/executable_suffix.gni")
 import("../sdk_args.gni")
@@ -379,10 +380,10 @@ copy_sanitizer_deps = []
 # If the default toolchain is already using a sanitizer, the sanitizer variant
 # toolchains will try to use multiple sanitizers at the same time, which
 # doesn't work. If we're not on Linux, the sanitizers are not statically linked
-# and not useable outside our tree. If we're are embedded in another GN
-# buildroot, such as Flutter, the sanitizer variant toolchains might not be
-# defined.
-if (!using_sanitizer && current_os == "linux" &&
+# and not useable outside our tree. If we're on Linux with musl-libc, the
+# sanitizers don't work. If we're are embedded in another GN buildroot, such as
+# Flutter, the sanitizer variant toolchains might not be defined.
+if (!using_sanitizer && current_os == "linux" && dart_sysroot != "alpine" &&
     get_path_info(".", "abspath") == "//sdk/") {
   sanitizers = []
   if (current_cpu == "x64" || current_cpu == "arm64") {


### PR DESCRIPTION
Since https://github.com/dart-lang/sdk/commit/6b500b25174afc3fce0bccc2bef8bdfe9022fd9f the community maintained builds for musl-libc has been failing as the sanitizer AOT runtimes cannot be built: https://github.com/dart-musl/dart/actions/runs/19842805943

This PR removes these sanitizer AOT runtimes for musl-libc.

@rmacnak-google

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.