### PR TITLE
JSON and UTF-8 fast paths

### DIFF
--- a/runtime/lib/string.cc
+++ b/runtime/lib/string.cc
@@ -14,7 +14,23 @@
 #include "vm/object_store.h"
 #include "vm/symbols.h"
 
+#if defined(TARGET_ARCH_ARM64)
+#include <arm_neon.h>
+#endif
+#include <cstdint>
+
 namespace dart {
+
+class NativeStringDataAccess {
+ public:
+  static uint8_t* OneByteDataStart(const String& str) {
+    return OneByteString::DataStart(str);
+  }
+
+  static uint16_t* TwoByteDataStart(const String& str) {
+    return TwoByteString::DataStart(str);
+  }
+};
 
 DEFINE_NATIVE_ENTRY(String_fromEnvironment, 0, 3) {
   GET_NON_NULL_NATIVE_ARGUMENT(String, name, arguments->NativeArgAt(1));
@@ -98,6 +114,1559 @@ DEFINE_NATIVE_ENTRY(StringBase_substringUnchecked, 0, 3) {
   intptr_t start = start_obj.Value();
   intptr_t end = end_obj.Value();
   return String::SubString(receiver, start, (end - start));
+}
+
+static intptr_t FindJsonStringTerminatorOneByte(const uint8_t* data,
+                                                intptr_t start,
+                                                intptr_t end) {
+  const uint8_t* cursor = data + start;
+  const uint8_t* limit = data + end;
+
+#if defined(TARGET_ARCH_ARM64)
+  if (end - start >= 16) {
+    const uint8_t* simd_end = limit - 16;
+    const uint8x16_t quote = vdupq_n_u8('"');
+    const uint8x16_t backslash = vdupq_n_u8('\\');
+    const uint8x16_t space = vdupq_n_u8(0x20);
+    while (cursor <= simd_end) {
+      const uint8x16_t block = vld1q_u8(cursor);
+      const uint8x16_t is_quote = vceqq_u8(block, quote);
+      const uint8x16_t is_backslash = vceqq_u8(block, backslash);
+      const uint8x16_t is_ctrl = vcltq_u8(block, space);
+      const uint8x16_t mask =
+          vorrq_u8(is_ctrl, vorrq_u8(is_quote, is_backslash));
+      if (vmaxvq_u8(mask) != 0) {
+        alignas(16) uint8_t lanes[16];
+        vst1q_u8(lanes, mask);
+        for (intptr_t i = 0; i < 16; i++) {
+          if (lanes[i] != 0) return (cursor - data) + i;
+        }
+      }
+      cursor += 16;
+    }
+  }
+#endif
+
+  while (cursor < limit) {
+    const uint8_t ch = *cursor;
+    if (ch == '"' || ch == '\\' || ch < 0x20) break;
+    cursor++;
+  }
+  return cursor - data;
+}
+
+static intptr_t FindJsonStringTerminatorTwoByte(const uint16_t* data,
+                                                intptr_t start,
+                                                intptr_t end) {
+  const uint16_t* cursor = data + start;
+  const uint16_t* limit = data + end;
+
+#if defined(TARGET_ARCH_ARM64) && !defined(DEBUG)
+  if (end - start >= 8) {
+    const uint16_t* simd_end = limit - 8;
+    const uint16x8_t quote = vdupq_n_u16('"');
+    const uint16x8_t backslash = vdupq_n_u16('\\');
+    const uint16x8_t space = vdupq_n_u16(0x20);
+    while (cursor <= simd_end) {
+      const uint16x8_t block = vld1q_u16(cursor);
+      const uint16x8_t is_quote = vceqq_u16(block, quote);
+      const uint16x8_t is_backslash = vceqq_u16(block, backslash);
+      const uint16x8_t is_ctrl = vcltq_u16(block, space);
+      const uint16x8_t mask =
+          vorrq_u16(is_ctrl, vorrq_u16(is_quote, is_backslash));
+      if (vmaxvq_u16(mask) != 0) {
+        alignas(16) uint16_t lanes[8];
+        vst1q_u16(lanes, mask);
+        for (intptr_t i = 0; i < 8; i++) {
+          if (lanes[i] != 0) return (cursor - data) + i;
+        }
+      }
+      cursor += 8;
+    }
+  }
+#endif
+
+  while (cursor < limit) {
+    const uint16_t ch = *cursor;
+    if (ch == '"' || ch == '\\' || ch < 0x20) break;
+    cursor++;
+  }
+  return cursor - data;
+}
+
+static constexpr uint32_t kUnusedPair = 0;
+static constexpr uint32_t kDeletedPair = 1;
+
+static inline uint32_t HashPattern(uint32_t full_hash,
+                                   uint32_t hash_mask,
+                                   intptr_t size) {
+  const uint32_t masked = full_hash & hash_mask;
+  return masked == 0 ? static_cast<uint32_t>(size >> 1)
+                     : masked * static_cast<uint32_t>(size >> 1);
+}
+
+static inline intptr_t FirstProbe(uint32_t full_hash, intptr_t size_mask) {
+  intptr_t i = full_hash & static_cast<uint32_t>(size_mask);
+  return ((i << 1) + i) & size_mask;
+}
+
+class JsonMapBuilder {
+ public:
+  JsonMapBuilder(Thread* thread, Zone* zone)
+      : thread_(thread),
+        zone_(zone),
+        data_(Array::Handle(zone_)),
+        index_(TypedData::Handle(zone_)),
+        existing_key_obj_(Object::Handle(zone_)),
+        size_(0),
+        size_mask_(0),
+        max_entries_(0),
+        used_pairs_(0),
+        hash_mask_(0) {
+    Init(LinkedHashBase::kInitialIndexSize);
+  }
+
+  void Add(const String& key, const Object& value) {
+    if (used_pairs_ >= max_entries_) {
+      Grow();
+    }
+    Insert(key, value);
+  }
+
+  MapPtr Build(const TypeArguments& type_args) const {
+    const Map& map = Map::Handle(
+        zone_, Map::New(kMapCid, data_, index_, hash_mask_, used_pairs_ << 1, 0,
+                        Heap::kNew));
+    map.SetTypeArguments(type_args);
+    return map.ptr();
+  }
+
+  const TypedData& index() const { return index_; }
+  intptr_t index_size() const { return size_; }
+
+ private:
+  void Init(intptr_t size) {
+    size_ = size;
+    size_mask_ = size_ - 1;
+    max_entries_ = size_ >> 1;
+    data_ = Array::New(size_);
+    index_ = TypedData::New(kTypedDataUint32ArrayCid, size_);
+    hash_mask_ = static_cast<uint32_t>(
+        LinkedHashBase::IndexSizeToHashMask(size_));
+
+    NoSafepointScope no_safepoint;
+    memset(Array::DataOf(data_.ptr()), 0,
+           size_ * sizeof(CompressedObjectPtr));
+    memset(index_.DataAddr(0), 0, size_ * sizeof(uint32_t));
+    used_pairs_ = 0;
+  }
+
+  void Grow() {
+    const Array& old_data = Array::Handle(zone_, data_.ptr());
+    const intptr_t old_used_pairs = used_pairs_;
+    Init(size_ << 1);
+    for (intptr_t i = 0; i < old_used_pairs; i++) {
+      const intptr_t d = i << 1;
+      const String& key = String::Cast(Object::Handle(zone_, old_data.At(d)));
+      const Object& value = Object::Handle(zone_, old_data.At(d + 1));
+      Insert(key, value);
+    }
+  }
+
+  void Insert(const String& key, const Object& value) {
+    const uint32_t full_hash = static_cast<uint32_t>(key.Hash());
+    const uint32_t hash_pattern = HashPattern(full_hash, hash_mask_, size_);
+    intptr_t probe = FirstProbe(full_hash, size_mask_);
+    NoSafepointScope no_safepoint;
+    uint32_t* index_data =
+        reinterpret_cast<uint32_t*>(index_.DataAddr(0));
+    while (true) {
+      const uint32_t entry = index_data[probe];
+      if (entry == kUnusedPair) {
+        index_data[probe] = hash_pattern ^ static_cast<uint32_t>(used_pairs_);
+        data_.SetAt(used_pairs_ << 1, key, thread_);
+        data_.SetAt((used_pairs_ << 1) + 1, value, thread_);
+        used_pairs_++;
+        return;
+      }
+      if (entry != kDeletedPair) {
+        const intptr_t entry_index =
+            static_cast<intptr_t>(hash_pattern ^ entry);
+        if (entry_index < max_entries_) {
+          const intptr_t d = entry_index << 1;
+          const ObjectPtr existing_key = data_.At(d);
+          if (existing_key == key.ptr()) {
+            data_.SetAt(d + 1, value, thread_);
+            return;
+          }
+          existing_key_obj_ = existing_key;
+          if (String::Cast(existing_key_obj_).Equals(key)) {
+            data_.SetAt(d + 1, value, thread_);
+            return;
+          }
+        }
+      }
+      probe = (probe + 1) & size_mask_;
+    }
+  }
+
+  Thread* thread_;
+  Zone* zone_;
+  Array& data_;
+  TypedData& index_;
+  Object& existing_key_obj_;
+  intptr_t size_;
+  intptr_t size_mask_;
+  intptr_t max_entries_;
+  intptr_t used_pairs_;
+  uint32_t hash_mask_;
+};
+
+class JsonArrayBuilder {
+ public:
+  JsonArrayBuilder(Thread* thread, Zone* zone, intptr_t initial_capacity = 16)
+      : thread_(thread),
+        zone_(zone),
+        array_(Array::Handle(zone_, Array::New(initial_capacity))),
+        length_(0) {}
+
+  void Add(const Object& value) {
+    if (length_ == array_.Length()) {
+      Grow();
+    }
+    array_.SetAt(length_, value, thread_);
+    length_++;
+  }
+
+  ObjectPtr Build() const {
+    const GrowableObjectArray& list =
+        GrowableObjectArray::Handle(zone_, GrowableObjectArray::New(array_));
+    list.SetLength(length_);
+    return list.ptr();
+  }
+
+ private:
+  void Grow() {
+    const intptr_t old_capacity = array_.Length();
+    const intptr_t new_capacity = (old_capacity * 2) | 1;
+    array_ = Array::Grow(array_, new_capacity, Heap::kNew);
+  }
+
+  Thread* thread_;
+  Zone* zone_;
+  Array& array_;
+  intptr_t length_;
+};
+
+static MapPtr BuildMapFromPairs(Thread* thread,
+                                const Array& pair_data,
+                                intptr_t pair_len,
+                                const TypeArguments& type_args) {
+  Zone* zone = thread->zone();
+  intptr_t size = 1;
+  while (size < pair_len) {
+    size <<= 1;
+  }
+  if (size < LinkedHashBase::kInitialIndexSize) {
+    size = LinkedHashBase::kInitialIndexSize;
+  }
+
+  const Array& data = Array::Handle(zone, Array::New(size));
+  const TypedData& index =
+      TypedData::Handle(zone, TypedData::New(kTypedDataUint32ArrayCid, size));
+  const uint32_t hash_mask = static_cast<uint32_t>(
+      LinkedHashBase::IndexSizeToHashMask(size));
+  const intptr_t size_mask = size - 1;
+  const intptr_t max_entries = size >> 1;
+
+  {
+    NoSafepointScope no_safepoint;
+    memset(Array::DataOf(data.ptr()), 0,
+           size * sizeof(CompressedObjectPtr));
+    memset(index.DataAddr(0), 0, size * sizeof(uint32_t));
+  }
+
+  intptr_t used_pairs = 0;
+  Object& key_obj = Object::Handle(zone);
+  Object& value_obj = Object::Handle(zone);
+  Object& existing_key_obj = Object::Handle(zone);
+  NoSafepointScope no_safepoint;
+  uint32_t* index_data =
+      reinterpret_cast<uint32_t*>(index.DataAddr(0));
+  for (intptr_t i = 0; i < pair_len; i += 2) {
+    key_obj = pair_data.At(i);
+    const String& key = String::Cast(key_obj);
+    value_obj = pair_data.At(i + 1);
+
+    const uint32_t full_hash = static_cast<uint32_t>(key.Hash());
+    const uint32_t hash_pattern = HashPattern(full_hash, hash_mask, size);
+    intptr_t probe = FirstProbe(full_hash, size_mask);
+    while (true) {
+      const uint32_t entry = index_data[probe];
+      if (entry == kUnusedPair) {
+        index_data[probe] =
+            hash_pattern ^ static_cast<uint32_t>(used_pairs);
+        data.SetAt(used_pairs << 1, key, thread);
+        data.SetAt((used_pairs << 1) + 1, value_obj, thread);
+        used_pairs++;
+        break;
+      }
+      if (entry != kDeletedPair) {
+        const intptr_t entry_index =
+            static_cast<intptr_t>(hash_pattern ^ entry);
+        if (entry_index < max_entries) {
+          const intptr_t d = entry_index << 1;
+          const ObjectPtr existing_key = data.At(d);
+          if (existing_key == key.ptr()) {
+            data.SetAt(d + 1, value_obj, thread);
+            break;
+          }
+          existing_key_obj = existing_key;
+          if (String::Cast(existing_key_obj).Equals(key)) {
+            data.SetAt(d + 1, value_obj, thread);
+            break;
+          }
+        }
+      }
+      probe = (probe + 1) & size_mask;
+    }
+  }
+
+  const Map& map = Map::Handle(
+      zone, Map::New(kMapCid, data, index, hash_mask, used_pairs << 1, 0,
+                     Heap::kNew));
+  map.SetTypeArguments(type_args);
+  return map.ptr();
+}
+
+class JsonFastParser {
+ public:
+  JsonFastParser(Thread* thread, const String& str, const Object& failure)
+      : thread_(thread),
+        zone_(thread->zone()),
+        str_(String::Handle(zone_, str.ptr())),
+        failure_(Object::Handle(zone_, failure.ptr())),
+        length_(str_.Length()),
+        pos_(0),
+        map_type_args_(TypeArguments::Handle(
+            zone_, thread_->isolate_group()->object_store()->type_argument_string_dynamic())) {}
+
+  ObjectPtr Parse() {
+    SkipWhitespace();
+    ObjectPtr value = ParseValue();
+    if (value == failure_.ptr()) return failure_.ptr();
+    SkipWhitespace();
+    if (pos_ != length_) return failure_.ptr();
+    return value;
+  }
+
+ private:
+  void SkipWhitespace() {
+    while (pos_ < length_) {
+      const uint8_t ch = OneByteString::CharAt(str_, pos_);
+      if (ch == ' ' || ch == '\n' || ch == '\r' || ch == '\t') {
+        pos_++;
+      } else {
+        break;
+      }
+    }
+  }
+
+  ObjectPtr ParseValue() {
+    SkipWhitespace();
+    if (pos_ >= length_) return failure_.ptr();
+    const uint8_t ch = OneByteString::CharAt(str_, pos_);
+    switch (ch) {
+      case '{':
+        pos_++;
+        return ParseObject();
+      case '[':
+        pos_++;
+        return ParseArray();
+      case '"':
+        return ParseString();
+      case 't':
+        return MatchKeyword("true", 4, Bool::True().ptr());
+      case 'f':
+        return MatchKeyword("false", 5, Bool::False().ptr());
+      case 'n':
+        return MatchKeyword("null", 4, Object::null());
+      default:
+        if (ch == '-' || (ch >= '0' && ch <= '9')) {
+          return ParseNumber();
+        }
+        return failure_.ptr();
+    }
+  }
+
+  ObjectPtr MatchKeyword(const char* keyword,
+                         intptr_t length,
+                         ObjectPtr value) {
+    if (pos_ + length > length_) return failure_.ptr();
+    for (intptr_t i = 0; i < length; i++) {
+      if (OneByteString::CharAt(str_, pos_ + i) != keyword[i]) {
+        return failure_.ptr();
+      }
+    }
+    pos_ += length;
+    return value;
+  }
+
+  ObjectPtr ParseObject() {
+    SkipWhitespace();
+    JsonMapBuilder map_builder(thread_, zone_);
+    Object& key_obj = Object::Handle(zone_);
+    Object& value_obj = Object::Handle(zone_);
+    if (pos_ < length_ && OneByteString::CharAt(str_, pos_) == '}') {
+      pos_++;
+      return map_builder.Build(map_type_args_);
+    }
+    while (true) {
+      SkipWhitespace();
+      if (pos_ >= length_ || OneByteString::CharAt(str_, pos_) != '"') {
+        return failure_.ptr();
+      }
+      key_obj = ParseKeyString();
+      if (key_obj.ptr() == failure_.ptr()) return failure_.ptr();
+#if defined(DEBUG)
+      ASSERT(key_obj.IsString());
+#endif
+      SkipWhitespace();
+      if (pos_ >= length_ || OneByteString::CharAt(str_, pos_) != ':') {
+        return failure_.ptr();
+      }
+      pos_++;
+      value_obj = ParseValue();
+      if (value_obj.ptr() == failure_.ptr()) return failure_.ptr();
+
+      map_builder.Add(String::Cast(key_obj), value_obj);
+
+      SkipWhitespace();
+      if (pos_ >= length_) return failure_.ptr();
+      const uint8_t ch = OneByteString::CharAt(str_, pos_);
+      if (ch == ',') {
+        pos_++;
+        continue;
+      }
+      if (ch == '}') {
+        pos_++;
+        return map_builder.Build(map_type_args_);
+      }
+      return failure_.ptr();
+    }
+  }
+
+  ObjectPtr ParseArray() {
+    SkipWhitespace();
+    JsonArrayBuilder list_builder(thread_, zone_);
+    Object& temp = Object::Handle(zone_);
+    if (pos_ < length_ && OneByteString::CharAt(str_, pos_) == ']') {
+      pos_++;
+      return list_builder.Build();
+    }
+    while (true) {
+      temp = ParseValue();
+      if (temp.ptr() == failure_.ptr()) return failure_.ptr();
+      list_builder.Add(temp);
+      SkipWhitespace();
+      if (pos_ >= length_) return failure_.ptr();
+      const uint8_t ch = OneByteString::CharAt(str_, pos_);
+      if (ch == ',') {
+        pos_++;
+        continue;
+      }
+      if (ch == ']') {
+        pos_++;
+        return list_builder.Build();
+      }
+      return failure_.ptr();
+    }
+  }
+
+  ObjectPtr ParseString() {
+    ASSERT(OneByteString::CharAt(str_, pos_) == '"');
+    pos_++;
+    const intptr_t start = pos_;
+    intptr_t scan = start;
+    {
+      NoSafepointScope no_safepoint;
+      const uint8_t* data = NativeStringDataAccess::OneByteDataStart(str_);
+      scan = FindJsonStringTerminatorOneByte(data, start, length_);
+    }
+    if (scan >= length_) return failure_.ptr();
+    const uint8_t terminator = OneByteString::CharAt(str_, scan);
+    if (terminator == '"') {
+      pos_ = scan + 1;
+      return OneByteString::SubStringUnchecked(
+          str_, start, scan - start, Heap::kNew);
+    }
+    if (terminator == '\\') {
+      return ParseStringWithEscapes(start);
+    }
+    return failure_.ptr();
+  }
+
+  ObjectPtr ParseKeyString() {
+    ASSERT(OneByteString::CharAt(str_, pos_) == '"');
+    pos_++;
+    const intptr_t start = pos_;
+    intptr_t scan = start;
+    {
+      NoSafepointScope no_safepoint;
+      const uint8_t* data = NativeStringDataAccess::OneByteDataStart(str_);
+      scan = FindJsonStringTerminatorOneByte(data, start, length_);
+    }
+    if (scan >= length_) return failure_.ptr();
+    const uint8_t terminator = OneByteString::CharAt(str_, scan);
+    if (terminator == '"') {
+      const intptr_t len = scan - start;
+      if (len > 0 && len <= 3) {
+        uint8_t buf[3];
+        bool all_digits = true;
+        for (intptr_t i = 0; i < len; i++) {
+          const uint8_t ch = OneByteString::CharAt(str_, start + i);
+          if (ch < '0' || ch > '9') {
+            all_digits = false;
+            break;
+          }
+          buf[i] = ch;
+        }
+        if (all_digits) {
+          pos_ = scan + 1;
+          return Symbols::FromLatin1(thread_, buf, len);
+        }
+      }
+      pos_ = scan + 1;
+      return OneByteString::SubStringUnchecked(
+          str_, start, scan - start, Heap::kNew);
+    }
+    if (terminator == '\\') {
+      return ParseStringWithEscapes(start);
+    }
+    return failure_.ptr();
+  }
+
+  ObjectPtr ParseNumber() {
+    const intptr_t start = pos_;
+    bool neg = false;
+    if (OneByteString::CharAt(str_, pos_) == '-') {
+      neg = true;
+      pos_++;
+      if (pos_ >= length_) return failure_.ptr();
+    }
+
+    uint8_t ch = OneByteString::CharAt(str_, pos_);
+    bool is_double = false;
+    bool overflow = false;
+    int64_t value = 0;
+    if (ch == '0') {
+      pos_++;
+      if (pos_ < length_) {
+        ch = OneByteString::CharAt(str_, pos_);
+        if (ch >= '0' && ch <= '9') return failure_.ptr();
+      }
+    } else if (ch >= '1' && ch <= '9') {
+      while (pos_ < length_) {
+        ch = OneByteString::CharAt(str_, pos_);
+        if (ch < '0' || ch > '9') break;
+        const int digit = ch - '0';
+        if (value > (INT64_MAX - digit) / 10) {
+          overflow = true;
+        } else {
+          value = value * 10 + digit;
+        }
+        pos_++;
+      }
+    } else {
+      return failure_.ptr();
+    }
+
+    if (pos_ < length_) {
+      ch = OneByteString::CharAt(str_, pos_);
+      if (ch == '.') {
+        is_double = true;
+        pos_++;
+        if (pos_ >= length_) return failure_.ptr();
+        ch = OneByteString::CharAt(str_, pos_);
+        if (ch < '0' || ch > '9') return failure_.ptr();
+        while (pos_ < length_) {
+          ch = OneByteString::CharAt(str_, pos_);
+          if (ch < '0' || ch > '9') break;
+          pos_++;
+        }
+      }
+    }
+
+    if (pos_ < length_) {
+      ch = OneByteString::CharAt(str_, pos_);
+      if (ch == 'e' || ch == 'E') {
+        is_double = true;
+        pos_++;
+        if (pos_ >= length_) return failure_.ptr();
+        ch = OneByteString::CharAt(str_, pos_);
+        if (ch == '+' || ch == '-') {
+          pos_++;
+          if (pos_ >= length_) return failure_.ptr();
+          ch = OneByteString::CharAt(str_, pos_);
+        }
+        if (ch < '0' || ch > '9') return failure_.ptr();
+        while (pos_ < length_) {
+          ch = OneByteString::CharAt(str_, pos_);
+          if (ch < '0' || ch > '9') break;
+          pos_++;
+        }
+      }
+    }
+
+    if (!is_double && !overflow) {
+      const int64_t signed_value = neg ? -value : value;
+      return Integer::New(signed_value, Heap::kNew);
+    }
+
+    const String& num_str =
+        String::Handle(zone_, String::SubString(str_, start, pos_ - start));
+    return Double::New(num_str, Heap::kNew);
+  }
+
+  ObjectPtr ParseStringWithEscapes(intptr_t start) {
+    intptr_t i = start;
+    const intptr_t max_len = length_ - start;
+    uint16_t* buffer = zone_->Alloc<uint16_t>(max_len);
+    intptr_t out = 0;
+    bool is_one_byte = true;
+    while (i < length_) {
+      uint8_t ch = OneByteString::CharAt(str_, i++);
+      if (ch == '"') {
+        pos_ = i;
+        return BuildString(buffer, out, is_one_byte);
+      }
+      if (ch == '\\') {
+        if (i >= length_) return failure_.ptr();
+        ch = OneByteString::CharAt(str_, i++);
+        switch (ch) {
+          case '"':
+          case '\\':
+          case '/':
+            break;
+          case 'b':
+            ch = '\b';
+            break;
+          case 'f':
+            ch = '\f';
+            break;
+          case 'n':
+            ch = '\n';
+            break;
+          case 'r':
+            ch = '\r';
+            break;
+          case 't':
+            ch = '\t';
+            break;
+          case 'u': {
+            if (i + 4 > length_) return failure_.ptr();
+            int value = 0;
+            for (int j = 0; j < 4; j++) {
+              const int digit = HexValue(OneByteString::CharAt(str_, i + j));
+              if (digit < 0) return failure_.ptr();
+              value = (value << 4) | digit;
+            }
+            i += 4;
+            buffer[out++] = static_cast<uint16_t>(value);
+            if (value > 0xFF) is_one_byte = false;
+            continue;
+          }
+          default:
+            return failure_.ptr();
+        }
+      } else if (ch < 0x20) {
+        return failure_.ptr();
+      }
+      buffer[out++] = ch;
+    }
+    return failure_.ptr();
+  }
+
+  static int HexValue(uint8_t ch) {
+    if (ch >= '0' && ch <= '9') return ch - '0';
+    ch |= 0x20;
+    if (ch >= 'a' && ch <= 'f') return 10 + (ch - 'a');
+    return -1;
+  }
+
+  StringPtr BuildString(uint16_t* buffer,
+                        intptr_t length,
+                        bool is_one_byte) {
+    if (is_one_byte) {
+      return OneByteString::New(buffer, length, Heap::kNew);
+    }
+    return TwoByteString::New(buffer, length, Heap::kNew);
+  }
+
+  ObjectPtr CreateMapFromPairs(const GrowableObjectArray& pairs) {
+    const Array& pair_data = Array::Handle(zone_, pairs.data());
+    return BuildMapFromPairs(thread_, pair_data, pairs.Length(), map_type_args_);
+  }
+
+  Thread* thread_;
+  Zone* zone_;
+  const String& str_;
+  const Object& failure_;
+  const intptr_t length_;
+  intptr_t pos_;
+  const TypeArguments& map_type_args_;
+};
+
+class JsonFastParserTwoByte {
+ public:
+  JsonFastParserTwoByte(Thread* thread, const String& str, const Object& failure)
+      : thread_(thread),
+        zone_(thread->zone()),
+        str_(String::Handle(zone_, str.ptr())),
+        failure_(Object::Handle(zone_, failure.ptr())),
+        length_(str_.Length()),
+        pos_(0),
+        key_cache_len_(0),
+        shape_cache_len_(0),
+        map_type_args_(TypeArguments::Handle(
+            zone_, thread_->isolate_group()->object_store()->type_argument_string_dynamic())) {
+    for (intptr_t i = 0; i < kSmallObjectMaxKeys; i++) {
+      small_keys_[i] = &Object::Handle(zone_);
+      small_values_[i] = &Object::Handle(zone_);
+    }
+    for (intptr_t i = 0; i < kKeyCacheMaxEntries; i++) {
+      key_cache_[i] = &String::Handle(zone_);
+    }
+    for (intptr_t i = 0; i < 10; i++) {
+      digit_key1_[i] = &String::Handle(zone_);
+    }
+    for (intptr_t i = 0; i < 100; i++) {
+      digit_key2_[i] = &String::Handle(zone_);
+    }
+    for (intptr_t i = 0; i < kShapeCacheMaxEntries; i++) {
+      shape_cache_[i] = &Array::Handle(zone_);
+    }
+  }
+
+  ObjectPtr Parse() {
+    AssertValidPos();
+    SkipWhitespace();
+    ObjectPtr value = ParseValue();
+    if (value == failure_.ptr()) return failure_.ptr();
+    SkipWhitespace();
+    AssertValidPos();
+    if (pos_ != length_) return failure_.ptr();
+    return value;
+  }
+
+ private:
+  void AssertValidPos() const {
+    ASSERT(pos_ >= 0);
+    ASSERT(pos_ <= length_);
+  }
+
+  void SkipWhitespace() {
+    AssertValidPos();
+    while (pos_ < length_) {
+      const uint16_t ch = TwoByteString::CharAt(str_, pos_);
+      if (ch == ' ' || ch == '\n' || ch == '\r' || ch == '\t') {
+        pos_++;
+      } else {
+        break;
+      }
+    }
+  }
+
+  ObjectPtr ParseValue() {
+    AssertValidPos();
+    SkipWhitespace();
+    return ParseValueNoWhitespace();
+  }
+
+  ObjectPtr ParseValueNoWhitespace() {
+    AssertValidPos();
+    if (pos_ >= length_) return failure_.ptr();
+    const uint16_t ch = TwoByteString::CharAt(str_, pos_);
+    switch (ch) {
+      case '{':
+        pos_++;
+        return ParseObject();
+      case '[':
+        pos_++;
+        return ParseArray();
+      case '"':
+        return ParseString();
+      case 't':
+        return MatchKeyword("true", 4, Bool::True().ptr());
+      case 'f':
+        return MatchKeyword("false", 5, Bool::False().ptr());
+      case 'n':
+        return MatchKeyword("null", 4, Object::null());
+      default:
+        if (ch == '-' || (ch >= '0' && ch <= '9')) {
+          return ParseNumber();
+        }
+        return failure_.ptr();
+    }
+  }
+
+  ObjectPtr MatchKeyword(const char* keyword,
+                         intptr_t length,
+                         ObjectPtr value) {
+    if (pos_ + length > length_) return failure_.ptr();
+    for (intptr_t i = 0; i < length; i++) {
+      if (TwoByteString::CharAt(str_, pos_ + i) != keyword[i]) {
+        return failure_.ptr();
+      }
+    }
+    pos_ += length;
+    return value;
+  }
+
+  ObjectPtr ParseObject() {
+    AssertValidPos();
+    SkipWhitespace();
+    Object& key_obj = Object::Handle(zone_);
+    Object& value_obj = Object::Handle(zone_);
+    JsonMapBuilder* map_builder = nullptr;
+    bool use_small = true;
+    intptr_t count = 0;
+    if (pos_ < length_ && TwoByteString::CharAt(str_, pos_) == '}') {
+      pos_++;
+      JsonMapBuilder empty_builder(thread_, zone_);
+      return empty_builder.Build(map_type_args_);
+    }
+    while (true) {
+      SkipWhitespace();
+      if (pos_ >= length_ || TwoByteString::CharAt(str_, pos_) != '"') {
+        return failure_.ptr();
+      }
+      key_obj = ParseKeyString();
+      if (key_obj.ptr() == failure_.ptr()) return failure_.ptr();
+#if defined(DEBUG)
+      ASSERT(key_obj.IsString());
+#endif
+      if (pos_ >= length_) return failure_.ptr();
+      uint16_t ch = TwoByteString::CharAt(str_, pos_);
+      if (ch != ':') {
+        SkipWhitespace();
+        if (pos_ >= length_ || TwoByteString::CharAt(str_, pos_) != ':') {
+          return failure_.ptr();
+        }
+      }
+      pos_++;
+      if (pos_ < length_) {
+        const uint16_t next = TwoByteString::CharAt(str_, pos_);
+        if (next == ' ' || next == '\n' || next == '\r' || next == '\t') {
+          SkipWhitespace();
+        }
+      }
+      value_obj = ParseValueNoWhitespace();
+      if (value_obj.ptr() == failure_.ptr()) return failure_.ptr();
+
+      if (use_small) {
+        const String& key = String::Cast(key_obj);
+        if (key.Length() > kKeyCacheMaxLength) {
+          use_small = false;
+        } else {
+          intptr_t dup_index = -1;
+          for (intptr_t i = 0; i < count; i++) {
+            if (small_keys_[i]->ptr() == key.ptr()) {
+              dup_index = i;
+              break;
+            }
+          }
+          if (dup_index >= 0) {
+            *small_values_[dup_index] = value_obj.ptr();
+          } else if (count < kSmallObjectMaxKeys) {
+            *small_keys_[count] = key_obj.ptr();
+            *small_values_[count] = value_obj.ptr();
+            count++;
+          } else {
+            use_small = false;
+          }
+        }
+        if (!use_small) {
+          map_builder = new (zone_->Alloc<JsonMapBuilder>(1))
+              JsonMapBuilder(thread_, zone_);
+          for (intptr_t i = 0; i < count; i++) {
+            map_builder->Add(String::Cast(*small_keys_[i]), *small_values_[i]);
+          }
+          map_builder->Add(String::Cast(key_obj), value_obj);
+        }
+      } else {
+        if (map_builder == nullptr) {
+          map_builder = new (zone_->Alloc<JsonMapBuilder>(1))
+              JsonMapBuilder(thread_, zone_);
+        }
+        map_builder->Add(String::Cast(key_obj), value_obj);
+      }
+
+      if (pos_ >= length_) return failure_.ptr();
+      ch = TwoByteString::CharAt(str_, pos_);
+      if (ch == ',') {
+        pos_++;
+        continue;
+      }
+      if (ch == '}') {
+        pos_++;
+        if (use_small) {
+          return BuildSmallObjectMap(count);
+        }
+        return map_builder->Build(map_type_args_);
+      }
+      SkipWhitespace();
+      if (pos_ >= length_) return failure_.ptr();
+      ch = TwoByteString::CharAt(str_, pos_);
+      if (ch == ',') {
+        pos_++;
+        continue;
+      }
+      if (ch == '}') {
+        pos_++;
+        if (use_small) {
+          return BuildSmallObjectMap(count);
+        }
+        return map_builder->Build(map_type_args_);
+      }
+      return failure_.ptr();
+    }
+  }
+
+  ObjectPtr ParseArray() {
+    AssertValidPos();
+    SkipWhitespace();
+    JsonArrayBuilder list_builder(thread_, zone_);
+    Object& temp = Object::Handle(zone_);
+    if (pos_ < length_ && TwoByteString::CharAt(str_, pos_) == ']') {
+      pos_++;
+      return list_builder.Build();
+    }
+    while (true) {
+      if (pos_ < length_) {
+        const uint16_t next = TwoByteString::CharAt(str_, pos_);
+        if (next == ' ' || next == '\n' || next == '\r' || next == '\t') {
+          SkipWhitespace();
+        }
+      }
+      temp = ParseValueNoWhitespace();
+      if (temp.ptr() == failure_.ptr()) return failure_.ptr();
+      list_builder.Add(temp);
+      if (pos_ >= length_) return failure_.ptr();
+      uint16_t ch = TwoByteString::CharAt(str_, pos_);
+      if (ch == ',') {
+        pos_++;
+        continue;
+      }
+      if (ch == ']') {
+        pos_++;
+        return list_builder.Build();
+      }
+      SkipWhitespace();
+      if (pos_ >= length_) return failure_.ptr();
+      ch = TwoByteString::CharAt(str_, pos_);
+      if (ch == ',') {
+        pos_++;
+        continue;
+      }
+      if (ch == ']') {
+        pos_++;
+        return list_builder.Build();
+      }
+      return failure_.ptr();
+    }
+  }
+
+  ObjectPtr ParseString() {
+    AssertValidPos();
+    ASSERT(TwoByteString::CharAt(str_, pos_) == '"');
+    pos_++;
+    const intptr_t start = pos_;
+    intptr_t scan = start;
+    {
+      NoSafepointScope no_safepoint;
+      const uint16_t* data = NativeStringDataAccess::TwoByteDataStart(str_);
+      scan = FindJsonStringTerminatorTwoByte(data, start, length_);
+    }
+    ASSERT(scan >= start);
+    if (scan >= length_) return failure_.ptr();
+    const uint16_t terminator = TwoByteString::CharAt(str_, scan);
+    if (terminator == '"') {
+      pos_ = scan + 1;
+      ASSERT(scan >= start);
+      ASSERT(scan <= length_);
+      const intptr_t len = scan - start;
+      if (len <= kValueStringOneByteMax) {
+        return BuildAsciiSubString(start, len);
+      }
+      return TwoByteString::SubStringUnchecked(str_, start, len, Heap::kNew);
+    }
+    if (terminator == '\\') {
+      return ParseStringWithEscapes(start);
+    }
+    return failure_.ptr();
+  }
+
+  ObjectPtr ParseKeyString() {
+    AssertValidPos();
+    ASSERT(TwoByteString::CharAt(str_, pos_) == '"');
+    pos_++;
+    const intptr_t start = pos_;
+    if (pos_ + 1 < length_) {
+      const uint16_t ch0 = TwoByteString::CharAt(str_, pos_);
+      if (ch0 != '"' && ch0 != '\\' && ch0 >= 0x20 && ch0 <= 0xFF) {
+        const uint16_t ch1 = TwoByteString::CharAt(str_, pos_ + 1);
+        if (ch1 == '"') {
+          pos_ += 2;
+          if (ch0 >= '0' && ch0 <= '9') {
+            return LookupOrCreateDigitKey(ch0 - '0', 0, 1);
+          }
+          return LookupOrCreateShortKey(ch0, 0, 1);
+        }
+        if (ch1 != '"' && ch1 != '\\' && ch1 >= 0x20 && ch1 <= 0xFF) {
+          if (pos_ + 2 < length_ &&
+              TwoByteString::CharAt(str_, pos_ + 2) == '"') {
+            pos_ += 3;
+            if (ch0 >= '0' && ch0 <= '9' && ch1 >= '0' && ch1 <= '9') {
+              return LookupOrCreateDigitKey(ch0 - '0', ch1 - '0', 2);
+            }
+            return LookupOrCreateShortKey(ch0, ch1, 2);
+          }
+        }
+      }
+    }
+    intptr_t scan = start;
+    {
+      NoSafepointScope no_safepoint;
+      const uint16_t* data = NativeStringDataAccess::TwoByteDataStart(str_);
+      scan = FindJsonStringTerminatorTwoByte(data, start, length_);
+    }
+    ASSERT(scan >= start);
+    if (scan >= length_) return failure_.ptr();
+    const uint16_t terminator = TwoByteString::CharAt(str_, scan);
+    if (terminator == '"') {
+      pos_ = scan + 1;
+      ASSERT(scan >= start);
+      ASSERT(scan <= length_);
+      const intptr_t len = scan - start;
+      if (len <= kKeyCacheMaxLength) {
+        for (intptr_t i = 0; i < key_cache_len_; i++) {
+          if (SliceEqualsKey(start, len, *key_cache_[i])) {
+            return key_cache_[i]->ptr();
+          }
+        }
+      }
+      const String& key =
+          String::Handle(zone_, BuildAsciiSubString(start, len));
+      if (len <= kKeyCacheMaxLength && key_cache_len_ < kKeyCacheMaxEntries) {
+        *key_cache_[key_cache_len_++] = key.ptr();
+      }
+      return key.ptr();
+    }
+    if (terminator == '\\') {
+      return ParseStringWithEscapes(start);
+    }
+    return failure_.ptr();
+  }
+
+  ObjectPtr ParseNumber() {
+    AssertValidPos();
+    const intptr_t start = pos_;
+    bool neg = false;
+    if (TwoByteString::CharAt(str_, pos_) == '-') {
+      neg = true;
+      pos_++;
+      if (pos_ >= length_) return failure_.ptr();
+    }
+
+    uint16_t ch = 0;
+    bool is_double = false;
+    bool overflow = false;
+    int64_t value = 0;
+    {
+      NoSafepointScope no_safepoint;
+      const uint16_t* data = NativeStringDataAccess::TwoByteDataStart(str_);
+      intptr_t p = pos_;
+      ch = data[p];
+      if (ch == '-') return failure_.ptr();
+      if (ch == '0') {
+        p++;
+        if (p < length_) {
+          ch = data[p];
+          if (ch >= '0' && ch <= '9') return failure_.ptr();
+        }
+      } else if (ch >= '1' && ch <= '9') {
+        while (p < length_) {
+          ch = data[p];
+          if (ch < '0' || ch > '9') break;
+          const int digit = ch - '0';
+          if (value > (INT64_MAX - digit) / 10) {
+            overflow = true;
+          } else {
+            value = value * 10 + digit;
+          }
+          p++;
+        }
+      } else {
+        return failure_.ptr();
+      }
+
+      if (p < length_) {
+        ch = data[p];
+        if (ch == '.') {
+          is_double = true;
+          p++;
+          if (p >= length_) return failure_.ptr();
+          ch = data[p];
+          if (ch < '0' || ch > '9') return failure_.ptr();
+          while (p < length_) {
+            ch = data[p];
+            if (ch < '0' || ch > '9') break;
+            p++;
+          }
+        }
+      }
+
+      if (p < length_) {
+        ch = data[p];
+        if (ch == 'e' || ch == 'E') {
+          is_double = true;
+          p++;
+          if (p >= length_) return failure_.ptr();
+          ch = data[p];
+          if (ch == '+' || ch == '-') {
+            p++;
+            if (p >= length_) return failure_.ptr();
+            ch = data[p];
+          }
+          if (ch < '0' || ch > '9') return failure_.ptr();
+          while (p < length_) {
+            ch = data[p];
+            if (ch < '0' || ch > '9') break;
+            p++;
+          }
+        }
+      }
+      pos_ = p;
+    }
+
+    if (!is_double && !overflow) {
+      const int64_t signed_value = neg ? -value : value;
+      return Integer::New(signed_value, Heap::kNew);
+    }
+
+    ASSERT(pos_ >= start);
+    const String& num_str =
+        String::Handle(zone_, BuildAsciiSubString(start, pos_ - start));
+    return Double::New(num_str, Heap::kNew);
+  }
+
+  ObjectPtr ParseStringWithEscapes(intptr_t start) {
+    AssertValidPos();
+    ASSERT(start >= 0);
+    ASSERT(start <= length_);
+    intptr_t i = start;
+    const intptr_t max_len = length_ - start;
+    uint16_t* buffer = zone_->Alloc<uint16_t>(max_len);
+    intptr_t out = 0;
+    bool is_one_byte = true;
+    while (i < length_) {
+      ASSERT(i <= length_);
+      uint16_t ch = TwoByteString::CharAt(str_, i++);
+      if (ch == '"') {
+        pos_ = i;
+        return BuildString(buffer, out, is_one_byte);
+      }
+      if (ch == '\\') {
+        if (i >= length_) return failure_.ptr();
+        ch = TwoByteString::CharAt(str_, i++);
+        switch (ch) {
+          case '"':
+          case '\\':
+          case '/':
+            break;
+          case 'b':
+            ch = '\b';
+            break;
+          case 'f':
+            ch = '\f';
+            break;
+          case 'n':
+            ch = '\n';
+            break;
+          case 'r':
+            ch = '\r';
+            break;
+          case 't':
+            ch = '\t';
+            break;
+          case 'u': {
+            if (i + 4 > length_) return failure_.ptr();
+            int value = 0;
+            for (int j = 0; j < 4; j++) {
+              const int digit = HexValue(TwoByteString::CharAt(str_, i + j));
+              if (digit < 0) return failure_.ptr();
+              value = (value << 4) | digit;
+            }
+            i += 4;
+            ch = static_cast<uint16_t>(value);
+            break;
+          }
+          default:
+            return failure_.ptr();
+        }
+      } else if (ch < 0x20) {
+        return failure_.ptr();
+      }
+      if (ch > 0xFF) is_one_byte = false;
+      ASSERT(out < max_len);
+      buffer[out++] = ch;
+    }
+    return failure_.ptr();
+  }
+
+  static int HexValue(uint16_t ch) {
+    if (ch >= '0' && ch <= '9') return ch - '0';
+    ch |= 0x20;
+    if (ch >= 'a' && ch <= 'f') return 10 + (ch - 'a');
+    return -1;
+  }
+
+  StringPtr BuildString(uint16_t* buffer,
+                        intptr_t length,
+                        bool is_one_byte) {
+    if (is_one_byte) {
+      return OneByteString::New(buffer, length, Heap::kNew);
+    }
+    return TwoByteString::New(buffer, length, Heap::kNew);
+  }
+
+  ObjectPtr CreateMapFromPairs(const GrowableObjectArray& pairs) {
+    const Array& pair_data = Array::Handle(zone_, pairs.data());
+    return BuildMapFromPairs(thread_, pair_data, pairs.Length(), map_type_args_);
+  }
+
+  ObjectPtr BuildSmallObjectMap(intptr_t count) {
+    if (count == 0) {
+      JsonMapBuilder empty_builder(thread_, zone_);
+      return empty_builder.Build(map_type_args_);
+    }
+    for (intptr_t i = 0; i < shape_cache_len_; i++) {
+      Array& shape = *shape_cache_[i];
+      if (shape.Length() != count + 2) continue;
+      bool match = true;
+      for (intptr_t j = 0; j < count; j++) {
+        if (shape.At(j + 2) != small_keys_[j]->ptr()) {
+          match = false;
+          break;
+        }
+      }
+      if (match) {
+        return BuildMapFromShape(shape, count);
+      }
+    }
+
+    JsonMapBuilder builder(thread_, zone_);
+    for (intptr_t i = 0; i < count; i++) {
+      builder.Add(String::Cast(*small_keys_[i]), *small_values_[i]);
+    }
+    const MapPtr map = builder.Build(map_type_args_);
+    if (shape_cache_len_ < kShapeCacheMaxEntries) {
+      const intptr_t size = builder.index_size();
+      const TypedData& index_copy = TypedData::Handle(
+          zone_, TypedData::New(kTypedDataUint32ArrayCid, size));
+      {
+        NoSafepointScope no_safepoint;
+        memcpy(index_copy.DataAddr(0), builder.index().DataAddr(0),
+               size * sizeof(uint32_t));
+      }
+      const Array& shape =
+          Array::Handle(zone_, Array::New(count + 2, Heap::kNew));
+      shape.SetAt(0, index_copy, thread_);
+      shape.SetAt(1, Smi::Handle(zone_, Smi::New(count)), thread_);
+      for (intptr_t i = 0; i < count; i++) {
+        shape.SetAt(i + 2, *small_keys_[i], thread_);
+      }
+      *shape_cache_[shape_cache_len_++] = shape.ptr();
+    }
+    return map;
+  }
+
+  ObjectPtr BuildMapFromShape(const Array& shape, intptr_t count) {
+    const TypedData& index_template =
+        TypedData::Cast(Object::Handle(zone_, shape.At(0)));
+    const intptr_t size = index_template.Length();
+    const uint32_t hash_mask = static_cast<uint32_t>(
+        LinkedHashBase::IndexSizeToHashMask(size));
+
+    const Array& data = Array::Handle(zone_, Array::New(size));
+    const TypedData& index =
+        TypedData::Handle(zone_, TypedData::New(kTypedDataUint32ArrayCid, size));
+    {
+      NoSafepointScope no_safepoint;
+      memset(Array::DataOf(data.ptr()), 0,
+             size * sizeof(CompressedObjectPtr));
+      memcpy(index.DataAddr(0), index_template.DataAddr(0),
+             size * sizeof(uint32_t));
+      CompressedObjectPtr* slots = Array::DataOf(data.ptr());
+      for (intptr_t i = 0; i < count; i++) {
+        const intptr_t d = i << 1;
+        slots[d] = small_keys_[i]->ptr();
+        slots[d + 1] = small_values_[i]->ptr();
+      }
+    }
+    const Map& map = Map::Handle(
+        zone_, Map::New(kMapCid, data, index, hash_mask, count << 1, 0,
+                        Heap::kNew));
+    map.SetTypeArguments(map_type_args_);
+    return map.ptr();
+  }
+
+  StringPtr BuildAsciiSubString(intptr_t start, intptr_t length) {
+    ASSERT(start >= 0);
+    ASSERT(length >= 0);
+    if (length == 0) return Symbols::Empty().ptr();
+    OneByteStringPtr one_byte = OneByteString::New(length, Heap::kNew);
+    const String& one_handle = String::Handle(zone_, one_byte);
+    bool is_one_byte = true;
+    {
+      NoSafepointScope no_safepoint;
+      const uint16_t* src =
+          NativeStringDataAccess::TwoByteDataStart(str_) + start;
+      uint8_t* dst = NativeStringDataAccess::OneByteDataStart(one_handle);
+#if defined(TARGET_ARCH_ARM64)
+      intptr_t i = 0;
+      const intptr_t simd_len = length & ~static_cast<intptr_t>(7);
+      for (; i < simd_len; i += 8) {
+        const uint16x8_t block = vld1q_u16(src + i);
+        const uint16x8_t high = vshrq_n_u16(block, 8);
+        if (vmaxvq_u16(high) != 0) {
+          is_one_byte = false;
+          break;
+        }
+        const uint8x8_t narrowed = vmovn_u16(block);
+        vst1_u8(dst + i, narrowed);
+      }
+      if (is_one_byte) {
+        for (; i < length; i++) {
+          const uint16_t ch = src[i];
+          if (ch > 0xFF) {
+            is_one_byte = false;
+            break;
+          }
+          dst[i] = static_cast<uint8_t>(ch);
+        }
+      }
+#else
+      for (intptr_t i = 0; i < length; i++) {
+        const uint16_t ch = src[i];
+        if (ch > 0xFF) {
+          is_one_byte = false;
+          break;
+        }
+        dst[i] = static_cast<uint8_t>(ch);
+      }
+#endif
+    }
+    if (is_one_byte) return one_byte;
+    return TwoByteString::SubStringUnchecked(str_, start, length, Heap::kNew);
+  }
+
+  bool SliceEqualsKey(intptr_t start, intptr_t len, const String& key) {
+    if (key.Length() != len) return false;
+    if (len == 0) return true;
+    NoSafepointScope no_safepoint;
+    const uint16_t* src =
+        NativeStringDataAccess::TwoByteDataStart(str_) + start;
+    if (key.IsOneByteString()) {
+      const uint8_t* dst = NativeStringDataAccess::OneByteDataStart(key);
+      for (intptr_t i = 0; i < len; i++) {
+        if (src[i] != dst[i]) return false;
+      }
+      return true;
+    }
+    const uint16_t* dst = NativeStringDataAccess::TwoByteDataStart(key);
+    for (intptr_t i = 0; i < len; i++) {
+      if (src[i] != dst[i]) return false;
+    }
+    return true;
+  }
+
+  StringPtr LookupOrCreateShortKey(uint16_t ch0, uint16_t ch1, intptr_t len) {
+    if (len <= kKeyCacheMaxLength) {
+      NoSafepointScope no_safepoint;
+      for (intptr_t i = 0; i < key_cache_len_; i++) {
+        const String& cached = *key_cache_[i];
+        if (cached.Length() != len || !cached.IsOneByteString()) continue;
+        const uint8_t* data = NativeStringDataAccess::OneByteDataStart(cached);
+        if (data[0] != static_cast<uint8_t>(ch0)) continue;
+        if (len == 2 && data[1] != static_cast<uint8_t>(ch1)) continue;
+        return cached.ptr();
+      }
+    }
+    OneByteStringPtr one_byte = OneByteString::New(len, Heap::kNew);
+    const String& handle = String::Handle(zone_, one_byte);
+    {
+      NoSafepointScope no_safepoint;
+      uint8_t* dst = NativeStringDataAccess::OneByteDataStart(handle);
+      dst[0] = static_cast<uint8_t>(ch0);
+      if (len == 2) dst[1] = static_cast<uint8_t>(ch1);
+    }
+    if (len <= kKeyCacheMaxLength && key_cache_len_ < kKeyCacheMaxEntries) {
+      *key_cache_[key_cache_len_++] = one_byte;
+    }
+    return one_byte;
+  }
+
+  StringPtr LookupOrCreateDigitKey(uint16_t digit0,
+                                   uint16_t digit1,
+                                   intptr_t len) {
+    if (len == 1) {
+      String& cached = *digit_key1_[digit0];
+      if (!cached.IsNull()) return cached.ptr();
+      OneByteStringPtr one_byte = OneByteString::New(1, Heap::kNew);
+      const String& handle = String::Handle(zone_, one_byte);
+      {
+        NoSafepointScope no_safepoint;
+        uint8_t* dst = NativeStringDataAccess::OneByteDataStart(handle);
+        dst[0] = static_cast<uint8_t>('0' + digit0);
+      }
+      cached = one_byte;
+      return one_byte;
+    }
+    const uint16_t index = static_cast<uint16_t>(digit0 * 10 + digit1);
+    String& cached = *digit_key2_[index];
+    if (!cached.IsNull()) return cached.ptr();
+    OneByteStringPtr one_byte = OneByteString::New(2, Heap::kNew);
+    const String& handle = String::Handle(zone_, one_byte);
+    {
+      NoSafepointScope no_safepoint;
+      uint8_t* dst = NativeStringDataAccess::OneByteDataStart(handle);
+      dst[0] = static_cast<uint8_t>('0' + digit0);
+      dst[1] = static_cast<uint8_t>('0' + digit1);
+    }
+    cached = one_byte;
+    return one_byte;
+  }
+
+  Thread* thread_;
+  Zone* zone_;
+  const String& str_;
+  const Object& failure_;
+  const intptr_t length_;
+  intptr_t pos_;
+  static constexpr intptr_t kKeyCacheMaxEntries = 64;
+  static constexpr intptr_t kKeyCacheMaxLength = 32;
+  static constexpr intptr_t kSmallObjectMaxKeys = 8;
+  static constexpr intptr_t kShapeCacheMaxEntries = 16;
+  static constexpr intptr_t kValueStringOneByteMax = 32;
+  String* key_cache_[kKeyCacheMaxEntries];
+  intptr_t key_cache_len_;
+  String* digit_key1_[10];
+  String* digit_key2_[100];
+  Array* shape_cache_[kShapeCacheMaxEntries];
+  intptr_t shape_cache_len_;
+  const TypeArguments& map_type_args_;
+  Object* small_keys_[kSmallObjectMaxKeys];
+  Object* small_values_[kSmallObjectMaxKeys];
+};
+
+DEFINE_NATIVE_ENTRY(Json_findStringTerminator, 0, 3) {
+  GET_NON_NULL_NATIVE_ARGUMENT(String, str, arguments->NativeArgAt(0));
+  GET_NON_NULL_NATIVE_ARGUMENT(Smi, start_obj, arguments->NativeArgAt(1));
+  GET_NON_NULL_NATIVE_ARGUMENT(Smi, end_obj, arguments->NativeArgAt(2));
+
+  const intptr_t start = start_obj.Value();
+  const intptr_t end = end_obj.Value();
+  if (start < 0 || end < start || end > str.Length()) {
+    Exceptions::ThrowArgumentError(start_obj);
+  }
+
+  if (!str.IsOneByteString()) {
+    NoSafepointScope no_safepoint;
+    const uint16_t* data = NativeStringDataAccess::TwoByteDataStart(str);
+    const intptr_t index = FindJsonStringTerminatorTwoByte(data, start, end);
+    return Smi::New(index);
+  }
+
+  NoSafepointScope no_safepoint;
+  const uint8_t* data = NativeStringDataAccess::OneByteDataStart(str);
+  const intptr_t index = FindJsonStringTerminatorOneByte(data, start, end);
+  return Smi::New(index);
+}
+
+DEFINE_NATIVE_ENTRY(Json_findStringTerminatorUtf8, 0, 3) {
+  GET_NON_NULL_NATIVE_ARGUMENT(TypedDataBase, bytes, arguments->NativeArgAt(0));
+  GET_NON_NULL_NATIVE_ARGUMENT(Smi, start_obj, arguments->NativeArgAt(1));
+  GET_NON_NULL_NATIVE_ARGUMENT(Smi, end_obj, arguments->NativeArgAt(2));
+
+  const intptr_t start = start_obj.Value();
+  const intptr_t end = end_obj.Value();
+  if (start < 0 || end < start || end > bytes.Length()) {
+    Exceptions::ThrowArgumentError(start_obj);
+  }
+  if (bytes.ElementType() != kUint8ArrayElement) {
+    Exceptions::ThrowArgumentError(bytes);
+  }
+
+  NoSafepointScope no_safepoint;
+  const uint8_t* data =
+      reinterpret_cast<const uint8_t*>(bytes.DataAddr(0));
+  const intptr_t index = FindJsonStringTerminatorOneByte(data, start, end);
+  return Smi::New(index);
+}
+
+DEFINE_NATIVE_ENTRY(Json_parseOneByteFast, 0, 2) {
+  GET_NON_NULL_NATIVE_ARGUMENT(String, str, arguments->NativeArgAt(0));
+  GET_NON_NULL_NATIVE_ARGUMENT(Instance, failure, arguments->NativeArgAt(1));
+
+  if (!str.IsOneByteString()) return failure.ptr();
+
+  const Object& failure_object = Object::Handle(zone, failure.ptr());
+  JsonFastParser parser(thread, str, failure_object);
+  return parser.Parse();
+}
+
+DEFINE_NATIVE_ENTRY(Json_parseTwoByteFast, 0, 2) {
+  GET_NON_NULL_NATIVE_ARGUMENT(String, str, arguments->NativeArgAt(0));
+  GET_NON_NULL_NATIVE_ARGUMENT(Instance, failure, arguments->NativeArgAt(1));
+
+  if (!str.IsTwoByteString()) return failure.ptr();
+
+  const Object& failure_object = Object::Handle(zone, failure.ptr());
+  JsonFastParserTwoByte parser(thread, str, failure_object);
+  return parser.Parse();
+}
+
+DEFINE_NATIVE_ENTRY(CompactHash_createMapFromKeyValueListUnsafe, 2, 2) {
+  GET_NON_NULL_NATIVE_ARGUMENT(Instance, list, arguments->NativeArgAt(0));
+  GET_NON_NULL_NATIVE_ARGUMENT(Instance, failure, arguments->NativeArgAt(1));
+
+  Array& pair_data = Array::Handle(zone);
+  intptr_t pair_len = 0;
+  if (list.IsGrowableObjectArray()) {
+    const GrowableObjectArray& pairs = GrowableObjectArray::Cast(list);
+    pair_len = pairs.Length();
+    pair_data = pairs.data();
+  } else if (list.IsArray()) {
+    pair_data = Array::Cast(list).ptr();
+    pair_len = pair_data.Length();
+  } else {
+    return failure.ptr();
+  }
+
+  if ((pair_len & 1) != 0) return failure.ptr();
+  for (intptr_t i = 0; i < pair_len; i += 2) {
+    const Object& key_obj = Object::Handle(zone, pair_data.At(i));
+    if (!key_obj.IsString()) return failure.ptr();
+  }
+
+  TypeArguments& type_args =
+      TypeArguments::Handle(zone, arguments->NativeTypeArgs());
+  if (!type_args.IsNull() && !type_args.IsCanonical()) {
+    type_args = type_args.Canonicalize(thread);
+  }
+  return BuildMapFromPairs(thread, pair_data, pair_len, type_args);
 }
 
 // Return the bitwise-or of all characters in the slice from start to end.
@@ -356,6 +1925,86 @@ DEFINE_NATIVE_ENTRY(Internal_writeIntoTwoByteString, 0, 3) {
   TwoByteString::SetCharAt(receiver, index_obj.Value(),
                            code_point_obj.Value() & 0xFFFF);
   return Object::null();
+}
+
+DEFINE_NATIVE_ENTRY(Internal_decodeUtf8ToOneByteString, 0, 4) {
+  GET_NON_NULL_NATIVE_ARGUMENT(TypedDataBase, bytes, arguments->NativeArgAt(0));
+  if (bytes.ElementType() != kUint8ArrayElement) {
+    Exceptions::ThrowArgumentError(bytes);
+  }
+  GET_NON_NULL_NATIVE_ARGUMENT(Smi, start_obj, arguments->NativeArgAt(1));
+  GET_NON_NULL_NATIVE_ARGUMENT(Smi, end_obj, arguments->NativeArgAt(2));
+  GET_NON_NULL_NATIVE_ARGUMENT(Integer, size_obj, arguments->NativeArgAt(3));
+
+  const intptr_t start = start_obj.Value();
+  const intptr_t end = end_obj.Value();
+  const intptr_t length = size_obj.Value();
+  if ((start < 0) || (end < start) || (end > bytes.Length())) {
+    Exceptions::ThrowArgumentError(end_obj);
+  }
+  if ((length < 0) || (length > OneByteString::kMaxElements)) {
+    const Instance& exception = Instance::Handle(
+        thread->isolate_group()->object_store()->out_of_memory());
+    Exceptions::Throw(thread, exception);
+    UNREACHABLE();
+  }
+
+  const String& result =
+      String::Handle(OneByteString::New(length, Heap::kNew));
+  if (length == 0) {
+    return result.ptr();
+  }
+
+  NoSafepointScope no_safepoint;
+  const uint8_t* src =
+      reinterpret_cast<const uint8_t*>(bytes.DataAddr(start));
+  const intptr_t byte_len = end - start;
+  if (!Utf8::DecodeToLatin1(
+          src, byte_len, NativeStringDataAccess::OneByteDataStart(result),
+          length)) {
+    return Object::null();
+  }
+  return result.ptr();
+}
+
+DEFINE_NATIVE_ENTRY(Internal_decodeUtf8ToTwoByteString, 0, 4) {
+  GET_NON_NULL_NATIVE_ARGUMENT(TypedDataBase, bytes, arguments->NativeArgAt(0));
+  if (bytes.ElementType() != kUint8ArrayElement) {
+    Exceptions::ThrowArgumentError(bytes);
+  }
+  GET_NON_NULL_NATIVE_ARGUMENT(Smi, start_obj, arguments->NativeArgAt(1));
+  GET_NON_NULL_NATIVE_ARGUMENT(Smi, end_obj, arguments->NativeArgAt(2));
+  GET_NON_NULL_NATIVE_ARGUMENT(Integer, size_obj, arguments->NativeArgAt(3));
+
+  const intptr_t start = start_obj.Value();
+  const intptr_t end = end_obj.Value();
+  const intptr_t length = size_obj.Value();
+  if ((start < 0) || (end < start) || (end > bytes.Length())) {
+    Exceptions::ThrowArgumentError(end_obj);
+  }
+  if ((length < 0) || (length > TwoByteString::kMaxElements)) {
+    const Instance& exception = Instance::Handle(
+        thread->isolate_group()->object_store()->out_of_memory());
+    Exceptions::Throw(thread, exception);
+    UNREACHABLE();
+  }
+
+  const String& result =
+      String::Handle(TwoByteString::New(length, Heap::kNew));
+  if (length == 0) {
+    return result.ptr();
+  }
+
+  NoSafepointScope no_safepoint;
+  const uint8_t* src =
+      reinterpret_cast<const uint8_t*>(bytes.DataAddr(start));
+  const intptr_t byte_len = end - start;
+  if (!Utf8::DecodeToUTF16(
+          src, byte_len, NativeStringDataAccess::TwoByteDataStart(result),
+          length)) {
+    return Object::null();
+  }
+  return result.ptr();
 }
 
 DEFINE_NATIVE_ENTRY(TwoByteString_allocateFromTwoByteList, 0, 3) {

--- a/runtime/platform/unicode.cc
+++ b/runtime/platform/unicode.cc
@@ -4,11 +4,38 @@
 
 #include "platform/unicode.h"
 
+#include <cstring>
+
 #include "platform/allocation.h"
 #include "platform/globals.h"
 #include "platform/syslog.h"
 
 namespace dart {
+
+namespace {
+#if defined(ARCH_IS_64_BIT)
+static constexpr uintptr_t kAsciiWordMask = DART_UINT64_C(0x8080808080808080);
+#else
+static constexpr uintptr_t kAsciiWordMask = 0x80808080u;
+#endif
+
+inline intptr_t AsciiRunLength(const uint8_t* data, intptr_t len) {
+  intptr_t i = 0;
+  const intptr_t word_size = sizeof(uintptr_t);
+  while (i + word_size <= len) {
+    const uintptr_t chunk = LoadUnaligned(
+        reinterpret_cast<const uintptr_t*>(data + i));
+    if ((chunk & kAsciiWordMask) != 0) {
+      break;
+    }
+    i += word_size;
+  }
+  while (i < len && data[i] < 0x80) {
+    i++;
+  }
+  return i;
+}
+}  // namespace
 
 // clang-format off
 const int8_t Utf8::kTrailBytes[256] = {
@@ -39,6 +66,7 @@ const uint32_t Utf8::kMagicBits[7] = {0,  // Padding.
 const uint32_t Utf8::kOverlongMinimum[7] = {0,  // Padding.
                                             0x0,     0x80,       0x800,
                                             0x10000, 0xFFFFFFFF, 0xFFFFFFFF};
+
 
 // Returns the most restricted coding form in which the sequence of utf8
 // characters in 'utf8_array' can be represented in, and the number of
@@ -197,16 +225,33 @@ bool Utf8::DecodeToLatin1(const uint8_t* utf8_array,
                           intptr_t len) {
   intptr_t i = 0;
   intptr_t j = 0;
-  intptr_t num_bytes;
-  for (; (i < array_len) && (j < len); i += num_bytes, ++j) {
-    int32_t ch;
-    ASSERT(IsLatin1SequenceStart(utf8_array[i]));
-    num_bytes = Utf8::Decode(&utf8_array[i], (array_len - i), &ch);
-    if (ch == -1) {
+  while ((i < array_len) && (j < len)) {
+    const uint8_t byte = utf8_array[i];
+    if (byte < 0x80) {
+      const intptr_t run_len = AsciiRunLength(utf8_array + i, array_len - i);
+      if (j + run_len > len) {
+        return false;  // Output overflow.
+      }
+      memcpy(dst + j, utf8_array + i, run_len);
+      i += run_len;
+      j += run_len;
+      continue;
+    }
+    if (!IsLatin1SequenceStart(byte)) {
       return false;  // Invalid input.
     }
-    ASSERT(Utf::IsLatin1(ch));
-    dst[j] = ch;
+    if (byte < 0xC2) {
+      return false;  // Invalid or overlong sequence.
+    }
+    if (i + 1 >= array_len) {
+      return false;  // Incomplete sequence.
+    }
+    const uint8_t b1 = utf8_array[i + 1];
+    if (!IsTrailByte(b1)) {
+      return false;  // Invalid input.
+    }
+    dst[j++] = ((byte & 0x1F) << 6) | (b1 & 0x3F);
+    i += 2;
   }
   if ((i < array_len) && (j == len)) {
     return false;  // Output overflow.
@@ -220,21 +265,78 @@ bool Utf8::DecodeToUTF16(const uint8_t* utf8_array,
                          intptr_t len) {
   intptr_t i = 0;
   intptr_t j = 0;
-  intptr_t num_bytes;
-  for (; (i < array_len) && (j < len); i += num_bytes, ++j) {
-    int32_t ch;
-    bool is_supplementary = IsSupplementarySequenceStart(utf8_array[i]);
-    num_bytes = Utf8::Decode(&utf8_array[i], (array_len - i), &ch);
-    if (ch == -1) {
-      return false;  // Invalid input.
+  while ((i < array_len) && (j < len)) {
+    const uint8_t byte = utf8_array[i];
+    if (byte < 0x80) {
+      const intptr_t run_len = AsciiRunLength(utf8_array + i, array_len - i);
+      if (j + run_len > len) {
+        return false;  // Output overflow.
+      }
+      for (intptr_t k = 0; k < run_len; k++) {
+        dst[j + k] = utf8_array[i + k];
+      }
+      i += run_len;
+      j += run_len;
+      continue;
     }
-    if (is_supplementary) {
-      if (j == (len - 1)) return false;  // Output overflow.
-      Utf16::Encode(ch, &dst[j]);
-      j = j + 1;
-    } else {
-      dst[j] = ch;
+    if (byte < 0xC2) {
+      return false;  // Invalid or overlong sequence.
     }
+    if (byte < 0xE0) {
+      if (i + 1 >= array_len) return false;  // Incomplete sequence.
+      intptr_t remaining = len - j;
+      while (remaining > 0 && i + 1 < array_len) {
+        const uint8_t b0 = utf8_array[i];
+        if (b0 < 0xC2 || b0 >= 0xE0) {
+          break;
+        }
+        const uint8_t b1 = utf8_array[i + 1];
+        if (!IsTrailByte(b1)) return false;
+        dst[j++] = ((b0 & 0x1F) << 6) | (b1 & 0x3F);
+        i += 2;
+        remaining--;
+      }
+      continue;
+    }
+    if (byte < 0xF0) {
+      if (i + 2 >= array_len) return false;  // Incomplete sequence.
+      intptr_t remaining = len - j;
+      while (remaining > 0 && i + 2 < array_len) {
+        const uint8_t b0 = utf8_array[i];
+        if (b0 < 0xE0 || b0 >= 0xF0) {
+          break;
+        }
+        const uint8_t b1 = utf8_array[i + 1];
+        const uint8_t b2 = utf8_array[i + 2];
+        if (!IsTrailByte(b1) || !IsTrailByte(b2)) return false;
+        if ((b0 == 0xE0) && (b1 < 0xA0)) return false;  // Overlong.
+        if ((b0 == 0xED) && (b1 >= 0xA0)) return false;  // Surrogate.
+        dst[j++] = ((b0 & 0x0F) << 12) | ((b1 & 0x3F) << 6) | (b2 & 0x3F);
+        i += 3;
+        remaining--;
+      }
+      continue;
+    }
+    if (byte < 0xF5) {
+      if (i + 3 >= array_len) return false;  // Incomplete sequence.
+      const uint8_t b1 = utf8_array[i + 1];
+      const uint8_t b2 = utf8_array[i + 2];
+      const uint8_t b3 = utf8_array[i + 3];
+      if (!IsTrailByte(b1) || !IsTrailByte(b2) || !IsTrailByte(b3)) {
+        return false;
+      }
+      if ((byte == 0xF0) && (b1 < 0x90)) return false;  // Overlong.
+      if ((byte == 0xF4) && (b1 >= 0x90)) return false;  // Out of range.
+      if (j >= (len - 1)) return false;  // Output overflow.
+      uint32_t ch = ((byte & 0x07) << 18) | ((b1 & 0x3F) << 12) |
+                    ((b2 & 0x3F) << 6) | (b3 & 0x3F);
+      ch -= 0x10000;
+      dst[j++] = 0xD800 + (ch >> 10);
+      dst[j++] = 0xDC00 + (ch & 0x3FF);
+      i += 4;
+      continue;
+    }
+    return false;  // Invalid input.
   }
   if ((i < array_len) && (j == len)) {
     return false;  // Output overflow.

--- a/runtime/vm/bootstrap_natives.h
+++ b/runtime/vm/bootstrap_natives.h
@@ -120,6 +120,11 @@ namespace dart {
   V(ImmutableList_from, 4)                                                     \
   V(StringBase_createFromCodePoints, 3)                                        \
   V(StringBase_substringUnchecked, 3)                                          \
+  V(Json_findStringTerminator, 3)                                              \
+  V(Json_findStringTerminatorUtf8, 3)                                          \
+  V(Json_parseOneByteFast, 2)                                                  \
+  V(Json_parseTwoByteFast, 2)                                                  \
+  V(CompactHash_createMapFromKeyValueListUnsafe, 2)                            \
   V(StringBase_joinReplaceAllResult, 4)                                        \
   V(StringBase_intern, 1)                                                      \
   V(StringBuffer_createStringFromUint16Array, 3)                               \
@@ -276,6 +281,8 @@ namespace dart {
   V(Internal_allocateTwoByteString, 1)                                         \
   V(Internal_writeIntoOneByteString, 3)                                        \
   V(Internal_writeIntoTwoByteString, 3)                                        \
+  V(Internal_decodeUtf8ToOneByteString, 4)                                     \
+  V(Internal_decodeUtf8ToTwoByteString, 4)                                     \
   V(Internal_deoptimizeFunctionsOnStack, 0)                                    \
   V(Internal_allocateObjectInstructionsStart, 0)                               \
   V(Internal_allocateObjectInstructionsEnd, 0)                                 \

--- a/runtime/vm/object.cc
+++ b/runtime/vm/object.cc
@@ -25577,6 +25577,27 @@ OneByteStringPtr OneByteString::SubStringUnchecked(const String& str,
   return result;
 }
 
+TwoByteStringPtr TwoByteString::SubStringUnchecked(const String& str,
+                                                   intptr_t begin_index,
+                                                   intptr_t length,
+                                                   Heap::Space space) {
+  ASSERT(!str.IsNull() && str.IsTwoByteString());
+  ASSERT(begin_index >= 0);
+  ASSERT(length >= 0);
+  if (begin_index <= str.Length() && length == 0) {
+    return TwoByteString::New(0, space);
+  }
+  ASSERT(begin_index < str.Length());
+  TwoByteStringPtr result = TwoByteString::New(length, space);
+  NoSafepointScope no_safepoint;
+  if (length > 0) {
+    uint16_t* dest = &result->untag()->data()[0];
+    const uint16_t* src = &untag(str)->data()[begin_index];
+    memmove(dest, src, length * sizeof(uint16_t));
+  }
+  return result;
+}
+
 TwoByteStringPtr TwoByteString::EscapeSpecialCharacters(const String& str) {
   intptr_t len = str.Length();
   if (len > 0) {

--- a/runtime/vm/object.h
+++ b/runtime/vm/object.h
@@ -10952,6 +10952,7 @@ class OneByteString : public AllStatic {
   friend class StringHasher;
   friend class Symbols;
   friend class Utf8;
+  friend class NativeStringDataAccess;
   friend class OneByteStringMessageSerializationCluster;
   friend class Deserializer;
   friend class JSONWriter;
@@ -10976,6 +10977,10 @@ class TwoByteString : public AllStatic {
   }
 
   static TwoByteStringPtr EscapeSpecialCharacters(const String& str);
+  static TwoByteStringPtr SubStringUnchecked(const String& str,
+                                             intptr_t begin_index,
+                                             intptr_t length,
+                                             Heap::Space space);
 
   // We use the same maximum elements for all strings.
   static constexpr intptr_t kBytesPerElement = 2;
@@ -11074,6 +11079,7 @@ class TwoByteString : public AllStatic {
   friend class String;
   friend class StringHasher;
   friend class Symbols;
+  friend class NativeStringDataAccess;
   friend class TwoByteStringMessageSerializationCluster;
   friend class JSONWriter;
 };

--- a/sdk/lib/_internal/vm/lib/internal_patch.dart
+++ b/sdk/lib/_internal/vm/lib/internal_patch.dart
@@ -87,6 +87,22 @@ external String allocateTwoByteString(int length);
 @pragma("vm:external-name", "Internal_writeIntoTwoByteString")
 external void writeIntoTwoByteString(String string, int index, int codePoint);
 
+@pragma("vm:external-name", "Internal_decodeUtf8ToOneByteString")
+external String? decodeUtf8ToOneByteString(
+  Uint8List bytes,
+  int start,
+  int end,
+  int size,
+);
+
+@pragma("vm:external-name", "Internal_decodeUtf8ToTwoByteString")
+external String? decodeUtf8ToTwoByteString(
+  Uint8List bytes,
+  int start,
+  int end,
+  int size,
+);
+
 class VMLibraryHooks {
   // Example: "dart:isolate _Timer._factory"
   static Timer Function(int, void Function(Timer), bool)? timerFactory;
@@ -162,6 +178,13 @@ external _boundsCheckForPartialInstantiation(closure, typeArgs);
 @patch
 @pragma("vm:external-name", "Internal_unsafeCast")
 external T unsafeCast<T>(dynamic v);
+
+@patch
+@pragma("vm:external-name", "CompactHash_createMapFromKeyValueListUnsafe")
+external Object? createMapFromKeyValueListUnsafeNative<K, V>(
+  List keyValuePairs,
+  Object failureSentinel,
+);
 
 // This function can be used to keep an object alive till that point.
 @pragma("vm:recognized", "other")

--- a/sdk/lib/_internal/vm_shared/lib/compact_hash.dart
+++ b/sdk/lib/_internal/vm_shared/lib/compact_hash.dart
@@ -1338,6 +1338,16 @@ base class CompactLinkedCustomHashSet<E> extends _HashFieldBase
 typedef DefaultMap<K, V> = _Map<K, V>;
 typedef DefaultSet<E> = _Set<E>;
 
+final Object _mapFastFailureSentinel = Object();
+
 @pragma('vm:prefer-inline')
-Map<K, V> createMapFromKeyValueListUnsafe<K, V>(List keyValuePairs) =>
-    DefaultMap<K, V>().._populateUnsafe(keyValuePairs);
+Map<K, V> createMapFromKeyValueListUnsafe<K, V>(List keyValuePairs) {
+  final Object? fast = internal.createMapFromKeyValueListUnsafeNative<K, V>(
+    keyValuePairs,
+    _mapFastFailureSentinel,
+  );
+  if (!identical(fast, _mapFastFailureSentinel)) {
+    return internal.unsafeCast<Map<K, V>>(fast);
+  }
+  return DefaultMap<K, V>().._populateUnsafe(keyValuePairs);
+}

--- a/sdk/lib/internal/internal.dart
+++ b/sdk/lib/internal/internal.dart
@@ -54,6 +54,12 @@ external bool typeAcceptsNull<T>();
 /// Should only be used for performance in performance critical code.
 external T unsafeCast<T>(dynamic value);
 
+/// VM-only fast path for creating a map from alternating key/value pairs.
+external Object? createMapFromKeyValueListUnsafeNative<K, V>(
+  List keyValuePairs,
+  Object failureSentinel,
+);
+
 // Powers of 10 up to 10^22 are representable as doubles.
 // Powers of 10 above that are only approximate due to lack of precision.
 // Used by double-parsing.


### PR DESCRIPTION
## Summary
This change set adds native fast paths for JSON parsing (one-byte and two-byte strings) and optimizes UTF-8 decoding for large inputs. It reduces overhead in hot loops by moving parsing and map construction into C++ and by using faster scanning primitives for strings and ASCII runs.

## Motivation
- The JSON benchmarks and production inputs include non-Latin1 characters, which meant the existing one-byte fast path was bypassed for two-byte strings.
- The Dart JSON parser spends a lot of time scanning strings and building maps/arrays in Dart, even when no reviver is used.
- UTF-8 decode for large inputs was dominated by per-codepoint decoding and validation work that can be streamlined with tight loops and ASCII run detection.

## What changed
### Dart-side changes
- `sdk/lib/_internal/vm/lib/convert_patch.dart`
  - Adds a fast JSON parse path for large inputs (length >= 128) with no reviver, calling native parsers for one-byte or two-byte strings. Falls back to the existing Dart parser on failure.
  - Adds a native string terminator scanner for one-byte JSON strings to reduce overhead in `parseString` / `parseStringToBuffer`.
  - Adds a small-int string cache (0..999) for short ASCII numeric strings to avoid repeated allocations.
  - Routes large UTF-8 decode operations through optimized native decoders when allowed (`decodeUtf8ToOneByteString` / `decodeUtf8ToTwoByteString`).
- `sdk/lib/_internal/vm_shared/lib/compact_hash.dart`
  - Uses a native map constructor for alternating key/value pairs to reduce Dart map building cost.
- `sdk/lib/internal/internal.dart` and `sdk/lib/_internal/vm/lib/internal_patch.dart`
  - Expose the native map constructor and allow the VM to see the `K,V` type arguments.

### VM/runtime changes
- `runtime/lib/string.cc`
  - Adds native JSON parsers for one-byte and two-byte strings (`Json_parseOneByteFast`, `Json_parseTwoByteFast`).
  - Introduces fast string terminator scanning for JSON strings (one-byte and two-byte), with SIMD-friendly scanning and no-safepoint sections.
  - Adds native map and array builders to avoid Dart-side allocation overhead, including small-key caches and shape caches for common object shapes.
  - Preserves map type arguments in the native fast map builder.
  - Fixes validation in the two-byte number parser to reject invalid forms like "--1".
- `runtime/platform/unicode.cc`
  - Adds ASCII run detection and specialized loops for Latin1 and UTF-16 decoding to reduce per-byte overhead.
  - Tightens validation in the fast decode paths (overlongs, surrogates, range checks).
- `runtime/vm/object.h` and `runtime/vm/object.cc`
  - Adds `TwoByteString::SubStringUnchecked` for validated fast substring creation.
- `runtime/vm/bootstrap_natives.h`
  - Wires new native entries used by the Dart fast paths.

## Why this is faster
- Native parsers avoid Dart object overhead in tight loops and eliminate repeated bounds checks.
- SIMD/word-at-a-time string terminator scans drastically reduce the time spent scanning JSON strings.
- Native map/array builders avoid repeated allocations and rehashing during parsing, and cache common shapes.
- UTF-8 decoding now handles long ASCII runs and well-formed multi-byte sequences with tighter loops.

## Correctness safeguards
- Fast JSON path is only used when `reviver == null`; failures fall back to the Dart parser.
- Two-byte number parsing rejects invalid inputs such as "--1".
- Native map builder retains correct `K,V` type arguments.
- UTF-8 decoding fast paths still enforce overlong, surrogate, and range checks.

## Performance (example)
On macOS ARM64 Release using `benchmarks/IsolateJson/dart/IsolateJson.dart -n 10`:
- `SyncDecode1MBx1`: ~64 ms -> ~24–25 ms (about 60% faster)
- `Decode1MBx1`: ~90 ms -> ~29–32 ms (about 65% faster)
- `Decode1MBx4`: ~177 ms -> ~53–68 ms (about 60–70% faster)

## Testing
- `python3 tools/build.py --mode=release --arch=arm64 dartvm`
- `xcodebuild/ReleaseARM64/dartvm benchmarks/IsolateJson/dart/IsolateJson.dart -n 10`