### PR TITLE
[vm/ffi] Migrate legacy multi-test files in sdk/tests/ffi to standard tests

### DIFF
--- a/sdk/tests/ffi/vmspecific_function_callbacks_exit_test.dart
+++ b/sdk/tests/ffi/vmspecific_function_callbacks_exit_test.dart
@@ -1,0 +1,1 @@
+Formatted 1 file (0 changed) in 0.47 seconds.

--- a/sdk/tests/ffi/vmspecific_highmem_32bit_test.dart
+++ b/sdk/tests/ffi/vmspecific_highmem_32bit_test.dart
@@ -1,0 +1,1 @@
+Formatted 1 file (0 changed) in 0.39 seconds.

--- a/sdk/tests/ffi/vmspecific_leaf_call_test.dart
+++ b/sdk/tests/ffi/vmspecific_leaf_call_test.dart
@@ -1,0 +1,1 @@
+Formatted 1 file (0 changed) in 0.31 seconds.

--- a/tests/ffi/abi_specific_int_incomplete_aot_test.dart
+++ b/tests/ffi/abi_specific_int_incomplete_aot_test.dart
@@ -22,5 +22,7 @@ final class Incomplete extends AbiSpecificInteger {
 void main() {
   // Any use that causes the class to be used, causes a compile-time error
   // during loading of the class.
-  nullptr.cast<Incomplete>(); // [cfe] Class 'Incomplete' does not have an AbiSpecificIntegerMapping for the current platform.
+  nullptr.cast<Incomplete>();
+  //      ^
+  // [cfe] Class 'Incomplete' does not have an AbiSpecificIntegerMapping for the current platform.
 }

--- a/tests/ffi/abi_specific_int_incomplete_aot_test.dart
+++ b/tests/ffi/abi_specific_int_incomplete_aot_test.dart
@@ -22,5 +22,5 @@ final class Incomplete extends AbiSpecificInteger {
 void main() {
   // Any use that causes the class to be used, causes a compile-time error
   // during loading of the class.
-  nullptr.cast<Incomplete>(); //# 1: compile-time error
+  nullptr.cast<Incomplete>(); // [cfe] Class 'Incomplete' does not have an AbiSpecificIntegerMapping for the current platform.
 }

--- a/tests/ffi/static_checks/regress_44986_test.dart
+++ b/tests/ffi/static_checks/regress_44986_test.dart
@@ -2,14 +2,13 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-
-
 import "dart:ffi";
 
 final class S2 extends Struct {
   external Pointer<Int8> notEmpty;
 
   external Null s;
+  //            ^
   // [cfe] Field 's' must have a native type.
   // [analyzer] COMPILE_TIME_ERROR.INVALID_FIELD_TYPE_IN_STRUCT
 }

--- a/tests/ffi/static_checks/regress_44986_test.dart
+++ b/tests/ffi/static_checks/regress_44986_test.dart
@@ -2,15 +2,16 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// Formatting can break multitests, so don't format them.
-// dart format off
+
 
 import "dart:ffi";
 
 final class S2 extends Struct {
   external Pointer<Int8> notEmpty;
 
-  external Null s; //# 01: compile-time error
+  external Null s;
+  // [cfe] Field 's' must have a native type.
+  // [analyzer] COMPILE_TIME_ERROR.INVALID_FIELD_TYPE_IN_STRUCT
 }
 
 void main() {

--- a/tests/ffi/static_checks/regress_46085_test.dart
+++ b/tests/ffi/static_checks/regress_46085_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-
-
 import "dart:ffi";
 
 final class MyStruct extends Struct {
@@ -11,11 +9,13 @@ final class MyStruct extends Struct {
 
   @Array.multi([])
   external Array<Int16> a0;
+  //                    ^^
   // [cfe] Array dimensions must be positive integers.
   // [analyzer] COMPILE_TIME_ERROR.SIZE_ANNOTATION_DIMENSIONS
 
   @Array.multi([1])
   external Array<Array<Int16>> a1;
+  //                           ^^
   // [cfe] Dimension count mismatch.
   // [analyzer] COMPILE_TIME_ERROR.SIZE_ANNOTATION_DIMENSIONS
 }

--- a/tests/ffi/static_checks/regress_46085_test.dart
+++ b/tests/ffi/static_checks/regress_46085_test.dart
@@ -2,19 +2,22 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// Formatting can break multitests, so don't format them.
-// dart format off
+
 
 import "dart:ffi";
 
 final class MyStruct extends Struct {
   external Pointer<Int8> notEmpty;
 
-  @Array.multi([]) //# 01: compile-time error
-  external Array<Int16> a0; //# 01: compile-time error
+  @Array.multi([])
+  external Array<Int16> a0;
+  // [cfe] Array dimensions must be positive integers.
+  // [analyzer] COMPILE_TIME_ERROR.SIZE_ANNOTATION_DIMENSIONS
 
-  @Array.multi([1]) //# 02: compile-time error
-  external Array<Array<Int16>> a1; //# 02: compile-time error
+  @Array.multi([1])
+  external Array<Array<Int16>> a1;
+  // [cfe] Dimension count mismatch.
+  // [analyzer] COMPILE_TIME_ERROR.SIZE_ANNOTATION_DIMENSIONS
 }
 
 void main() {

--- a/tests/ffi/static_checks/regress_47673_2_test.dart
+++ b/tests/ffi/static_checks/regress_47673_2_test.dart
@@ -4,8 +4,7 @@
 //
 // SharedObjects=ffi_test_functions
 
-// Formatting can break multitests, so don't format them.
-// dart format off
+
 
 import 'dart:ffi';
 
@@ -14,8 +13,10 @@ final class A extends Struct {
   external Array<Int8> a;
 
   // This should not crash the FFI transform.
-  @Array.multi([16]) //# 1: compile-time error
-  external Array<Unknown> b; //# 1: compile-time error
+  @Array.multi([16])
+  external Array<Unknown> b;
+  // [cfe] The type 'Unknown' isn't defined.
+  // [analyzer] COMPILE_TIME_ERROR.UNDEFINED_CLASS
 }
 
 main() {}

--- a/tests/ffi/static_checks/regress_47673_2_test.dart
+++ b/tests/ffi/static_checks/regress_47673_2_test.dart
@@ -4,8 +4,6 @@
 //
 // SharedObjects=ffi_test_functions
 
-
-
 import 'dart:ffi';
 
 final class A extends Struct {
@@ -15,6 +13,7 @@ final class A extends Struct {
   // This should not crash the FFI transform.
   @Array.multi([16])
   external Array<Unknown> b;
+  //             ^^^^^^^
   // [cfe] The type 'Unknown' isn't defined.
   // [analyzer] COMPILE_TIME_ERROR.UNDEFINED_CLASS
 }

--- a/tests/ffi/static_checks/regress_51041_test.dart
+++ b/tests/ffi/static_checks/regress_51041_test.dart
@@ -2,8 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// Formatting can break multitests, so don't format them.
-// dart format off
+
 
 import 'dart:ffi';
 
@@ -12,8 +11,10 @@ import 'package:ffi/ffi.dart';
 final class Foo extends Struct {
   @Int32()
   external int // Force `?` to newline.
-      ? //# 1: compile-time error
+      ?
       x;
+  // [cfe] Field 'x' cannot be nullable.
+  // [analyzer] COMPILE_TIME_ERROR.INVALID_FIELD_TYPE_IN_STRUCT
 }
 
 void main() {

--- a/tests/ffi/static_checks/regress_51041_test.dart
+++ b/tests/ffi/static_checks/regress_51041_test.dart
@@ -13,6 +13,7 @@ final class Foo extends Struct {
   external int // Force `?` to newline.
       ?
       x;
+  //  ^
   // [cfe] Field 'x' cannot be nullable.
   // [analyzer] COMPILE_TIME_ERROR.INVALID_FIELD_TYPE_IN_STRUCT
 }

--- a/tests/ffi/static_checks/regress_51041_test.dart
+++ b/tests/ffi/static_checks/regress_51041_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-
-
 import 'dart:ffi';
 
 import 'package:ffi/ffi.dart';
@@ -11,8 +9,8 @@ import 'package:ffi/ffi.dart';
 final class Foo extends Struct {
   @Int32()
   external int // Force `?` to newline.
-      ?
-      x;
+  ?
+  x;
   //  ^
   // [cfe] Field 'x' cannot be nullable.
   // [analyzer] COMPILE_TIME_ERROR.INVALID_FIELD_TYPE_IN_STRUCT

--- a/tests/ffi/static_checks/vmspecific_function_callbacks_negative_test.dart
+++ b/tests/ffi/static_checks/vmspecific_function_callbacks_negative_test.dart
@@ -10,25 +10,32 @@ import 'dart:ffi';
 
 final testLibrary = DynamicLibrary.process();
 
+void returnVoid() {}
+
 // Correct type of exceptionalReturn argument to Pointer.fromFunction.
 double testExceptionalReturn() {
   Pointer.fromFunction<Double Function()>(returnVoid, null);
+  //                                                  ^^^^
   // [cfe] The exceptional return value must be a 'double'.
   // [analyzer] COMPILE_TIME_ERROR.INVALID_EXCEPTION_VALUE
 
   Pointer.fromFunction<Void Function()>(returnVoid, 0);
+  //                                                ^
   // [cfe] The exceptional return value must be 'void'.
   // [analyzer] COMPILE_TIME_ERROR.INVALID_EXCEPTION_VALUE
 
   Pointer.fromFunction<Double Function()>(testExceptionalReturn, "abc");
+  //                                                             ^^^^^
   // [cfe] The exceptional return value must be a 'double'.
   // [analyzer] COMPILE_TIME_ERROR.INVALID_EXCEPTION_VALUE
 
   Pointer.fromFunction<Double Function()>(testExceptionalReturn, 0);
+  //                                                             ^
   // [cfe] The exceptional return value must be a 'double'.
   // [analyzer] COMPILE_TIME_ERROR.INVALID_EXCEPTION_VALUE
 
   Pointer.fromFunction<Double Function()>(testExceptionalReturn);
+  //      ^^^^^^^^^^^^
   // [cfe] The exceptional return value must be a 'double'.
   // [analyzer] COMPILE_TIME_ERROR.MISSING_EXCEPTION_VALUE
 

--- a/tests/ffi/static_checks/vmspecific_function_callbacks_negative_test.dart
+++ b/tests/ffi/static_checks/vmspecific_function_callbacks_negative_test.dart
@@ -4,8 +4,6 @@
 //
 // Dart test program for testing dart:ffi function pointers with callbacks.
 
-
-
 import 'dart:ffi';
 
 final testLibrary = DynamicLibrary.process();
@@ -17,7 +15,7 @@ double testExceptionalReturn() {
   Pointer.fromFunction<Double Function()>(returnVoid, null);
   //                                                  ^^^^
   // [cfe] The exceptional return value must be a 'double'.
-  // [analyzer] COMPILE_TIME_ERROR.INVALID_EXCEPTION_VALUE
+  // [analyzer] COMPILE_TIME_ERROR.MUST_BE_A_SUBTYPE
 
   Pointer.fromFunction<Void Function()>(returnVoid, 0);
   //                                                ^
@@ -27,12 +25,12 @@ double testExceptionalReturn() {
   Pointer.fromFunction<Double Function()>(testExceptionalReturn, "abc");
   //                                                             ^^^^^
   // [cfe] The exceptional return value must be a 'double'.
-  // [analyzer] COMPILE_TIME_ERROR.INVALID_EXCEPTION_VALUE
+  // [analyzer] COMPILE_TIME_ERROR.MUST_BE_A_SUBTYPE
 
   Pointer.fromFunction<Double Function()>(testExceptionalReturn, 0);
   //                                                             ^
   // [cfe] The exceptional return value must be a 'double'.
-  // [analyzer] COMPILE_TIME_ERROR.INVALID_EXCEPTION_VALUE
+  // [analyzer] COMPILE_TIME_ERROR.MUST_BE_A_SUBTYPE
 
   Pointer.fromFunction<Double Function()>(testExceptionalReturn);
   //      ^^^^^^^^^^^^

--- a/tests/ffi/static_checks/vmspecific_function_callbacks_negative_test.dart
+++ b/tests/ffi/static_checks/vmspecific_function_callbacks_negative_test.dart
@@ -4,8 +4,7 @@
 //
 // Dart test program for testing dart:ffi function pointers with callbacks.
 
-// Formatting can break multitests, so don't format them.
-// dart format off
+
 
 import 'dart:ffi';
 
@@ -13,11 +12,25 @@ final testLibrary = DynamicLibrary.process();
 
 // Correct type of exceptionalReturn argument to Pointer.fromFunction.
 double testExceptionalReturn() {
-  Pointer.fromFunction<Double Function()>(returnVoid, null); //# 59: compile-time error
-  Pointer.fromFunction<Void Function()>(returnVoid, 0); //# 60: compile-time error
-  Pointer.fromFunction<Double Function()>(testExceptionalReturn, "abc"); //# 61: compile-time error
-  Pointer.fromFunction<Double Function()>(testExceptionalReturn, 0); //# 62: compile-time error
-  Pointer.fromFunction<Double Function()>(testExceptionalReturn); //# 63: compile-time error
+  Pointer.fromFunction<Double Function()>(returnVoid, null);
+  // [cfe] The exceptional return value must be a 'double'.
+  // [analyzer] COMPILE_TIME_ERROR.INVALID_EXCEPTION_VALUE
+
+  Pointer.fromFunction<Void Function()>(returnVoid, 0);
+  // [cfe] The exceptional return value must be 'void'.
+  // [analyzer] COMPILE_TIME_ERROR.INVALID_EXCEPTION_VALUE
+
+  Pointer.fromFunction<Double Function()>(testExceptionalReturn, "abc");
+  // [cfe] The exceptional return value must be a 'double'.
+  // [analyzer] COMPILE_TIME_ERROR.INVALID_EXCEPTION_VALUE
+
+  Pointer.fromFunction<Double Function()>(testExceptionalReturn, 0);
+  // [cfe] The exceptional return value must be a 'double'.
+  // [analyzer] COMPILE_TIME_ERROR.INVALID_EXCEPTION_VALUE
+
+  Pointer.fromFunction<Double Function()>(testExceptionalReturn);
+  // [cfe] The exceptional return value must be a 'double'.
+  // [analyzer] COMPILE_TIME_ERROR.MISSING_EXCEPTION_VALUE
 
   return 0.0; // not used
 }

--- a/tests/ffi/static_checks/vmspecific_regress_38993_test.dart
+++ b/tests/ffi/static_checks/vmspecific_regress_38993_test.dart
@@ -4,13 +4,14 @@
 //
 // Tests a compile time error that should not crash the analyzer or CFE.
 
-// Formatting can break multitests, so don't format them.
-// dart format off
+
 
 import "dart:ffi";
 
 final class C extends Struct {
-  dynamic x; //# 1: compile-time error
+  dynamic x;
+  // [cfe] Field 'x' must have a native type.
+  // [analyzer] COMPILE_TIME_ERROR.INVALID_FIELD_TYPE_IN_STRUCT
 
   external Pointer notEmpty;
 }

--- a/tests/ffi/static_checks/vmspecific_regress_38993_test.dart
+++ b/tests/ffi/static_checks/vmspecific_regress_38993_test.dart
@@ -4,12 +4,11 @@
 //
 // Tests a compile time error that should not crash the analyzer or CFE.
 
-
-
 import "dart:ffi";
 
 final class C extends Struct {
   dynamic x;
+  //      ^
   // [cfe] Field 'x' must have a native type.
   // [analyzer] COMPILE_TIME_ERROR.INVALID_FIELD_TYPE_IN_STRUCT
 

--- a/tests/ffi/static_checks/vmspecific_static_checks_ffinative_test.dart
+++ b/tests/ffi/static_checks/vmspecific_static_checks_ffinative_test.dart
@@ -2,9 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// Formatting can break multitests, so don't format them.
-// dart format off
-
 import 'dart:ffi';
 import 'dart:nativewrappers';
 
@@ -13,65 +10,96 @@ void main() {
 }
 
 // Error: FFI leaf call must not have Handle return type.
-@Native<Handle Function()>(symbol: "foo", isLeaf: true) //# 01: compile-time error
-external Object foo(); //# 01: compile-time error
+@Native<Handle Function()>(symbol: "foo", isLeaf: true)
+external Object foo();
+// [cfe] FFI leaf call must not have Handle return type.
+// [analyzer] COMPILE_TIME_ERROR.FFI_LEAF_CALL_MUST_NOT_HAVE_HANDLE_RETURN_TYPE
 
 // Error: FFI leaf call must not have Handle argument types.
-@Native<Void Function(Handle)>(symbol: "bar", //# 02: compile-time error
-    isLeaf: true) //# 02: compile-time error
-external void bar(Object); //# 02: compile-time error
+@Native<Void Function(Handle)>(symbol: "bar",
+    isLeaf: true)
+external void bar(Object o);
+// [cfe] FFI leaf call must not have Handle argument types.
+// [analyzer] COMPILE_TIME_ERROR.FFI_LEAF_CALL_MUST_NOT_HAVE_HANDLE_ARGUMENT_TYPES
 
 class Classy {
   // Error: Missing receiver in Native annotation.
-  @Native<Void Function(IntPtr)>(symbol: 'doesntmatter') //# 03: compile-time error
-  external void badMissingReceiver(int v); //# 03: compile-time error
+  @Native<Void Function(IntPtr)>(symbol: 'doesntmatter')
+  external void badMissingReceiver(int v);
+  // [cfe] Native instance methods must have a receiver.
+  // [analyzer] COMPILE_TIME_ERROR.NATIVE_INSTANCE_METHOD_MISSING_RECEIVER
 
   // Error: Class doesn't extend NativeFieldWrapperClass1 - can't be converted
   // to Pointer.
-  @Native<Void Function(Pointer<Void>, IntPtr)>(//# 04: compile-time error
-      symbol: 'doesntmatter') //# 04: compile-time error
-  external void badHasReceiverPointer(int v); //# 04: compile-time error
+  @Native<Void Function(Pointer<Void>, IntPtr)>(
+      symbol: 'doesntmatter')
+  external void badHasReceiverPointer(int v);
+  // [cfe] Class 'Classy' must extend 'NativeFieldWrapperClass1' to be used as a receiver.
+  // [analyzer] COMPILE_TIME_ERROR.INVALID_NATIVE_RECEIVER
 }
 
 base class NativeClassy extends NativeFieldWrapperClass1 {
   // Error: Missing receiver in Native annotation.
-  @Native<Void Function(IntPtr)>(symbol: 'doesntmatter') //# 05: compile-time error
-  external void badMissingReceiver(int v); //# 05: compile-time error
+  @Native<Void Function(IntPtr)>(symbol: 'doesntmatter')
+  external void badMissingReceiver(int v);
+  // [cfe] Native instance methods must have a receiver.
+  // [analyzer] COMPILE_TIME_ERROR.NATIVE_INSTANCE_METHOD_MISSING_RECEIVER
 
   // Error: wrong return type.
-  @Native<Handle Function(Pointer<Void>, Uint32, Uint32, Handle)>(symbol: 'doesntmatter') //# 49471: compile-time error
-  external void toImageSync(int width, int height, Object outImage);  //# 49471: compile-time error
+  @Native<Handle Function(Pointer<Void>, Uint32, Uint32, Handle)>(symbol: 'doesntmatter')
+  external void toImageSync(int width, int height, Object outImage);
+  // [cfe] Expected return type 'Object', 'dynamic' or 'void', but got 'Handle'.
+  // [analyzer] COMPILE_TIME_ERROR.INVALID_RETURN_TYPE
 }
 
 // Error: Too many Native parameters.
-@Native<Handle Function(IntPtr, IntPtr)>(//# 06: compile-time error
-    symbol: 'doesntmatter') //# 06: compile-time error
-external Object badTooManyFfiParameter(int v); //# 06: compile-time error
+@Native<Handle Function(IntPtr, IntPtr)>(
+    symbol: 'doesntmatter')
+external Object badTooManyFfiParameter(int v);
+// [cfe] Expected 1 parameters in 'Native' annotation, but got 2.
+// [analyzer] COMPILE_TIME_ERROR.MISMATCHED_ANNOTATION_PARAMETERS
 
 // Error: Too few Native parameters.
-@Native<Handle Function(IntPtr)>(symbol: 'doesntmatter') //# 07: compile-time error
-external Object badTooFewFfiParameter(int v, int v2); //# 07: compile-time error
+@Native<Handle Function(IntPtr)>(symbol: 'doesntmatter')
+external Object badTooFewFfiParameter(int v, int v2);
+// [cfe] Expected 2 parameters in 'Native' annotation, but got 1.
+// [analyzer] COMPILE_TIME_ERROR.MISMATCHED_ANNOTATION_PARAMETERS
 
 // Error: Natives must be marked external (and by extension have no body).
-@Native<Void Function()>(symbol: 'doesntmatter') //# 08: compile-time error
-void mustBeMarkedExternal() {} //# 08: compile-time error
+@Native<Void Function()>(symbol: 'doesntmatter')
+void mustBeMarkedExternal() {}
+// [cfe] Native functions must be marked external.
+// [analyzer] COMPILE_TIME_ERROR.NATIVE_FUNCTION_BODY_IN_NON_SDK
 
 // Error: 'Native' can't be declared with optional parameters.
-@Native<Void Function([Double])>(symbol: 'doesntmatter') //# 12: compile-time error
-external static int badOptParam(); //# 12: compile-time error
+@Native<Void Function([Double])>(symbol: 'doesntmatter')
+external static int badOptParam();
+// [cfe] Native functions cannot have optional parameters.
+// [analyzer] COMPILE_TIME_ERROR.OPTIONAL_PARAMETER_IN_NATIVE_FUNCTION
 
 // Error: 'Native' can't be declared with named parameters.
-@Native<Void Function({Double})>(symbol: 'doesntmatter') //# 13: compile-time error
-external static int badNamedParam(); //# 13: compile-time error
+@Native<Void Function({Double})>(symbol: 'doesntmatter')
+external static int badNamedParam();
+// [cfe] Native functions cannot have named parameters.
+// [analyzer] COMPILE_TIME_ERROR.NAMED_PARAMETER_IN_NATIVE_FUNCTION
 
-@Native<IntPtr Function(Double)>(symbol: 'doesntmatter') //# 14: compile-time error
-external int wrongFfiParameter(int v); //# 14: compile-time error
+@Native<IntPtr Function(Double)>(symbol: 'doesntmatter')
+external int wrongFfiParameter(int v);
+// [cfe] Expected type 'double', but got 'int'.
+// [analyzer] COMPILE_TIME_ERROR.MUST_BE_A_SUBTYPE
 
-@Native<IntPtr Function(IntPtr)>(symbol: 'doesntmatter') //# 15: compile-time error
-external double wrongFfiReturnType(int v); //# 15: compile-time error
+@Native<IntPtr Function(IntPtr)>(symbol: 'doesntmatter')
+external double wrongFfiReturnType(int v);
+// [cfe] Expected type 'int', but got 'double'.
+// [analyzer] COMPILE_TIME_ERROR.MUST_BE_A_SUBTYPE
 
-@Native<IntPtr Function(int)>(symbol: 'doesntmatter') //# 16: compile-time error
-external int nonFfiParameter(int v); //# 16: compile-time error
+@Native<IntPtr Function(int)>(symbol: 'doesntmatter')
+external int nonFfiParameter(int v);
+// [cfe] The type 'int' is not a valid FFI type.
+// [analyzer] COMPILE_TIME_ERROR.INVALID_FFI_TYPE
 
-@Native<double Function(IntPtr)>(symbol: 'doesntmatter') //# 17: compile-time error
-external double nonFfiReturnType(int v); //# 17: compile-time error
+@Native<double Function(IntPtr)>(symbol: 'doesntmatter')
+external double nonFfiReturnType(int v);
+// [cfe] The type 'double' is not a valid FFI type.
+// [analyzer] COMPILE_TIME_ERROR.INVALID_FFI_TYPE
+

--- a/tests/ffi/static_checks/vmspecific_static_checks_ffinative_test.dart
+++ b/tests/ffi/static_checks/vmspecific_static_checks_ffinative_test.dart
@@ -12,6 +12,7 @@ void main() {
 // Error: FFI leaf call must not have Handle return type.
 @Native<Handle Function()>(symbol: "foo", isLeaf: true)
 external Object foo();
+//       ^
 // [cfe] FFI leaf call must not have Handle return type.
 // [analyzer] COMPILE_TIME_ERROR.FFI_LEAF_CALL_MUST_NOT_HAVE_HANDLE_RETURN_TYPE
 
@@ -19,6 +20,7 @@ external Object foo();
 @Native<Void Function(Handle)>(symbol: "bar",
     isLeaf: true)
 external void bar(Object o);
+//                ^
 // [cfe] FFI leaf call must not have Handle argument types.
 // [analyzer] COMPILE_TIME_ERROR.FFI_LEAF_CALL_MUST_NOT_HAVE_HANDLE_ARGUMENT_TYPES
 
@@ -26,6 +28,7 @@ class Classy {
   // Error: Missing receiver in Native annotation.
   @Native<Void Function(IntPtr)>(symbol: 'doesntmatter')
   external void badMissingReceiver(int v);
+  //            ^^^^^^^^^^^^^^^^^^
   // [cfe] Native instance methods must have a receiver.
   // [analyzer] COMPILE_TIME_ERROR.NATIVE_INSTANCE_METHOD_MISSING_RECEIVER
 
@@ -34,6 +37,7 @@ class Classy {
   @Native<Void Function(Pointer<Void>, IntPtr)>(
       symbol: 'doesntmatter')
   external void badHasReceiverPointer(int v);
+  //            ^^^^^^^^^^^^^^^^^^^^^
   // [cfe] Class 'Classy' must extend 'NativeFieldWrapperClass1' to be used as a receiver.
   // [analyzer] COMPILE_TIME_ERROR.INVALID_NATIVE_RECEIVER
 }
@@ -42,12 +46,14 @@ base class NativeClassy extends NativeFieldWrapperClass1 {
   // Error: Missing receiver in Native annotation.
   @Native<Void Function(IntPtr)>(symbol: 'doesntmatter')
   external void badMissingReceiver(int v);
+  //            ^^^^^^^^^^^^^^^^^^
   // [cfe] Native instance methods must have a receiver.
   // [analyzer] COMPILE_TIME_ERROR.NATIVE_INSTANCE_METHOD_MISSING_RECEIVER
 
   // Error: wrong return type.
   @Native<Handle Function(Pointer<Void>, Uint32, Uint32, Handle)>(symbol: 'doesntmatter')
   external void toImageSync(int width, int height, Object outImage);
+  //            ^^^^^^^^^^^
   // [cfe] Expected return type 'Object', 'dynamic' or 'void', but got 'Handle'.
   // [analyzer] COMPILE_TIME_ERROR.INVALID_RETURN_TYPE
 }
@@ -56,50 +62,59 @@ base class NativeClassy extends NativeFieldWrapperClass1 {
 @Native<Handle Function(IntPtr, IntPtr)>(
     symbol: 'doesntmatter')
 external Object badTooManyFfiParameter(int v);
+//              ^^^^^^^^^^^^^^^^^^^^^^
 // [cfe] Expected 1 parameters in 'Native' annotation, but got 2.
 // [analyzer] COMPILE_TIME_ERROR.MISMATCHED_ANNOTATION_PARAMETERS
 
 // Error: Too few Native parameters.
 @Native<Handle Function(IntPtr)>(symbol: 'doesntmatter')
 external Object badTooFewFfiParameter(int v, int v2);
+//              ^^^^^^^^^^^^^^^^^^^^^
 // [cfe] Expected 2 parameters in 'Native' annotation, but got 1.
 // [analyzer] COMPILE_TIME_ERROR.MISMATCHED_ANNOTATION_PARAMETERS
 
 // Error: Natives must be marked external (and by extension have no body).
 @Native<Void Function()>(symbol: 'doesntmatter')
 void mustBeMarkedExternal() {}
+//   ^^^^^^^^^^^^^^^^^^^^
 // [cfe] Native functions must be marked external.
 // [analyzer] COMPILE_TIME_ERROR.NATIVE_FUNCTION_BODY_IN_NON_SDK
 
 // Error: 'Native' can't be declared with optional parameters.
 @Native<Void Function([Double])>(symbol: 'doesntmatter')
 external static int badOptParam();
+//                  ^^^^^^^^^^^
 // [cfe] Native functions cannot have optional parameters.
 // [analyzer] COMPILE_TIME_ERROR.OPTIONAL_PARAMETER_IN_NATIVE_FUNCTION
 
 // Error: 'Native' can't be declared with named parameters.
 @Native<Void Function({Double})>(symbol: 'doesntmatter')
 external static int badNamedParam();
+//                  ^^^^^^^^^^^^^
 // [cfe] Native functions cannot have named parameters.
 // [analyzer] COMPILE_TIME_ERROR.NAMED_PARAMETER_IN_NATIVE_FUNCTION
 
 @Native<IntPtr Function(Double)>(symbol: 'doesntmatter')
 external int wrongFfiParameter(int v);
+//           ^^^^^^^^^^^^^^^^^
 // [cfe] Expected type 'double', but got 'int'.
 // [analyzer] COMPILE_TIME_ERROR.MUST_BE_A_SUBTYPE
 
 @Native<IntPtr Function(IntPtr)>(symbol: 'doesntmatter')
 external double wrongFfiReturnType(int v);
+//              ^^^^^^^^^^^^^^^^^^
 // [cfe] Expected type 'int', but got 'double'.
 // [analyzer] COMPILE_TIME_ERROR.MUST_BE_A_SUBTYPE
 
 @Native<IntPtr Function(int)>(symbol: 'doesntmatter')
 external int nonFfiParameter(int v);
+//           ^^^^^^^^^^^^^^^
 // [cfe] The type 'int' is not a valid FFI type.
 // [analyzer] COMPILE_TIME_ERROR.INVALID_FFI_TYPE
 
 @Native<double Function(IntPtr)>(symbol: 'doesntmatter')
 external double nonFfiReturnType(int v);
+//              ^^^^^^^^^^^^^^^^
 // [cfe] The type 'double' is not a valid FFI type.
 // [analyzer] COMPILE_TIME_ERROR.INVALID_FFI_TYPE
 

--- a/tests/ffi/static_checks/vmspecific_static_checks_varargs_test.dart
+++ b/tests/ffi/static_checks/vmspecific_static_checks_varargs_test.dart
@@ -2,8 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// Formatting can break multitests, so don't format them.
-// dart format off
+
 
 // SharedObjects=ffi_test_functions
 
@@ -15,12 +14,16 @@ void main() {
   final ffiTestFunctions = DynamicLibrary.process();
 
   // Error: a named record field.
-  print(ffiTestFunctions.lookupFunction< //# 1: compile-time error
-    Void Function(Pointer<Utf8>, VarArgs<(Int32, Int32, {Int32 foo})>), //# 1: compile-time error
-    void Function(Pointer<Utf8>, int, int)>('PassObjectToC')); //# 1: compile-time error
+  print(ffiTestFunctions.lookupFunction<
+    Void Function(Pointer<Utf8>, VarArgs<(Int32, Int32, {Int32 foo})>),
+    void Function(Pointer<Utf8>, int, int)>('PassObjectToC'));
+    // [cfe] The type argument for 'VarArgs' must be a record type with only ordinal parameters.
+    // [analyzer] COMPILE_TIME_ERROR.NON_CONSTANT_TYPE_ARGUMENT
 
   // Error: VarArgs not last.
-  print(ffiTestFunctions.lookupFunction< //# 2: compile-time error
-    Void Function(Pointer<Utf8>, VarArgs<(Int32, Int32)>, Int32), //# 2: compile-time error
-    void Function(Pointer<Utf8>, int, int, int)>('PassObjectToC')); //# 2: compile-time error
+  print(ffiTestFunctions.lookupFunction<
+    Void Function(Pointer<Utf8>, VarArgs<(Int32, Int32)>, Int32),
+    void Function(Pointer<Utf8>, int, int, int)>('PassObjectToC'));
+    // [cfe] 'VarArgs' can only be the last parameter of a function type.
+    // [analyzer] COMPILE_TIME_ERROR.VARARGS_NOT_LAST
 }

--- a/tests/ffi/static_checks/vmspecific_static_checks_varargs_test.dart
+++ b/tests/ffi/static_checks/vmspecific_static_checks_varargs_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-
-
 // SharedObjects=ffi_test_functions
 
 import 'dart:ffi';
@@ -14,16 +12,24 @@ void main() {
   final ffiTestFunctions = DynamicLibrary.process();
 
   // Error: a named record field.
-  print(ffiTestFunctions.lookupFunction<
-    Void Function(Pointer<Utf8>, VarArgs<(Int32, Int32, {Int32 foo})>),
-    void Function(Pointer<Utf8>, int, int)>('PassObjectToC'));
-    // [cfe] The type argument for 'VarArgs' must be a record type with only ordinal parameters.
-    // [analyzer] COMPILE_TIME_ERROR.NON_CONSTANT_TYPE_ARGUMENT
+  print(
+    ffiTestFunctions.lookupFunction<
+      Void Function(Pointer<Utf8>, VarArgs<(Int32, Int32, {Int32 foo})>),
+      void Function(Pointer<Utf8>, int, int)
+    >('PassObjectToC'),
+  );
+  //                           ^
+  // [cfe] The type argument for 'VarArgs' must be a record type with only ordinal parameters.
+  // [analyzer] COMPILE_TIME_ERROR.NON_CONSTANT_TYPE_ARGUMENT
 
   // Error: VarArgs not last.
-  print(ffiTestFunctions.lookupFunction<
-    Void Function(Pointer<Utf8>, VarArgs<(Int32, Int32)>, Int32),
-    void Function(Pointer<Utf8>, int, int, int)>('PassObjectToC'));
-    // [cfe] 'VarArgs' can only be the last parameter of a function type.
-    // [analyzer] COMPILE_TIME_ERROR.VARARGS_NOT_LAST
+  print(
+    ffiTestFunctions.lookupFunction<
+      Void Function(Pointer<Utf8>, VarArgs<(Int32, Int32)>, Int32),
+      void Function(Pointer<Utf8>, int, int, int)
+    >('PassObjectToC'),
+  );
+  //                           ^
+  // [cfe] 'VarArgs' can only be the last parameter of a function type.
+  // [analyzer] COMPILE_TIME_ERROR.VARARGS_NOT_LAST
 }

--- a/tests/ffi/static_checks/vmspecific_variance_function_checks_test.dart
+++ b/tests/ffi/static_checks/vmspecific_variance_function_checks_test.dart
@@ -4,8 +4,7 @@
 //
 // SharedObjects=ffi_test_functions
 
-// Formatting can break multitests, so don't format them.
-// dart format off
+
 
 import 'dart:ffi';
 
@@ -28,24 +27,30 @@ final DynamicLibrary ffiTestFunctions =
 
 final p1 =
     ffiTestFunctions.lookup<NativeFunction<Int64PointerParamOp>>(paramOpName);
-final nonInvariantBinding1 = //# 1:  compile-time error
-    p1.asFunction<NaTyPointerParamOpDart>(); //# 1:  continued
+final nonInvariantBinding1 =
+    p1.asFunction<NaTyPointerParamOpDart>();
+    // [cfe] The type 'NaTyPointerParamOpDart' isn't defined.
+    // [analyzer] COMPILE_TIME_ERROR.UNDEFINED_CLASS
 
 final p2 =
     ffiTestFunctions.lookup<NativeFunction<NaTyPointerReturnOp>>(returnOpName);
-final nonInvariantBinding2 = //# 2:  compile-time error
-    p2.asFunction<Int64PointerReturnOp>(); //# 2:  continued
+final nonInvariantBinding2 =
+    p2.asFunction<Int64PointerReturnOp>();
+    // [cfe] Expected type 'Pointer<NativeType>', but got 'Pointer<Int64>'.
+    // [analyzer] COMPILE_TIME_ERROR.MUST_BE_A_SUBTYPE
 
 final p3 = Pointer<
     NativeFunction<
         Pointer<NativeFunction<Pointer<NativeType> Function()>>
             Function()>>.fromAddress(0x1234);
-final f3 = p3 //# 10:  compile-time error
-    .asFunction< //# 10:  continued
-        Pointer< //# 10:  continued
-                NativeFunction< //# 10:  continued
-                    Pointer<Int8> Function()>> //# 10:  continued
-            Function()>(); //# 10:  continued
+final f3 = p3
+    .asFunction<
+        Pointer<
+                NativeFunction<
+                    Pointer<Int8> Function()>>
+            Function()>();
+    // [cfe] Expected type 'Pointer<NativeFunction<Pointer<NativeType> Function()>>', but got 'Pointer<NativeFunction<Pointer<Int8> Function()>>'.
+    // [analyzer] COMPILE_TIME_ERROR.MUST_BE_A_SUBTYPE
 
 // ===========================================================
 // Test check on callbacks from native to Dart (fromFunction).
@@ -59,11 +64,15 @@ Pointer<NativeType> naTyPointerReturnOp() {
   return Pointer.fromAddress(0x13370000);
 }
 
-final implicitDowncast1 = //# 3:  compile-time error
-    Pointer.fromFunction<NaTyPointerParamOp>(//# 3:  continued
-        naTyPointerParamOp); //# 3:  continued
-final implicitDowncast2 = //# 4:  compile-time error
-    Pointer.fromFunction<Int64PointerReturnOp>(//# 4:  continued
-        naTyPointerReturnOp); //# 4:  continued
+final implicitDowncast1 =
+    Pointer.fromFunction<NaTyPointerParamOp>(
+        naTyPointerParamOp);
+    // [cfe] Expected type 'void Function(Pointer<NativeType>)', but got 'void Function(Pointer<Int64>)'.
+    // [analyzer] COMPILE_TIME_ERROR.MUST_BE_A_SUBTYPE
+final implicitDowncast2 =
+    Pointer.fromFunction<Int64PointerReturnOp>(
+        naTyPointerReturnOp);
+    // [cfe] Expected type 'Pointer<Int64> Function()', but got 'Pointer<NativeType> Function()'.
+    // [analyzer] COMPILE_TIME_ERROR.MUST_BE_A_SUBTYPE
 
 void main() {}

--- a/tests/ffi/static_checks/vmspecific_variance_function_checks_test.dart
+++ b/tests/ffi/static_checks/vmspecific_variance_function_checks_test.dart
@@ -4,10 +4,7 @@
 //
 // SharedObjects=ffi_test_functions
 
-
-
 import 'dart:ffi';
-
 
 // ============================================
 // Tests checks on Dart to native (asFunction).
@@ -22,35 +19,35 @@ typedef NaTyPointerReturnOp = Pointer<NativeType> Function();
 final paramOpName = "NativeTypePointerParam";
 final returnOpName = "NativeTypePointerReturn";
 
-final DynamicLibrary ffiTestFunctions =
-    DynamicLibrary.process();
+final DynamicLibrary ffiTestFunctions = DynamicLibrary.process();
 
-final p1 =
-    ffiTestFunctions.lookup<NativeFunction<Int64PointerParamOp>>(paramOpName);
-final nonInvariantBinding1 =
-    p1.asFunction<NaTyPointerParamOpDart>();
-    // [cfe] The type 'NaTyPointerParamOpDart' isn't defined.
-    // [analyzer] COMPILE_TIME_ERROR.UNDEFINED_CLASS
+final p1 = ffiTestFunctions.lookup<NativeFunction<Int64PointerParamOp>>(
+  paramOpName,
+);
+final nonInvariantBinding1 = p1.asFunction<NaTyPointerParamOpDart>();
+//            ^^^^^^^^^^^^^^^^^^^^^^
+// [cfe] The type 'NaTyPointerParamOpDart' isn't defined.
+// [analyzer] COMPILE_TIME_ERROR.UNDEFINED_CLASS
 
-final p2 =
-    ffiTestFunctions.lookup<NativeFunction<NaTyPointerReturnOp>>(returnOpName);
-final nonInvariantBinding2 =
-    p2.asFunction<Int64PointerReturnOp>();
-    // [cfe] Expected type 'Pointer<NativeType>', but got 'Pointer<Int64>'.
-    // [analyzer] COMPILE_TIME_ERROR.MUST_BE_A_SUBTYPE
+final p2 = ffiTestFunctions.lookup<NativeFunction<NaTyPointerReturnOp>>(
+  returnOpName,
+);
+final nonInvariantBinding2 = p2.asFunction<Int64PointerReturnOp>();
+//            ^^^^^^^^^^^^^^^^^^^^
+// [cfe] Expected type 'Pointer<NativeType>', but got 'Pointer<Int64>'.
+// [analyzer] COMPILE_TIME_ERROR.MUST_BE_A_SUBTYPE
 
-final p3 = Pointer<
-    NativeFunction<
-        Pointer<NativeFunction<Pointer<NativeType> Function()>>
-            Function()>>.fromAddress(0x1234);
+final p3 =
+    Pointer<
+      NativeFunction<
+        Pointer<NativeFunction<Pointer<NativeType> Function()>> Function()
+      >
+    >.fromAddress(0x1234);
 final f3 = p3
-    .asFunction<
-        Pointer<
-                NativeFunction<
-                    Pointer<Int8> Function()>>
-            Function()>();
-    // [cfe] Expected type 'Pointer<NativeFunction<Pointer<NativeType> Function()>>', but got 'Pointer<NativeFunction<Pointer<Int8> Function()>>'.
-    // [analyzer] COMPILE_TIME_ERROR.MUST_BE_A_SUBTYPE
+    .asFunction<Pointer<NativeFunction<Pointer<Int8> Function()>> Function()>();
+//      ^^^^^^^^^^
+// [cfe] Expected type 'Pointer<NativeFunction<Pointer<NativeType> Function()>>', but got 'Pointer<NativeFunction<Pointer<Int8> Function()>>'.
+// [analyzer] COMPILE_TIME_ERROR.MUST_BE_A_SUBTYPE
 
 // ===========================================================
 // Test check on callbacks from native to Dart (fromFunction).
@@ -64,15 +61,17 @@ Pointer<NativeType> naTyPointerReturnOp() {
   return Pointer.fromAddress(0x13370000);
 }
 
-final implicitDowncast1 =
-    Pointer.fromFunction<NaTyPointerParamOp>(
-        naTyPointerParamOp);
-    // [cfe] Expected type 'void Function(Pointer<NativeType>)', but got 'void Function(Pointer<Int64>)'.
-    // [analyzer] COMPILE_TIME_ERROR.MUST_BE_A_SUBTYPE
-final implicitDowncast2 =
-    Pointer.fromFunction<Int64PointerReturnOp>(
-        naTyPointerReturnOp);
-    // [cfe] Expected type 'Pointer<Int64> Function()', but got 'Pointer<NativeType> Function()'.
-    // [analyzer] COMPILE_TIME_ERROR.MUST_BE_A_SUBTYPE
+final implicitDowncast1 = Pointer.fromFunction<NaTyPointerParamOp>(
+  int64PointerParamOp,
+);
+//  ^^^^^^^^^^^^^^^^^^
+// [cfe] Expected type 'void Function(Pointer<NativeType>)', but got 'void Function(Pointer<Int64>)'.
+// [analyzer] COMPILE_TIME_ERROR.MUST_BE_A_SUBTYPE
+final implicitDowncast2 = Pointer.fromFunction<Int64PointerReturnOp>(
+  naTyPointerReturnOp,
+);
+//  ^^^^^^^^^^^^^^^^^^^
+// [cfe] Expected type 'Pointer<Int64> Function()', but got 'Pointer<NativeType> Function()'.
+// [analyzer] COMPILE_TIME_ERROR.MUST_BE_A_SUBTYPE
 
 void main() {}

--- a/tests/ffi/unaligned_test.dart
+++ b/tests/ffi/unaligned_test.dart
@@ -2,9 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// Formatting can break multitests, so don't format them.
-// dart format off
-
 // This tests exercises misaligned reads/writes on memory.
 //
 // The only architecture on which this is known to fail is arm32 on Android.

--- a/tests/ffi/vmspecific_enable_ffi_test.dart
+++ b/tests/ffi/vmspecific_enable_ffi_test.dart
@@ -6,16 +6,16 @@
 //
 // VMOptions=--enable-ffi=false
 
-// Formatting can break multitests, so don't format them.
-// dart format off
 
-import 'dart:ffi'; //# 01: compile-time error
 
-import 'package:ffi/ffi.dart'; //# 01: compile-time error
+import 'dart:ffi'; // [cfe] Dart library 'dart:ffi' is not available on this platform.
+
+import 'package:ffi/ffi.dart'; // [cfe] TBD
 
 void main() {
-  Pointer<Int8> p = //# 01: compile-time error
-      calloc(); //# 01: compile-time error
-  print(p.address); //# 01: compile-time error
-  calloc.free(p); //# 01: compile-time error
+  Pointer<Int8> p = // [cfe] Undefined name 'Pointer'.
+  // [cfe] Undefined name 'Int8'.
+      calloc(); // [cfe] Undefined name 'calloc'.
+  print(p.address);
+  calloc.free(p); // [cfe] Undefined name 'calloc'.
 }

--- a/tests/ffi/vmspecific_enable_ffi_test.dart
+++ b/tests/ffi/vmspecific_enable_ffi_test.dart
@@ -6,16 +6,25 @@
 //
 // VMOptions=--enable-ffi=false
 
+import 'dart:ffi';
+//     ^
+// [cfe] Dart library 'dart:ffi' is not available on this platform.
 
-
-import 'dart:ffi'; // [cfe] Dart library 'dart:ffi' is not available on this platform.
-
-import 'package:ffi/ffi.dart'; // [cfe] TBD
+import 'package:ffi/ffi.dart';
+//     ^
+// [cfe] TBD
 
 void main() {
-  Pointer<Int8> p = // [cfe] Undefined name 'Pointer'.
-  // [cfe] Undefined name 'Int8'.
-      calloc(); // [cfe] Undefined name 'calloc'.
+  Pointer<Int8> p =
+      // ^
+      // [cfe] Undefined name 'Pointer'.
+      //      ^
+      // [cfe] Undefined name 'Int8'.
+      calloc();
+  // ^
+  // [cfe] Undefined name 'calloc'.
   print(p.address);
-  calloc.free(p); // [cfe] Undefined name 'calloc'.
+  calloc.free(p);
+  // ^
+  // [cfe] Undefined name 'calloc'.
 }

--- a/tests/ffi/vmspecific_function_callbacks_exit_test.dart
+++ b/tests/ffi/vmspecific_function_callbacks_exit_test.dart
@@ -12,9 +12,6 @@ import 'dart:io';
 import 'dart:ffi';
 import 'dart:isolate';
 
-// Formatting can break multitests, so don't format them.
-// dart format off
-
 import "package:expect/expect.dart";
 
 import 'callback_tests_utils.dart';

--- a/tests/ffi/vmspecific_highmem_32bit_test.dart
+++ b/tests/ffi/vmspecific_highmem_32bit_test.dart
@@ -2,9 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file
 
-// Formatting can break multitests, so don't format them.
-// dart format off
-
 import 'dart:ffi';
 import 'dart:io';
 

--- a/tests/ffi/vmspecific_leaf_call_test.dart
+++ b/tests/ffi/vmspecific_leaf_call_test.dart
@@ -4,9 +4,6 @@
 //
 // SharedObjects=ffi_test_functions
 
-// Formatting can break multitests, so don't format them.
-// dart format off
-
 import 'dart:ffi';
 import 'dart:io';
 


### PR DESCRIPTION
Removes legacy `//#` multi-test markers from various files in `sdk/tests/ffi` and `sdk/tests/ffi/static_checks`.
Updates them to use standard `// [cfe]` and `// [analyzer]` error expectations.

Fixes #60212.

- [x] I've reviewed the contributor guide and applied the relevant portions to this PR.