### PR TITLE
[build] Fix gcc build fails with msan enabled

### DIFF
--- a/sdk/BUILD.gn
+++ b/sdk/BUILD.gn
@@ -395,9 +395,13 @@ if (!using_sanitizer && current_os == "linux" &&
   if (current_cpu == "x64" || current_cpu == "arm64") {
     sanitizers += [
       "asan",
-      "msan",
       "tsan",
     ]
+    if (is_clang) {
+      sanitizers += [
+        "msan",
+      ]
+    }
   } else if (current_cpu == "riscv64") {
     # Fuchsia Clang is missing the riscv64 MSAN runtime.
     sanitizers += [


### PR DESCRIPTION
Only Clang supports -fsanitize=memory

fix following error:

```
g++ -MMD -MF x64_msan/obj/runtime/bin/libcrashpad.crashpad.o.d -DNDEBUG -DTARGET_ARCH_X64 -DSUPPORT_PERFETTO -DPRODUCT -DDART_TARGET_OS_LINUX -I../../runtime -I../.. -Ix64_msan/gen -I../../runtime/include -fsanitize=memory -m64 -march=x86-64 -msse2 -fPIE -Wall -Wextra -Werror -Wendif-labels -Wno-missing-field-initializers -Wno-unused-parameter -Wno-ignored-qualifiers -fdebug-prefix-map=/var/tmp/portage/dev-lang/dart-3.11.0/work/dart-sdk-3.11.0/= -no-canonical-prefixes -fvisibility=hidden -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -O2 -fno-ident -fdata-sections -ffunction-sections -g3 -ggdb3 -Wno-unused-parameter -Wno-unused-private-field -Wnon-virtual-dtor -Wvla -Woverloaded-virtual -Wno-comments -g3 -ggdb3 -fno-rtti -fno-exceptions -Wno-cast-function-type -Wno-dangling-reference -O2 -fvisibility=hidden -fvisibility-inlines-hidden -fno-omit-frame-pointer -std=c++20 -O2 -pipe -std=c++20 -fno-rtti -c ../../runtime/bin/crashpad.cc -o x64_msan/obj/runtime/bin/libcrashpad.crashpad.o
g++: error: unrecognized argument to ‘-fsanitize=’ option: ‘memory’
```

- Thanks for your contribution! Please replace this text with a description of what this PR is changing or adding and why, list any relevant issues, and review the contribution guidelines below.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
