### PR TITLE
[io/http] Fix race condition where RawSecureSocket dispatches read events after shutdown

### DIFF
--- a/sdk/lib/io/secure_socket.dart
+++ b/sdk/lib/io/secure_socket.dart
@@ -1177,6 +1177,7 @@ class _RawSecureSocket extends Stream<RawSocketEvent>
   // If a read event should be sent, add it to the controller.
   _scheduleReadEvent() {
     if (!_pendingReadEvent &&
+        !_closedRead &&
         _readEventsEnabled &&
         _pauseCount == 0 &&
         _secureFilter != null &&
@@ -1189,6 +1190,7 @@ class _RawSecureSocket extends Stream<RawSocketEvent>
   _sendReadEvent() {
     _pendingReadEvent = false;
     if (_status != closedStatus &&
+        !_closedRead &&
         _readEventsEnabled &&
         _pauseCount == 0 &&
         _secureFilter != null &&

--- a/tests/standalone/io/regress_62514_test.dart
+++ b/tests/standalone/io/regress_62514_test.dart
@@ -1,0 +1,57 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+//
+// OtherResources=certificates/server_chain.pem
+// OtherResources=certificates/server_key.pem
+
+// Test that cancellation of subscription to [SecureSocket] works as
+// expected.
+
+import 'dart:async';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:async_helper/async_helper.dart';
+import 'package:expect/expect.dart';
+
+String relativeToScript(path) => Platform.script.resolve(path).toFilePath();
+
+final String serverCert = relativeToScript('certificates/server_chain.pem');
+final String serverKey = relativeToScript('certificates/server_key.pem');
+
+void main() {
+  asyncTest(() async {
+    final serverContext = SecurityContext()
+      ..useCertificateChain(serverCert)
+      ..usePrivateKey(serverKey, password: 'dartdart');
+
+    final secureServer = await SecureServerSocket.bind(
+      InternetAddress.loopbackIPv4,
+      0,
+      serverContext,
+    );
+
+    final dataStream = Stream.fromIterable(
+      Iterable<List<int>>.generate(100, (_) => Uint8List(1024 * 1024)),
+    );
+
+    secureServer.listen((client) async {
+      await dataStream.pipe(client);
+      await client.close();
+    });
+
+    final secureClient = await SecureSocket.connect(
+      InternetAddress.loopbackIPv4,
+      secureServer.port,
+      context: SecurityContext()..setTrustedCertificates(serverCert),
+    );
+    late final StreamSubscription clientSub;
+    clientSub = secureClient.listen((event) async {
+      clientSub.cancel();
+    });
+    await clientSub.asFuture();
+
+    await Future.wait([secureClient.close(), secureServer.close()]);
+  });
+}


### PR DESCRIPTION
This PR resolves an issue where `RawSecureSocket` potentially emits a `RawSocketEvent.read` event after the read-side of the socket has been closed. The receiver would then attempt to read from the socket, which throws `SocketException: Reading from a closed socket`.

Issue: https://github.com/dart-lang/sdk/issues/62514


---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
