### PR TITLE
[analysis_server] Fix duplication in swap with parent assist

### DIFF
--- a/pkg/analysis_server/test/src/services/correction/assist/flutter_swap_with_parent_test.dart
+++ b/pkg/analysis_server/test/src/services/correction/assist/flutter_swap_with_parent_test.dart
@@ -25,6 +25,37 @@ class FlutterSwapWithParentTest extends AssistProcessorTest {
     writeTestPackageConfig(flutter: true);
   }
 
+  Future<void> test_bodyWidgetNotDuplicated() async {
+    await resolveTestCode('''
+import 'package:flutter/material.dart';
+
+class MyWidget extends StatelessWidget {
+  const MyWidget({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(body: ^SizedBox(child: Placeholder()));
+  }
+}
+''');
+    await assertHasAssist('''
+import 'package:flutter/material.dart';
+
+class MyWidget extends StatelessWidget {
+  const MyWidget({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      child: Scaffold(
+        body: Placeholder(),
+      ),
+    );
+  }
+}
+''');
+  }
+
   Future<void> test_inCenter() async {
     await resolveTestCode('''
 import 'package:flutter/material.dart';
@@ -218,36 +249,5 @@ build() {
 startResize() {}
 ''');
     await assertNoAssist();
-  }
-
-  Future<void> test_bodyWidgetNotDuplicated() async {
-    await resolveTestCode('''
-import 'package:flutter/material.dart';
-
-class MyWidget extends StatelessWidget {
-  const MyWidget({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(body: ^SizedBox(child: Placeholder()));
-  }
-}
-''');
-    await assertHasAssist('''
-import 'package:flutter/material.dart';
-
-class MyWidget extends StatelessWidget {
-  const MyWidget({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return SizedBox(
-      child: Scaffold(
-        body: Placeholder(),
-      ),
-    );
-  }
-}
-''');
   }
 }

--- a/pkg/analysis_server/test/src/services/correction/assist/flutter_swap_with_parent_test.dart
+++ b/pkg/analysis_server/test/src/services/correction/assist/flutter_swap_with_parent_test.dart
@@ -219,4 +219,35 @@ startResize() {}
 ''');
     await assertNoAssist();
   }
+
+  Future<void> test_bodyWidgetNotDuplicated() async {
+    await resolveTestCode('''
+import 'package:flutter/material.dart';
+
+class MyWidget extends StatelessWidget {
+  const MyWidget({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(body: ^SizedBox(child: Placeholder()));
+  }
+}
+''');
+    await assertHasAssist('''
+import 'package:flutter/material.dart';
+
+class MyWidget extends StatelessWidget {
+  const MyWidget({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      child: Scaffold(
+        body: Placeholder(),
+      ),
+    );
+  }
+}
+''');
+  }
 }


### PR DESCRIPTION
Update the "Swap with parent" assist to detect the named parameter (e.g. 'body', 'child') holding the child widget, rather than defaulting to 'child'.

Fixes a bug where swapping a Scaffold's body would cause the swapped Widget to duplicate.

Fixes issue #62350.

---

- [x] I have signed the Google CLA.
- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] I have included a new test. 

