### PR TITLE
tools(hytopia_server): add minimal Hytopia server

### DIFF
--- a/tools/hytopia_server/.dockerignore
+++ b/tools/hytopia_server/.dockerignore
@@ -1,0 +1,10 @@
+**/.git
+**/.gitignore
+**/.hytopia
+**/build
+**/.dart_tool
+**/packages
+**/pubspec.lock
+node_modules
+*.log
+*.tmp

--- a/tools/hytopia_server/Dockerfile
+++ b/tools/hytopia_server/Dockerfile
@@ -1,0 +1,16 @@
+# Simple Dockerfile for the Hytopia server (Dart)
+FROM dart:stable
+
+WORKDIR /app
+
+# Copy repository files (keep context small when building)
+COPY . /app
+
+# Ensure dependencies (no-op if none)
+RUN dart pub get || true
+
+# Expose default port (can be overridden via HYTOPIA_PORT)
+EXPOSE 8080
+
+# Default command
+CMD ["dart", "run", "tools/hytopia_server/bin/server.dart"]

--- a/tools/hytopia_server/README.md
+++ b/tools/hytopia_server/README.md
@@ -1,0 +1,23 @@
+# Hytopia server
+
+Minimal Dart HTTP server for Hytopia.
+
+Run:
+
+```bash
+# From workspace root
+dart run tools/hytopia_server/bin/server.dart
+```
+
+Environment:
+
+- `HYTOPIA_PORT` — override default port (8080)
+
+Endpoints:
+
+- `GET /` — serves a small HTML page
+- `GET /health` — returns `{ "status": "ok" }`
+- `POST /echo` — echoes submitted JSON as `{ "echo": ... }`
+- `GET /static/<path>` — serves files from `tools/hytopia_server/public`
+
+Next steps (optional): Dockerfile, systemd unit, or integrate into your deployment.

--- a/tools/hytopia_server/bin/server.dart
+++ b/tools/hytopia_server/bin/server.dart
@@ -1,0 +1,112 @@
+import 'dart:convert';
+import 'dart:io';
+
+Future<void> main() async {
+  final ip = InternetAddress.anyIPv4;
+  final port = int.tryParse(Platform.environment['HYTOPIA_PORT'] ?? '8080') ?? 8080;
+
+  final server = await HttpServer.bind(ip, port);
+  print('Hytopia server running on http://$ip:$port');
+
+  await for (HttpRequest request in server) {
+    try {
+      _setDefaultHeaders(request);
+
+      final path = request.uri.path;
+
+      if (path == '/' || path == '/index.html') {
+        _serveStaticFile(request, 'public/index.html');
+      } else if (path == '/health') {
+        _handleHealth(request);
+      } else if (path == '/echo' && request.method == 'POST') {
+        await _handleEcho(request);
+      } else if (path.startsWith('/static/')) {
+        final filePath = 'public' + path.substring('/static'.length);
+        _serveStaticFile(request, filePath);
+      } else {
+        _notFound(request);
+      }
+    } catch (e, st) {
+      stderr.writeln('Error handling request: $e\n$st');
+      _internalError(request, e.toString());
+    }
+  }
+}
+
+void _setDefaultHeaders(HttpRequest request) {
+  request.response.headers.set('content-type', 'application/json; charset=utf-8');
+  request.response.headers.set('access-control-allow-origin', '*');
+  request.response.headers.set('access-control-allow-methods', 'GET,POST,OPTIONS');
+  request.response.headers.set('access-control-allow-headers', 'content-type');
+  if (request.method == 'OPTIONS') {
+    request.response.statusCode = HttpStatus.noContent;
+    request.response.close();
+  }
+}
+
+void _handleHealth(HttpRequest request) {
+  request.response.statusCode = HttpStatus.ok;
+  request.response.write(jsonEncode({'status': 'ok'}));
+  request.response.close();
+}
+
+Future<void> _handleEcho(HttpRequest request) async {
+  final body = await utf8.decoder.bind(request).join();
+  dynamic decoded;
+  try {
+    decoded = jsonDecode(body);
+  } catch (_) {
+    decoded = {'raw': body};
+  }
+
+  request.response.statusCode = HttpStatus.ok;
+  request.response.write(jsonEncode({'echo': decoded}));
+  await request.response.close();
+}
+
+void _serveStaticFile(HttpRequest request, String filePath) {
+  final file = File(filePath);
+  if (!file.existsSync()) {
+    _notFound(request);
+    return;
+  }
+
+  final ext = filePath.split('.').last.toLowerCase();
+  final contentType = _contentTypeForExt(ext);
+  request.response.headers.set('content-type', contentType);
+  request.response.addStream(file.openRead()).whenComplete(() => request.response.close());
+}
+
+String _contentTypeForExt(String ext) {
+  switch (ext) {
+    case 'html':
+      return 'text/html; charset=utf-8';
+    case 'css':
+      return 'text/css; charset=utf-8';
+    case 'js':
+      return 'application/javascript; charset=utf-8';
+    case 'png':
+      return 'image/png';
+    case 'jpg':
+    case 'jpeg':
+      return 'image/jpeg';
+    case 'svg':
+      return 'image/svg+xml';
+    case 'json':
+      return 'application/json; charset=utf-8';
+    default:
+      return 'application/octet-stream';
+  }
+}
+
+void _notFound(HttpRequest request) {
+  request.response.statusCode = HttpStatus.notFound;
+  request.response.write(jsonEncode({'error': 'Not found'}));
+  request.response.close();
+}
+
+void _internalError(HttpRequest request, String message) {
+  request.response.statusCode = HttpStatus.internalServerError;
+  request.response.write(jsonEncode({'error': 'Internal server error', 'message': message}));
+  request.response.close();
+}

