### PR TITLE
chore: Fix typos in analysis_server error messages

### DIFF
--- a/pkg/analysis_server/lib/src/scheduler/message_scheduler.dart
+++ b/pkg/analysis_server/lib/src/scheduler/message_scheduler.dart
@@ -306,7 +306,7 @@ final class MessageScheduler {
           : null;
     } catch (error, stackTrace) {
       (server as LspAnalysisServer).logException(
-        'An error occured while parsing cancel parameters',
+        'An error occurred while parsing cancel parameters',
         error,
         stackTrace,
       );

--- a/pkg/analysis_server/tool/log_player/log_player.dart
+++ b/pkg/analysis_server/tool/log_player/log_player.dart
@@ -99,7 +99,7 @@ class LogPlayer {
                 if (actualId == null) {
                   throw StateError(
                     'Cannot respond to a server message that we haven\'t '
-                    'recieved yet, expected an analysis server request with '
+                    'received yet, expected an analysis server request with '
                     'ID: ${entry.message.id}',
                   );
                 }


### PR DESCRIPTION
Thanks for your contribution! This PR fixes two small typos in string literals within the `analysis_server` package to improve clarity and consistency.

### Description
This PR corrects two misspelled string literals:

- `occured` → `occurred` in `message_scheduler.dart`
- `recieved` → `received` in `log_player.dart`

These are non-functional, documentation-style fixes and do not affect runtime behavior. They improve message quality and maintain a consistent standard across the codebase.

There are no behavioral or API changes.

### Relevant Issues
N/A (typo corrections)

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
