### PR TITLE
Fix parameter_assignments documentation for null safety and updated dart syntax

### DIFF
--- a/pkg/linter/messages.yaml
+++ b/pkg/linter/messages.yaml
@@ -8261,6 +8261,7 @@ LinterLintCode:
     hasPublishedDocs: false
     documentation: |-
       **DON'T** assign new values to parameters of methods or functions.
+
       Assigning new values to parameters is generally a bad practice, even when using
       operators such as `??=`. Arbitrarily reassigning parameters is usually a
       mistake and can make code harder to reason about.

--- a/pkg/linter/messages.yaml
+++ b/pkg/linter/messages.yaml
@@ -8259,7 +8259,7 @@ LinterLintCode:
       stable: "2.0"
     categories: [style]
     hasPublishedDocs: false
-    documentation: |-
+    deprecatedDetails: |-
       **DON'T** assign new values to parameters of methods or functions.
 
       Assigning new values to parameters is generally a bad practice, even when using

--- a/pkg/linter/messages.yaml
+++ b/pkg/linter/messages.yaml
@@ -8259,12 +8259,11 @@ LinterLintCode:
       stable: "2.0"
     categories: [style]
     hasPublishedDocs: false
-    deprecatedDetails: |-
+    documentation: |-
       **DON'T** assign new values to parameters of methods or functions.
-
-      Assigning new values to parameters is generally a bad practice unless an
-      operator such as `??=` is used.  Otherwise, arbitrarily reassigning parameters
-      is usually a mistake.
+      Assigning new values to parameters is generally a bad practice, even when using
+      operators such as `??=`. Arbitrarily reassigning parameters is usually a
+      mistake and can make code harder to reason about.
 
       **BAD:**
       ```dart
@@ -8275,14 +8274,14 @@ LinterLintCode:
 
       **BAD:**
       ```dart
-      void badFunction(int required, {int optional: 42}) { // LINT
+      void badFunction(int required, {int? optional}) { // LINT
         optional ??= 8;
       }
       ```
 
       **BAD:**
       ```dart
-      void badFunctionPositional(int required, [int optional = 42]) { // LINT
+      void badFunctionPositional(int required, [int? optional]) { // LINT
         optional ??= 8;
       }
       ```
@@ -8305,15 +8304,17 @@ LinterLintCode:
 
       **GOOD:**
       ```dart
-      void actuallyGood(int required, {int optional}) { // OK
-        optional ??= ...;
+      void actuallyGood(int required, {int? optional}) { // OK
+        final value = optional ?? 8;
+        print(value);
       }
       ```
 
       **GOOD:**
       ```dart
-      void actuallyGoodPositional(int required, [int optional]) { // OK
-        optional ??= ...;
+      void actuallyGoodPositional(int required, [int? optional]) { // OK
+        final value = optional ?? 8;
+        print(value);
       }
       ```
 


### PR DESCRIPTION
Fix [7048](https://github.com/dart-lang/site-www/issues/7048)

- Fixed incorrect use of ??= on non-nullable parameters
- Converted affected parameters to nullable where appropriate (int → int?)
- Ensured each BAD example triggers exactly one diagnostic (the parameter_assignments lint)
- Ensured each GOOD example produces zero diagnostics
- Removed logically dead code caused by non-nullable ??= usage