--- a/tools/hytopia_server/bin/server.dart
+++ b/tools/hytopia_server/bin/server.dart
@@ -1,7 +1,13 @@
 import 'dart:convert';
 import 'dart:io';
 
-Future<void> main() async {
+Future<void> main(List<String> args) async {
+  // CLI: `hytopia init`
+  if (args.isNotEmpty && args.first == 'init') {
+    await _performInit();
+    return;
+  }
+
   final ip = InternetAddress.anyIPv4;
   final port = int.tryParse(Platform.environment['HYTOPIA_PORT'] ?? '8080') ?? 8080;
 
@@ -31,6 +37,28 @@ Future<void> main() async {
       _internalError(request, e.toString());
     }
   }
+}
+
+Future<void> _performInit() async {
+  final baseDir = Directory('tools/hytopia_server/.hytopia');
+  if (!baseDir.existsSync()) {
+    baseDir.createSync(recursive: true);
+  }
+
+  final configFile = File('${baseDir.path}/config.json');
+  if (configFile.existsSync()) {
+    print('Hytopia already initialized at ${baseDir.path}');
+    return;
+  }
+
+  final defaultConfig = {
+    'port': 8080,
+    'createdAt': DateTime.now().toUtc().toIso8601String(),
+    'welcomeMessage': 'Welcome Shadow Army!'
+  };
+
+  await configFile.writeAsString(const JsonEncoder.withIndent('  ').convert(defaultConfig));
+  print('Initialized Hytopia config at ${configFile.path}');
 }
 
 void _setDefaultHeaders(HttpRequest request) {

--- a/tools/hytopia_server/js/server.mjs
+++ b/tools/hytopia_server/js/server.mjs
@@ -1,0 +1,53 @@
+import { Server } from "@hytopia/sdk";
+
+// Minimal example — adapt to the real @hytopia/sdk API.
+async function main() {
+  const port = process.env.PORT ? Number(process.env.PORT) : 8080;
+
+  // `Server` constructor and methods below are illustrative.
+  const server = new Server({ port });
+
+  // If the SDK uses an event emitter style:
+  if (typeof server.on === 'function') {
+    server.on('request', (req, res) => {
+      res.writeHead(200, { 'Content-Type': 'text/plain' });
+      res.end('Hello from Hytopia Server (JS example)\n');
+    });
+  }
+
+  // Example: handle player join using hypothetical SDK hooks.
+  // Many game/server SDKs provide either a specific method like
+  // `onPlayerJoin` or an event name such as 'playerJoin'. Handle both.
+  if (typeof server.onPlayerJoin === 'function') {
+    server.onPlayerJoin((player) => {
+      if (typeof player.sendMessage === 'function') {
+        player.sendMessage('Welcome Shadow Army!');
+      } else {
+        console.log('Player joined (no sendMessage):', player);
+      }
+    });
+  } else if (typeof server.on === 'function') {
+    server.on('playerJoin', (player) => {
+      if (player && typeof player.sendMessage === 'function') {
+        player.sendMessage('Welcome Shadow Army!');
+      } else {
+        console.log('Player joined (event):', player);
+      }
+    });
+  }
+
+  // If the SDK exposes an async start method:
+  if (typeof server.start === 'function') {
+    await server.start();
+    console.log(`Hytopia Server running on port ${port}`);
+    return;
+  }
+
+  // Fallback: if constructor already binds, just log.
+  console.log(`Hytopia Server instance created (port ${port}).`);
+}
+
+main().catch((e) => {
+  console.error('Failed to start Hytopia Server example:', e);
+  process.exit(1);
+});

--- a/tools/hytopia_server/public/index.html
+++ b/tools/hytopia_server/public/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>Hytopia Server</title>
+    <style>body{font-family:system-ui,Segoe UI,Roboto,Helvetica,Arial;margin:2rem}</style>
+  </head>
+  <body>
+    <h1>Hytopia Server</h1>
+    <p>The minimal Hytopia server is running.</p>
+    <p>Try <a href="/health">/health</a> or POST JSON to <code>/echo</code>.</p>
+  </body>
+</html>

--- a/tools/hytopia_server/pubspec.yaml
+++ b/tools/hytopia_server/pubspec.yaml
@@ -1,0 +1,4 @@
+name: hytopia_server
+description: Minimal HTTP server for Hytopia.
+environment:
+  sdk: '>=2.17.0 <4.0.0'


### PR DESCRIPTION
Adds a minimal Hytopia server under tools/hytopia_server with:

- Dart HTTP server () serving , ,  and static files
- Static page  and README
- JavaScript ESM example importing  from  in 

This is a lightweight example for development and testing. Please review for placement and formatting; happy to add a Dockerfile, systemd unit, or smoke tests if desired.