### PR TITLE
Fix VM service smaps path NUL termination to prevent OOB reads

### DIFF
--- a/runtime/vm/service.cc
+++ b/runtime/vm/service.cc
@@ -4895,6 +4895,7 @@ static void AddVMMappings(JSONArray* rss_children) {
       }
 
       strncpy(path, path_start, sizeof(path) - 1);
+      path[sizeof(path) - 1] = '\0';
       int len = strlen(path);
       if ((len > 0) && path[len - 1] == '\n') {
         path[len - 1] = 0;
@@ -4923,7 +4924,8 @@ static void AddVMMappings(JSONArray* rss_children) {
         }
         if (!updated) {
           VMMapping mapping;
-          strncpy(mapping.path, path, sizeof(mapping.path));
+          strncpy(mapping.path, path, sizeof(mapping.path) - 1);
+          mapping.path[sizeof(mapping.path) - 1] = '\0';
           mapping.size = size;
           mappings.Add(mapping);
         }


### PR DESCRIPTION
Ensure NUL termination when copying mapping paths from /proc/self/smaps.
Prevent potential out‑of‑bounds reads and info disclosure in VM service RSS mappings.