### PR TITLE
Update convert_field_formal_to_normal.dart to handle private named parameters

### DIFF
--- a/pkg/analysis_server/test/src/services/correction/assist/convert_field_formal_to_normal_test.dart
+++ b/pkg/analysis_server/test/src/services/correction/assist/convert_field_formal_to_normal_test.dart
@@ -308,4 +308,93 @@ class C {
 }
 ''');
   }
+
+  Future<void> test_privateNamedParameter_optionalNamed() async {
+    await resolveTestCode('''
+class C {
+  int? _foo;
+
+  C({this._f^oo});
+}
+''');
+    await assertHasAssist('''
+class C {
+  int? _foo;
+
+  C({int? foo}) : _foo = foo;
+}
+''');
+  }
+
+  Future<void> test_privateNamedParameter_requiredNamed() async {
+    await resolveTestCode('''
+class C {
+  int _foo;
+
+  C({required this._f^oo});
+}
+''');
+    await assertHasAssist('''
+class C {
+  int _foo;
+
+  C({required int foo}) : _foo = foo;
+}
+''');
+  }
+
+  Future<void> test_privateNamedParameter_explicitType() async {
+    await resolveTestCode('''
+class C {
+  num _foo;
+
+  C({int this._f^oo = 0});
+}
+''');
+    await assertHasAssist('''
+class C {
+  num _foo;
+
+  C({int foo = 0}) : _foo = foo;
+}
+''');
+  }
+
+  Future<void> test_privateNamedParameter_withExistingInitializer() async {
+    await resolveTestCode('''
+class C {
+  int _foo;
+  int _bar;
+
+  C({required this._f^oo, required int bar}) : _bar = bar;
+}
+''');
+    await assertHasAssist('''
+class C {
+  int _foo;
+  int _bar;
+
+  C({required int foo, required int bar}) : _bar = bar, _foo = foo;
+}
+''');
+  }
+
+  Future<void> test_privateNamedParameter_disabled() async {
+    await resolveTestCode('''
+// @dart=3.10
+class C {
+  int? _foo;
+
+  C({this._f^oo});
+}
+''');
+    await assertHasAssist('''
+// @dart=3.10
+class C {
+  int? _foo;
+
+  C({int? _foo}) : _foo = _foo;
+}
+''');
+  }
 }

--- a/pkg/analysis_server/test/src/services/correction/assist/convert_to_normal_parameter_test.dart
+++ b/pkg/analysis_server/test/src/services/correction/assist/convert_to_normal_parameter_test.dart
@@ -69,4 +69,68 @@ class A {
 }
 ''');
   }
+
+  Future<void> test_privateNamedParameter_optionalNamed() async {
+    await resolveTestCode('''
+class A {
+  int? _foo;
+  A({this._f^oo});
+}
+''');
+    await assertHasAssist('''
+class A {
+  int? _foo;
+  A({int? foo}) : _foo = foo;
+}
+''');
+  }
+
+  Future<void> test_privateNamedParameter_requiredNamed() async {
+    await resolveTestCode('''
+class A {
+  int _foo;
+  A({required this._f^oo});
+}
+''');
+    await assertHasAssist('''
+class A {
+  int _foo;
+  A({required int foo}) : _foo = foo;
+}
+''');
+  }
+
+  Future<void> test_privateNamedParameter_withExistingInitializer() async {
+    await resolveTestCode('''
+class A {
+  double aaa;
+  int _bbb;
+  A({required this._bb^b}) : aaa = 1.0;
+}
+''');
+    await assertHasAssist('''
+class A {
+  double aaa;
+  int _bbb;
+  A({required int bbb}) : aaa = 1.0, _bbb = bbb;
+}
+''');
+  }
+
+  Future<void> test_privateNamedParameter_disabled() async {
+    await resolveTestCode('''
+// @dart=3.10
+class A {
+  int? _foo;
+  A({this._f^oo});
+}
+''');
+    await assertHasAssist('''
+// @dart=3.10
+class A {
+  int? _foo;
+  A({int? _foo}) : _foo = _foo;
+}
+''');
+  }
 }


### PR DESCRIPTION
Fixes https://github.com/dart-lang/sdk/issues/62436

## Changes
When converting a field formal parameter (`this._foo`) to a normal parameter with an initializer, the assist now properly handles private named parameters:

- Uses the public name for the parameter declaration (`foo` instead of `_foo`)
- Preserves the private field name in the initializer (`_foo = foo`)
- Only applies when the `private_named_parameters` feature is enabled
- Falls back to old behavior when the feature is disabled

## Example
Before (with private named parameters enabled):
```dart
class C {
  int _foo;
  C({required this._foo});
}
```

After applying the assist:
```dart
class C {
  int _foo;
  C({required int foo}) : _foo = foo;
}
```

## Tests Added
- `test_privateNamedParameter_optionalNamed`
- `test_privateNamedParameter_requiredNamed`
- `test_privateNamedParameter_explicitType`
- `test_privateNamedParameter_withExistingInitializer`
- `test_privateNamedParameter_disabled`