### PR TITLE
[vm] Allow to skip crash handler installation in bin::Platform::Initialize.

### DIFF
--- a/runtime/bin/platform.h
+++ b/runtime/bin/platform.h
@@ -21,7 +21,7 @@ namespace bin {
 class Platform {
  public:
   // Perform platform specific initialization.
-  static bool Initialize();
+  static bool Initialize(bool install_crash_handler = true);
 
   // Returns the number of processors on the machine.
   static int NumberOfProcessors();

--- a/runtime/bin/platform_fuchsia.cc
+++ b/runtime/bin/platform_fuchsia.cc
@@ -29,7 +29,7 @@ const char* Platform::executable_name_ = nullptr;
 int Platform::script_index_ = 1;
 char** Platform::argv_ = nullptr;
 
-bool Platform::Initialize() {
+bool Platform::Initialize(bool install_crash_handler /* = true */) {
   return true;
 }
 

--- a/runtime/bin/platform_linux.cc
+++ b/runtime/bin/platform_linux.cc
@@ -65,7 +65,7 @@ static void segv_handler(int signal, siginfo_t* siginfo, void* context) {
   abort();
 }
 
-bool Platform::Initialize() {
+bool Platform::Initialize(bool install_crash_handler /* = true */) {
   // Turn off the signal handler for SIGPIPE as it causes the process
   // to terminate on writing to a closed pipe. Without the signal
   // handler error EPIPE is set instead.
@@ -87,31 +87,35 @@ bool Platform::Initialize() {
     return false;
   }
 
-  act.sa_flags = SA_SIGINFO;
-  act.sa_sigaction = &segv_handler;
-  if (sigemptyset(&act.sa_mask) != 0) {
-    perror("sigemptyset() failed.");
-    return false;
-  }
-  if (sigaddset(&act.sa_mask, SIGPROF) != 0) {
-    perror("sigaddset() failed");
-    return false;
-  }
-  if (sigaction(SIGSEGV, &act, nullptr) != 0) {
-    perror("sigaction() failed.");
-    return false;
-  }
-  if (sigaction(SIGBUS, &act, nullptr) != 0) {
-    perror("sigaction() failed.");
-    return false;
-  }
-  if (sigaction(SIGTRAP, &act, nullptr) != 0) {
-    perror("sigaction() failed.");
-    return false;
-  }
-  if (sigaction(SIGILL, &act, nullptr) != 0) {
-    perror("sigaction() failed.");
-    return false;
+  if (install_crash_handler) {
+    act = {};
+    act.sa_flags = SA_SIGINFO;
+    act.sa_sigaction = &segv_handler;
+
+    if (sigemptyset(&act.sa_mask) != 0) {
+      perror("sigemptyset() failed.");
+      return false;
+    }
+    if (sigaddset(&act.sa_mask, SIGPROF) != 0) {
+      perror("sigaddset() failed");
+      return false;
+    }
+    if (sigaction(SIGSEGV, &act, nullptr) != 0) {
+      perror("sigaction() failed.");
+      return false;
+    }
+    if (sigaction(SIGBUS, &act, nullptr) != 0) {
+      perror("sigaction() failed.");
+      return false;
+    }
+    if (sigaction(SIGTRAP, &act, nullptr) != 0) {
+      perror("sigaction() failed.");
+      return false;
+    }
+    if (sigaction(SIGILL, &act, nullptr) != 0) {
+      perror("sigaction() failed.");
+      return false;
+    }
   }
   return true;
 }

--- a/runtime/bin/platform_macos.cc
+++ b/runtime/bin/platform_macos.cc
@@ -72,7 +72,7 @@ static void segv_handler(int signal, siginfo_t* siginfo, void* context) {
   abort();
 }
 
-bool Platform::Initialize() {
+bool Platform::Initialize(bool install_crash_handler /*= true */) {
   // Turn off the signal handler for SIGPIPE as it causes the process
   // to terminate on writing to a closed pipe. Without the signal
   // handler error EPIPE is set instead.
@@ -94,31 +94,34 @@ bool Platform::Initialize() {
     return false;
   }
 
-  act.sa_flags = SA_SIGINFO;
-  act.sa_sigaction = &segv_handler;
-  if (sigemptyset(&act.sa_mask) != 0) {
-    perror("sigemptyset() failed.");
-    return false;
-  }
-  if (sigaddset(&act.sa_mask, SIGPROF) != 0) {
-    perror("sigaddset() failed");
-    return false;
-  }
-  if (sigaction(SIGSEGV, &act, nullptr) != 0) {
-    perror("sigaction() failed.");
-    return false;
-  }
-  if (sigaction(SIGBUS, &act, nullptr) != 0) {
-    perror("sigaction() failed.");
-    return false;
-  }
-  if (sigaction(SIGTRAP, &act, nullptr) != 0) {
-    perror("sigaction() failed.");
-    return false;
-  }
-  if (sigaction(SIGILL, &act, nullptr) != 0) {
-    perror("sigaction() failed.");
-    return false;
+  if (install_crash_handler) {
+    act = {};
+    act.sa_flags = SA_SIGINFO;
+    act.sa_sigaction = &segv_handler;
+    if (sigemptyset(&act.sa_mask) != 0) {
+      perror("sigemptyset() failed.");
+      return false;
+    }
+    if (sigaddset(&act.sa_mask, SIGPROF) != 0) {
+      perror("sigaddset() failed");
+      return false;
+    }
+    if (sigaction(SIGSEGV, &act, nullptr) != 0) {
+      perror("sigaction() failed.");
+      return false;
+    }
+    if (sigaction(SIGBUS, &act, nullptr) != 0) {
+      perror("sigaction() failed.");
+      return false;
+    }
+    if (sigaction(SIGTRAP, &act, nullptr) != 0) {
+      perror("sigaction() failed.");
+      return false;
+    }
+    if (sigaction(SIGILL, &act, nullptr) != 0) {
+      perror("sigaction() failed.");
+      return false;
+    }
   }
   return true;
 }

--- a/runtime/bin/platform_win.cc
+++ b/runtime/bin/platform_win.cc
@@ -38,7 +38,7 @@ char** Platform::argv_ = nullptr;
 
 class PlatformWin {
  public:
-  static void InitOnce() {
+  static void InitOnce(bool install_crash_handler) {
     // Set up a no-op handler so that CRT functions return an error instead of
     // hitting an assertion failure.
     // See: https://msdn.microsoft.com/en-us/library/a9yf33zb.aspx
@@ -73,7 +73,9 @@ class PlatformWin {
     UINT existing_mode = SetErrorMode(new_mode);
     SetErrorMode(new_mode | existing_mode);
     // Set up global exception handler to be able to dump stack trace on crash.
-    SetExceptionHandler();
+    if (install_crash_handler) {
+      SetExceptionHandler();
+    }
   }
 
   // Windows top-level unhandled exception handler function.
@@ -131,8 +133,8 @@ class CoInitializeScope : public ValueObject {
   HRESULT hres;
 };
 
-bool Platform::Initialize() {
-  PlatformWin::InitOnce();
+bool Platform::Initialize(bool install_crash_handler /* = true */) {
+  PlatformWin::InitOnce(install_crash_handler);
   return true;
 }
 

--- a/runtime/bin/process_macos.cc
+++ b/runtime/bin/process_macos.cc
@@ -209,19 +209,8 @@ class ExitCodeHandler {
         intptr_t exit_code_fd = ProcessInfoList::LookupProcessExitFd(pid);
         if (exit_code_fd != 0) {
           int message[2] = {exit_code, negative};
-          ssize_t result;
-
-          // Block SIGPIPE so writing to a closed pipe does not terminate the process.
-          sigset_t block_sigpipe, old_mask;
-          sigemptyset(&block_sigpipe);
-          sigaddset(&block_sigpipe, SIGPIPE);
-          pthread_sigmask(SIG_BLOCK, &block_sigpipe, &old_mask);
-
-          result =
+          ssize_t result =
               FDUtils::WriteToBlocking(exit_code_fd, &message, sizeof(message));
-              
-          pthread_sigmask(SIG_SETMASK, &old_mask, nullptr);
-
           // If the process has been closed, the read end of the exit
           // pipe has been closed. It is therefore not a problem that
           // write fails with a broken pipe error. Other errors should

--- a/runtime/bin/process_macos.cc
+++ b/runtime/bin/process_macos.cc
@@ -209,8 +209,19 @@ class ExitCodeHandler {
         intptr_t exit_code_fd = ProcessInfoList::LookupProcessExitFd(pid);
         if (exit_code_fd != 0) {
           int message[2] = {exit_code, negative};
-          ssize_t result =
+          ssize_t result;
+
+          // Block SIGPIPE so writing to a closed pipe does not terminate the process.
+          sigset_t block_sigpipe, old_mask;
+          sigemptyset(&block_sigpipe);
+          sigaddset(&block_sigpipe, SIGPIPE);
+          pthread_sigmask(SIG_BLOCK, &block_sigpipe, &old_mask);
+
+          result =
               FDUtils::WriteToBlocking(exit_code_fd, &message, sizeof(message));
+              
+          pthread_sigmask(SIG_SETMASK, &old_mask, nullptr);
+
           // If the process has been closed, the read end of the exit
           // pipe has been closed. It is therefore not a problem that
           // write fails with a broken pipe error. Other errors should


### PR DESCRIPTION
## Summary
On macOS, writing to a closed exit pipe can deliver SIGPIPE which terminates the process even when EPIPE is handled correctly.

This change temporarily blocks SIGPIPE while writing the exit code in "ExitCodeHandlerEntry". This ensures that failed "Process.start" calls do not trigger unintended process termination.

The signal mask is scoped only around the write operation to keep the behaviour localized and avoid affecting global signal handling.

## Platform: macOS only

## Fixes: #62679.