### PR TITLE
[DOC] Clarify `Expando` value retention while key is reachable

### DIFF
--- a/sdk/lib/core/weak.dart
+++ b/sdk/lib/core/weak.dart
@@ -20,7 +20,7 @@ part of "dart:core";
 /// becomes inaccessible. While the object remains reachable, the associated
 /// property value is retained and cannot be garbage-collected independently
 /// of the object. In other words, the property value’s lifetime is bound to
-/// the object for as long as the object is set in the Expando, or until the
+/// the object for as long as the object is set in the `Expando`, or until the
 /// object itself is garbage-collected.
 ///
 /// Since you can always create a new number that is identical to an existing

--- a/sdk/lib/core/weak.dart
+++ b/sdk/lib/core/weak.dart
@@ -20,8 +20,8 @@ part of "dart:core";
 /// becomes inaccessible. While the object remains reachable, the associated
 /// property value is retained and cannot be garbage-collected independently
 /// of the object. In other words, the property value’s lifetime is bound to
-/// the object for as long as the object is set in the `Expando`, or until the
-/// object itself is garbage-collected.
+/// the object for as long as the object is set in the `Expando`, or until
+/// the object itself is garbage-collected.
 ///
 /// Since you can always create a new number that is identical to an existing
 /// number, it means that an expando property on a number could never be

--- a/sdk/lib/core/weak.dart
+++ b/sdk/lib/core/weak.dart
@@ -17,7 +17,11 @@ part of "dart:core";
 /// `dart:ffi` pointers, `dart:ffi` structs, or `dart:ffi` unions.
 ///
 /// An `Expando` does not hold on to the added property value after an object
-/// becomes inaccessible.
+/// becomes inaccessible. While the object remains reachable, the associated
+/// property value is retained and cannot be garbage-collected independently
+/// of the object. In other words, the property value’s lifetime is bound to
+/// the object for as long as the object is set in the Expando, or until the
+/// object itself is garbage-collected.
 ///
 /// Since you can always create a new number that is identical to an existing
 /// number, it means that an expando property on a number could never be


### PR DESCRIPTION
Clarifies that `Expando` values are retained while their key objects are reachable and are only eligible for garbage collection when the key objects become inaccessible or are collected.

---

- [✅ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
