### PR TITLE
glossary link for ‘obviously typed’ in obvious * types docs

### DIFF
--- a/pkg/linter/messages.yaml
+++ b/pkg/linter/messages.yaml
@@ -11955,7 +11955,7 @@ LinterLintCode:
     hasPublishedDocs: false
     deprecatedDetails: |-
       Do type annotate initialized top-level or static variables when the type is
-      non-obvious.
+      [non-obvious](https://dart.dev/resources/glossary#obviously-typed).
 
       Type annotations on top-level or static variables can serve as a request for
       type inference, documenting the expected outcome of the type inference step,

--- a/pkg/linter/messages.yaml
+++ b/pkg/linter/messages.yaml
@@ -11969,28 +11969,6 @@ LinterLintCode:
       information about the type of the given variable (which may not be immediately
       evident by looking at the initializing expression).
 
-      An expression is considered to have a non-obvious type when it does not
-      have an obvious type.
-
-      An expression e has an obvious type in the following cases:
-
-      - e is a non-collection literal. For instance, 1, true, 'Hello, $name!'.
-      - e is a collection literal with actual type arguments. For instance,
-        <int, bool>{}.
-      - e is a list literal or a set literal where at least one element has an
-        obvious type, and all elements have the same type. For instance, [1, 2] and
-        { [true, false], [] }, but not [1, 1.5].
-      - e is a map literal where all key-value pair have a key with an obvious type
-        and a value with an obvious type, and all keys have the same type, and all
-        values have the same type. For instance, { #a: <int>[] }, but not
-        {1: 1, 2: true}.
-      - e is an instance creation expression whose class part is not raw. For
-        instance C(14) if C is a non-generic class, or C<int>(14) if C accepts one
-        type argument, but not C(14) if C accepts one or more type arguments.
-      - e is a cascade whose target has an obvious type. For instance,
-        1..isEven..isEven has an obvious type because 1 has an obvious type.
-      - e is a type cast. For instance, `myComplexExpression as int`.
-
       **BAD:**
       ```dart
       final myTopLevelVariable =

--- a/pkg/linter/messages.yaml
+++ b/pkg/linter/messages.yaml
@@ -7741,12 +7741,12 @@ LinterLintCode:
     categories: [style]
     hasPublishedDocs: false
     deprecatedDetails: |-
-      Don't type annotate initialized local variables when the type is obvious.
+      Don't type annotate initialized local variables when the type is [obvious](https://dart.dev/resources/glossary#obviously-typed).
 
       Local variables, especially in modern code where functions tend to be small,
       have very little scope. Omitting the type focuses the reader's attention on the
       more important *name* of the variable and its initialized value. Hence, local
-      variable type annotations that are obvious should be omitted.
+      variable type annotations that are [obvious](https://dart.dev/resources/glossary#obviously-typed) should be omitted.
 
       **BAD:**
       ```dart
@@ -7815,7 +7815,7 @@ LinterLintCode:
     hasPublishedDocs: false
     deprecatedDetails: |-
       Don't type annotate initialized top-level or static variables when the type is
-      obvious.
+      [obvious](https://dart.dev/resources/glossary#obviously-typed).
 
       **BAD:**
       ```dart


### PR DESCRIPTION
fix [6993](https://github.com/dart-lang/site-www/issues/6993)
fix [6994](https://github.com/dart-lang/site-www/issues/6994)
fix [6992](https://github.com/dart-lang/site-www/issues/6992)

This PR adds a hyperlink from “obvious” / “obviously typed” to the official glossary entry: https://dart.dev/resources/glossary#obviously-typed.  
