### PR TITLE
[analysis_server] Add document links for plugins in analysis_options.yaml

### DIFF
--- a/pkg/analysis_server/lib/src/lsp/handlers/handler_document_link.dart
+++ b/pkg/analysis_server/lib/src/lsp/handlers/handler_document_link.dart
@@ -77,7 +77,7 @@ class DocumentLinkHandler
       return _convert(link, lineInfo);
     }
 
-    var visitor = AnalysisOptionLinkComputer();
+    var visitor = AnalysisOptionLinkComputer(server.pubApi.pubHostedUrl);
     return success(
       visitor.findLinks(analysisOptionsContent).map(convert).toList(),
     );

--- a/pkg/analysis_server/test/lsp/document_link_test.dart
+++ b/pkg/analysis_server/test/lsp/document_link_test.dart
@@ -79,6 +79,60 @@ linter:
     await _test_pubspec_links(content, []);
   }
 
+  Future<void> test_analysisOptions_plugins_and_lints() async {
+    var content = '''
+analyzer:
+  plugins:
+    - /*[0*/my_plugin/*0]*/
+
+linter:
+  rules:
+    - /*[1*/await_only_futures/*1]*/
+''';
+
+    var expectedLinks = [
+      '${_pubBase}my_plugin',
+      '${_lintBase}await_only_futures',
+    ];
+
+    await _test_analysisOptions_links(content, expectedLinks);
+  }
+
+  Future<void> test_analysisOptions_plugins_list() async {
+    var content = '''
+analyzer:
+  plugins:
+    - /*[0*/dart_code_metrics/*0]*/
+    - /*[1*/custom_lint/*1]*/
+''';
+
+    var expectedLinks = [
+      '${_pubBase}dart_code_metrics',
+      '${_pubBase}custom_lint',
+    ];
+
+    await _test_analysisOptions_links(content, expectedLinks);
+  }
+
+  Future<void> test_analysisOptions_plugins_map() async {
+    var content = '''
+analyzer:
+  plugins:
+    /*[0*/dart_code_metrics/*0]*/:
+      enabled: true
+    /*[1*/custom_lint/*1]*/:
+      options:
+        foo: bar
+''';
+
+    var expectedLinks = [
+      '${_pubBase}dart_code_metrics',
+      '${_pubBase}custom_lint',
+    ];
+
+    await _test_analysisOptions_links(content, expectedLinks);
+  }
+
   Future<void> test_analysisOptions_undefinedLint() async {
     var content = '''
 linter:

--- a/pkg/analyzer_plugin/lib/src/utilities/navigation/document_links.dart
+++ b/pkg/analyzer_plugin/lib/src/utilities/navigation/document_links.dart
@@ -73,17 +73,6 @@ class AnalysisOptionLinkComputer {
     return links;
   }
 
-  /// Computes a link for the plugin named [plugin].
-  Uri? _computePluginLink(YamlNode plugin) {
-    if (plugin is! YamlScalar) return null;
-    var name = plugin.value;
-    if (name is! String || name.isEmpty) return null;
-
-    var separator = pubHostedUrl.endsWith('/') ? '' : '/';
-
-    return Uri.parse('$pubHostedUrl${separator}packages/$name');
-  }
-
   /// Computes a link for the rule named [rule].
   Uri? _computeLink(YamlNode rule) {
     if (rule is! YamlScalar) return null;
@@ -98,6 +87,17 @@ class AnalysisOptionLinkComputer {
     }
 
     return Uri.tryParse(_lintsUrl + name);
+  }
+
+  /// Computes a link for the plugin named [plugin].
+  Uri? _computePluginLink(YamlNode plugin) {
+    if (plugin is! YamlScalar) return null;
+    var name = plugin.value;
+    if (name is! String || name.isEmpty) return null;
+
+    var separator = pubHostedUrl.endsWith('/') ? '' : '/';
+
+    return Uri.parse('$pubHostedUrl${separator}packages/$name');
   }
 }
 

--- a/pkg/analyzer_plugin/lib/src/utilities/navigation/document_links.dart
+++ b/pkg/analyzer_plugin/lib/src/utilities/navigation/document_links.dart
@@ -14,8 +14,9 @@ import 'package:yaml/yaml.dart';
 /// Computes [DocumentLink]s for lint names in an 'analysis_options.yaml'.
 class AnalysisOptionLinkComputer {
   static const _lintsUrl = 'https://dart.dev/tools/linter-rules/';
+  final String pubHostedUrl;
 
-  AnalysisOptionLinkComputer();
+  AnalysisOptionLinkComputer(this.pubHostedUrl);
 
   List<DocumentLink> findLinks(String content) {
     YamlNode node;
@@ -30,7 +31,7 @@ class AnalysisOptionLinkComputer {
     var allRules = <YamlNode>[
       if (node.nodes['linter'] case YamlMap dependencies)
         ...switch (dependencies.nodes['rules']) {
-          YamlMap(:var nodes) => nodes.keys.map((node) => node as YamlNode),
+          YamlMap(:var nodes) => nodes.keys.cast<YamlNode>(),
           YamlList rules => rules.nodes,
           _ => const <YamlNode>[],
         },
@@ -47,7 +48,40 @@ class AnalysisOptionLinkComputer {
       }
     }
 
+    var allPlugins = <YamlNode>[
+      if (node.nodes['analyzer'] case YamlMap analyzer)
+        if (analyzer.nodes['plugins'] case YamlNode plugins)
+          ...switch (plugins) {
+            YamlMap(:var nodes) => nodes.keys.cast<YamlNode>(),
+            YamlList plugins => plugins.nodes,
+            _ => const <YamlNode>[],
+          },
+    ];
+
+    for (final plugin in allPlugins) {
+      var pluginLink = _computePluginLink(plugin);
+
+      if (pluginLink != null) {
+        var offset = plugin.span.start.offset;
+        var length = plugin.span.length;
+        links.add(DocumentLink(offset, length, pluginLink));
+      }
+    }
+
+    links.sort((a, b) => a.offset.compareTo(b.offset));
+
     return links;
+  }
+
+  /// Computes a link for the plugin named [plugin].
+  Uri? _computePluginLink(YamlNode plugin) {
+    if (plugin is! YamlScalar) return null;
+    var name = plugin.value;
+    if (name is! String || name.isEmpty) return null;
+
+    var separator = pubHostedUrl.endsWith('/') ? '' : '/';
+
+    return Uri.parse('$pubHostedUrl${separator}packages/$name');
   }
 
   /// Computes a link for the rule named [rule].


### PR DESCRIPTION
Adds support for generating document links for plugins defined in `analysis_options.yaml`.

Previously, document links were only generated for linter rules. This change updates `AnalysisOptionLinkComputer` to detect plugins listed under the `analyzer: plugins:` section and generate links to their package page on pub.dev (or the configured `pubHostedUrl`).

It supports both plugin definitions:
- List format (`- plugin_name`)
- Map format (`plugin_name: options`)

Fixes #62387

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] I've implemented new tests that cover the changes.
- [x] I've signed the Google CLA.