### PR TITLE
Fix stale code in docs to test analyzer plugin rules

### DIFF
--- a/pkg/analysis_server_plugin/doc/testing_rules.md
+++ b/pkg/analysis_server_plugin/doc/testing_rules.md
@@ -21,10 +21,7 @@ import 'package:test_reflective_loader/test_reflective_loader.dart';
 @reflectiveTest
 class MyRuleTest extends AnalysisRuleTest {
   @override
-  void setUp() {
-    rule = MyRule();
-    super.setUp();
-  }
+  String get analysisRule => 'my_rule';
 
   // Test cases go here.
 }
@@ -45,10 +42,8 @@ components of the `MyRuleTest` class.
   `AnalysisRuleTest`, from the `analyzer_testing` package, as a base.
   `AnalysisRuleTest` provides common functionality like `assertDiagnostics` and
   `newFile`.
-* `void setUp` - Override this method to provide some set-up code that is
-  executed before each test. This method must call `super.setUp()`. This method
-  is where we instantiate the analysis rule that we are testing:
-  `rule = MyRule();`.
+* `String get analysisRule` - Override this getter to specify which analysis rule
+  we are testing. This value must match your rule's diagnostic code's name.
 
 ## The test cases
 


### PR DESCRIPTION
Removed the setUp method and updated documentation to reflect the use of the analysisRule getter.

- Thanks for your contribution! Please replace this text with a description of what this PR is changing or adding and why, list any relevant issues, and review the contribution guidelines below.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
