### PR TITLE
Mark #sizeOf getter as synthetic in FFI struct transformation

### DIFF
--- a/pkg/front_end/testcases/general/ffi_external_in_part_file.dart.strong.transformed.expect
+++ b/pkg/front_end/testcases/general/ffi_external_in_part_file.dart.strong.transformed.expect
@@ -33,7 +33,7 @@ final class Struct1ByteInt extends ffi::Struct {
   static synthetic get a0#offsetOf() → core::int
     return #C13.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
   @#C10
-  static get #sizeOf() → core::int
+  static synthetic get #sizeOf() → core::int
     return #C15.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
 }
 static method notMain() → void {

--- a/pkg/front_end/testcases/general/ffi_sample.dart.strong.transformed.expect
+++ b/pkg/front_end/testcases/general/ffi_sample.dart.strong.transformed.expect
@@ -70,7 +70,7 @@ class Coordinate extends ffi::Struct {
   set next(synthesized ffi::Pointer<self::Coordinate> #v) → void
     return ffi::_storePointer<self::Coordinate>(this.{ffi::_Compound::_typedDataBase}{core::Object}, self::Coordinate::next#offsetOf.{core::num::+}(this.{ffi::_Compound::_offsetInBytes}{core::int}){(core::num) → core::num}, #v);
   @#C11
-  static get #sizeOf() → core::int
+  static synthetic get #sizeOf() → core::int
     return #C21.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
 }
 static method main() → dynamic {}

--- a/pkg/front_end/testcases/incremental/crash_05.yaml.world.1.expect
+++ b/pkg/front_end/testcases/incremental/crash_05.yaml.world.1.expect
@@ -28,7 +28,7 @@ library from "org-dartlang-test:///lib.dart" as lib {
     static synthetic get yy#offsetOf() → dart.core::int
       return #C13.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
     @#C10
-    static get #sizeOf() → dart.core::int
+    static synthetic get #sizeOf() → dart.core::int
       return #C15.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
   }
 }
@@ -60,7 +60,7 @@ library from "org-dartlang-test:///main.dart" as main {
     static synthetic get xx#offsetOf() → dart.core::int
       return #C13.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
     @#C10
-    static get #sizeOf() → dart.core::int
+    static synthetic get #sizeOf() → dart.core::int
       return #C15.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
   }
 }

--- a/pkg/front_end/testcases/incremental/crash_05.yaml.world.2.expect
+++ b/pkg/front_end/testcases/incremental/crash_05.yaml.world.2.expect
@@ -28,7 +28,7 @@ library from "org-dartlang-test:///lib.dart" as lib {
     static synthetic get yy#offsetOf() → dart.core::int
       return #C13.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
     @#C10
-    static get #sizeOf() → dart.core::int
+    static synthetic get #sizeOf() → dart.core::int
       return #C15.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
   }
 }
@@ -60,7 +60,7 @@ library from "org-dartlang-test:///main.dart" as main {
     static synthetic get xx#offsetOf() → dart.core::int
       return #C13.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
     @#C10
-    static get #sizeOf() → dart.core::int
+    static synthetic get #sizeOf() → dart.core::int
       return #C15.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
   }
 }

--- a/pkg/front_end/testcases/incremental/crash_06.yaml.world.1.expect
+++ b/pkg/front_end/testcases/incremental/crash_06.yaml.world.1.expect
@@ -44,7 +44,7 @@ library from "org-dartlang-test:///structs.dart" as str {
     static synthetic get yy#offsetOf() → dart.core::int
       return #C12.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
     @#C10
-    static get #sizeOf() → dart.core::int
+    static synthetic get #sizeOf() → dart.core::int
       return #C12.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
   }
   @#C3
@@ -62,7 +62,7 @@ library from "org-dartlang-test:///structs.dart" as str {
     external get zz() → invalid-type;
     external set zz(synthesized invalid-type #externalFieldValue) → void;
     @#C10
-    static get #sizeOf() → dart.core::int
+    static synthetic get #sizeOf() → dart.core::int
       return #C12.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
   }
 }

--- a/pkg/front_end/testcases/incremental/crash_06.yaml.world.2.expect
+++ b/pkg/front_end/testcases/incremental/crash_06.yaml.world.2.expect
@@ -44,7 +44,7 @@ library from "org-dartlang-test:///structs.dart" as str {
     static synthetic get yy#offsetOf() → dart.core::int
       return #C12.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
     @#C10
-    static get #sizeOf() → dart.core::int
+    static synthetic get #sizeOf() → dart.core::int
       return #C12.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
   }
   @#C3
@@ -62,7 +62,7 @@ library from "org-dartlang-test:///structs.dart" as str {
     external get zz() → invalid-type;
     external set zz(synthesized invalid-type #externalFieldValue) → void;
     @#C10
-    static get #sizeOf() → dart.core::int
+    static synthetic get #sizeOf() → dart.core::int
       return #C12.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
   }
 }

--- a/pkg/front_end/testcases/incremental/ffi_01.yaml.world.1.expect
+++ b/pkg/front_end/testcases/incremental/ffi_01.yaml.world.1.expect
@@ -48,7 +48,7 @@ library from "org-dartlang-test:///lib.dart" as lib {
     static synthetic get next#offsetOf() → dart.core::int
       return #C18.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
     @#C11
-    static get #sizeOf() → dart.core::int
+    static synthetic get #sizeOf() → dart.core::int
       return #C21.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
   }
 }

--- a/pkg/front_end/testcases/incremental/ffi_01.yaml.world.2.expect
+++ b/pkg/front_end/testcases/incremental/ffi_01.yaml.world.2.expect
@@ -48,7 +48,7 @@ library from "org-dartlang-test:///lib.dart" as lib {
     static synthetic get next#offsetOf() → dart.core::int
       return #C18.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
     @#C11
-    static get #sizeOf() → dart.core::int
+    static synthetic get #sizeOf() → dart.core::int
       return #C21.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
   }
 }

--- a/pkg/front_end/testcases/incremental/ffi_02.yaml.world.1.expect
+++ b/pkg/front_end/testcases/incremental/ffi_02.yaml.world.1.expect
@@ -48,7 +48,7 @@ library from "org-dartlang-test:///lib.dart" as lib {
     static synthetic get next#offsetOf() → dart.core::int
       return #C18.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
     @#C11
-    static get #sizeOf() → dart.core::int
+    static synthetic get #sizeOf() → dart.core::int
       return #C21.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
   }
 }

--- a/pkg/front_end/testcases/incremental/issue_46666.yaml.world.1.expect
+++ b/pkg/front_end/testcases/incremental/issue_46666.yaml.world.1.expect
@@ -53,7 +53,7 @@ library from "org-dartlang-test:///a.dart" as a {
     static synthetic get blah#offsetOf() → dart.core::int
       return #C14.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
     @#C11
-    static get #sizeOf() → dart.core::int
+    static synthetic get #sizeOf() → dart.core::int
       return #C23.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
   }
   @#C3
@@ -97,7 +97,7 @@ library from "org-dartlang-test:///a.dart" as a {
     static synthetic get n3#offsetOf() → dart.core::int
       return #C21.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
     @#C11
-    static get #sizeOf() → dart.core::int
+    static synthetic get #sizeOf() → dart.core::int
       return #C14.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
   }
 }
@@ -131,7 +131,7 @@ library from "org-dartlang-test:///b.dart" as b {
     static synthetic get b1#offsetOf() → dart.core::int
       return #C16.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
     @#C11
-    static get #sizeOf() → dart.core::int
+    static synthetic get #sizeOf() → dart.core::int
       return #C23.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
   }
   static method periodic() → void {

--- a/pkg/front_end/testcases/incremental/issue_46666.yaml.world.2.expect
+++ b/pkg/front_end/testcases/incremental/issue_46666.yaml.world.2.expect
@@ -53,7 +53,7 @@ library from "org-dartlang-test:///a.dart" as a {
     static synthetic get blah#offsetOf() → dart.core::int
       return #C14.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
     @#C11
-    static get #sizeOf() → dart.core::int
+    static synthetic get #sizeOf() → dart.core::int
       return #C23.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
   }
   @#C3
@@ -97,7 +97,7 @@ library from "org-dartlang-test:///a.dart" as a {
     static synthetic get n3#offsetOf() → dart.core::int
       return #C21.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
     @#C11
-    static get #sizeOf() → dart.core::int
+    static synthetic get #sizeOf() → dart.core::int
       return #C14.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
   }
 }
@@ -131,7 +131,7 @@ library from "org-dartlang-test:///b.dart" as b {
     static synthetic get b1#offsetOf() → dart.core::int
       return #C16.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
     @#C11
-    static get #sizeOf() → dart.core::int
+    static synthetic get #sizeOf() → dart.core::int
       return #C23.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
   }
   static method periodic() → void {

--- a/pkg/front_end/testcases/incremental/no_outline_change_35.yaml.world.1.expect
+++ b/pkg/front_end/testcases/incremental/no_outline_change_35.yaml.world.1.expect
@@ -48,7 +48,7 @@ library from "org-dartlang-test:///lib.dart" as lib {
     static synthetic get next#offsetOf() → dart.core::int
       return #C18.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
     @#C11
-    static get #sizeOf() → dart.core::int
+    static synthetic get #sizeOf() → dart.core::int
       return #C21.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
   }
 }

--- a/pkg/front_end/testcases/incremental/no_outline_change_35.yaml.world.2.expect
+++ b/pkg/front_end/testcases/incremental/no_outline_change_35.yaml.world.2.expect
@@ -48,7 +48,7 @@ library from "org-dartlang-test:///lib.dart" as lib {
     static synthetic get next#offsetOf() → dart.core::int
       return #C18.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
     @#C11
-    static get #sizeOf() → dart.core::int
+    static synthetic get #sizeOf() → dart.core::int
       return #C21.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
   }
 }

--- a/pkg/front_end/testcases/incremental/no_outline_change_35.yaml.world.3.expect
+++ b/pkg/front_end/testcases/incremental/no_outline_change_35.yaml.world.3.expect
@@ -49,7 +49,7 @@ library from "org-dartlang-test:///lib.dart" as lib {
     static synthetic get next#offsetOf() → dart.core::int
       return #C18.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
     @#C11
-    static get #sizeOf() → dart.core::int
+    static synthetic get #sizeOf() → dart.core::int
       return #C21.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
   }
 }

--- a/pkg/front_end/testcases/incremental/no_outline_change_48_ffi.yaml.world.1.expect
+++ b/pkg/front_end/testcases/incremental/no_outline_change_48_ffi.yaml.world.1.expect
@@ -50,7 +50,7 @@ library from "org-dartlang-test:///lib.dart" as lib {
     static synthetic get y3#offsetOf() → dart.core::int
       return #C20.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
     @#C11
-    static get #sizeOf() → dart.core::int
+    static synthetic get #sizeOf() → dart.core::int
       return #C23.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
   }
 }
@@ -102,7 +102,7 @@ library from "org-dartlang-test:///main.dart" as main {
     static synthetic get x3#offsetOf() → dart.core::int
       return #C30.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
     @#C11
-    static get #sizeOf() → dart.core::int
+    static synthetic get #sizeOf() → dart.core::int
       return #C33.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
   }
 }

--- a/pkg/front_end/testcases/incremental/no_outline_change_48_ffi.yaml.world.2.expect
+++ b/pkg/front_end/testcases/incremental/no_outline_change_48_ffi.yaml.world.2.expect
@@ -50,7 +50,7 @@ library from "org-dartlang-test:///lib.dart" as lib {
     static synthetic get y2#offsetOf() → dart.core::int
       return #C21.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
     @#C11
-    static get #sizeOf() → dart.core::int
+    static synthetic get #sizeOf() → dart.core::int
       return #C23.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
   }
 }
@@ -102,7 +102,7 @@ library from "org-dartlang-test:///main.dart" as main {
     static synthetic get x3#offsetOf() → dart.core::int
       return #C30.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
     @#C11
-    static get #sizeOf() → dart.core::int
+    static synthetic get #sizeOf() → dart.core::int
       return #C33.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
   }
 }

--- a/pkg/front_end/testcases/incremental/no_outline_change_49_ffi.yaml.world.1.expect
+++ b/pkg/front_end/testcases/incremental/no_outline_change_49_ffi.yaml.world.1.expect
@@ -50,7 +50,7 @@ library from "org-dartlang-test:///lib.dart" as lib {
     static synthetic get y3#offsetOf() → dart.core::int
       return #C20.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
     @#C11
-    static get #sizeOf() → dart.core::int
+    static synthetic get #sizeOf() → dart.core::int
       return #C23.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
   }
 }
@@ -102,7 +102,7 @@ library from "org-dartlang-test:///main.dart" as main {
     static synthetic get x3#offsetOf() → dart.core::int
       return #C30.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
     @#C11
-    static get #sizeOf() → dart.core::int
+    static synthetic get #sizeOf() → dart.core::int
       return #C33.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
   }
 }

--- a/pkg/front_end/testcases/incremental/no_outline_change_49_ffi.yaml.world.2.expect
+++ b/pkg/front_end/testcases/incremental/no_outline_change_49_ffi.yaml.world.2.expect
@@ -50,7 +50,7 @@ library from "org-dartlang-test:///lib.dart" as lib {
     static synthetic get y2#offsetOf() → dart.core::int
       return #C21.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
     @#C11
-    static get #sizeOf() → dart.core::int
+    static synthetic get #sizeOf() → dart.core::int
       return #C23.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
   }
 }
@@ -102,7 +102,7 @@ library from "org-dartlang-test:///main.dart" as main {
     static synthetic get x3#offsetOf() → dart.core::int
       return #C30.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
     @#C11
-    static get #sizeOf() → dart.core::int
+    static synthetic get #sizeOf() → dart.core::int
       return #C33.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
   }
 }

--- a/pkg/front_end/testcases/incremental/no_outline_change_50_ffi.yaml.world.1.expect
+++ b/pkg/front_end/testcases/incremental/no_outline_change_50_ffi.yaml.world.1.expect
@@ -50,7 +50,7 @@ library from "org-dartlang-test:///lib.dart" as lib {
     static synthetic get y3#offsetOf() → dart.core::int
       return #C20.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
     @#C11
-    static get #sizeOf() → dart.core::int
+    static synthetic get #sizeOf() → dart.core::int
       return #C23.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
   }
 }
@@ -324,7 +324,7 @@ library from "org-dartlang-test:///main.dart" as main {
     static synthetic get x3#offsetOf() → dart.core::int
       return #C30.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
     @#C11
-    static get #sizeOf() → dart.core::int
+    static synthetic get #sizeOf() → dart.core::int
       return #C33.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
   }
 }

--- a/pkg/front_end/testcases/incremental/no_outline_change_50_ffi.yaml.world.2.expect
+++ b/pkg/front_end/testcases/incremental/no_outline_change_50_ffi.yaml.world.2.expect
@@ -50,7 +50,7 @@ library from "org-dartlang-test:///lib.dart" as lib {
     static synthetic get y2#offsetOf() → dart.core::int
       return #C21.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
     @#C11
-    static get #sizeOf() → dart.core::int
+    static synthetic get #sizeOf() → dart.core::int
       return #C23.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
   }
 }
@@ -324,7 +324,7 @@ library from "org-dartlang-test:///main.dart" as main {
     static synthetic get x3#offsetOf() → dart.core::int
       return #C30.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
     @#C11
-    static get #sizeOf() → dart.core::int
+    static synthetic get #sizeOf() → dart.core::int
       return #C33.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
   }
 }

--- a/pkg/front_end/testcases/incremental/regress_46004.yaml.world.1.expect
+++ b/pkg/front_end/testcases/incremental/regress_46004.yaml.world.1.expect
@@ -28,7 +28,7 @@ library from "org-dartlang-test:///lib.dart" as lib {
     static synthetic get lpVtbl#offsetOf() → dart.core::int
       return #C12.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
     @#C10
-    static get #sizeOf() → dart.core::int
+    static synthetic get #sizeOf() → dart.core::int
       return #C15.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
   }
 }
@@ -60,7 +60,7 @@ library from "org-dartlang-test:///main.dart" as main {
     static synthetic get xx#offsetOf() → dart.core::int
       return #C12.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
     @#C10
-    static get #sizeOf() → dart.core::int
+    static synthetic get #sizeOf() → dart.core::int
       return #C15.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
   }
 }

--- a/pkg/front_end/testcases/incremental/regress_46004.yaml.world.2.expect
+++ b/pkg/front_end/testcases/incremental/regress_46004.yaml.world.2.expect
@@ -28,7 +28,7 @@ library from "org-dartlang-test:///lib.dart" as lib {
     static synthetic get lpVtbl#offsetOf() → dart.core::int
       return #C12.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
     @#C10
-    static get #sizeOf() → dart.core::int
+    static synthetic get #sizeOf() → dart.core::int
       return #C15.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
   }
 }
@@ -60,7 +60,7 @@ library from "org-dartlang-test:///main.dart" as main {
     static synthetic get xx#offsetOf() → dart.core::int
       return #C12.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
     @#C10
-    static get #sizeOf() → dart.core::int
+    static synthetic get #sizeOf() → dart.core::int
       return #C15.{dart.core::List::[]}(dart.ffi::_abi()){(dart.core::int) → dart.core::int};
   }
 }

--- a/pkg/front_end/testcases/nnbd/ffi_sample.dart.strong.transformed.expect
+++ b/pkg/front_end/testcases/nnbd/ffi_sample.dart.strong.transformed.expect
@@ -56,7 +56,7 @@ final class Coordinate extends ffi::Struct {
   static synthetic get next#offsetOf() → core::int
     return #C18.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
   @#C11
-  static get #sizeOf() → core::int
+  static synthetic get #sizeOf() → core::int
     return #C21.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
 }
 static method main() → dynamic {}

--- a/pkg/front_end/testcases/nnbd/ffi_struct_inline_array.dart.strong.transformed.expect
+++ b/pkg/front_end/testcases/nnbd/ffi_struct_inline_array.dart.strong.transformed.expect
@@ -32,7 +32,7 @@ final class StructInlineArray extends ffi::Struct {
   static synthetic get a0#offsetOf() → core::int
     return #C18.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
   @#C13
-  static get #sizeOf() → core::int
+  static synthetic get #sizeOf() → core::int
     return #C16.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
 }
 static method main() → dynamic {}

--- a/pkg/front_end/testcases/nnbd/ffi_struct_inline_array_multi_dimensional.dart.strong.transformed.expect
+++ b/pkg/front_end/testcases/nnbd/ffi_struct_inline_array_multi_dimensional.dart.strong.transformed.expect
@@ -33,7 +33,7 @@ final class StructInlineArrayMultiDimensional extends ffi::Struct {
   static synthetic get a0#offsetOf() → core::int
     return #C19.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
   @#C13
-  static get #sizeOf() → core::int
+  static synthetic get #sizeOf() → core::int
     return #C17.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
 }
 static method main() → dynamic {

--- a/pkg/vm/lib/modular/transformations/ffi/definitions.dart
+++ b/pkg/vm/lib/modular/transformations/ffi/definitions.dart
@@ -1149,7 +1149,9 @@ class _FfiDefinitionTransformer extends FfiTransformer {
       fileUri: compound.fileUri,
       reference: getterReference,
       isStatic: true,
-    )..fileOffset = compound.fileOffset;
+    )
+    ..fileOffset = compound.fileOffset
+    ..isSynthetic = true;
     addPragmaPreferInline(getter);
     compound.addProcedure(getter);
   }

--- a/pkg/vm/testcases/transformations/ffi/abi_specific_int.dart.aot.expect
+++ b/pkg/vm/testcases/transformations/ffi/abi_specific_int.dart.aot.expect
@@ -12,7 +12,7 @@ abstract final class WChar extends ffi::AbiSpecificInteger /*hasConstConstructor
   [@vm.inferred-return-type.metadata=dart.core::_Smi]
   [@vm.unboxing-info.metadata=()->i]
   @#C10
-  static get #sizeOf() → core::int
+  static synthetic get #sizeOf() → core::int
     return #C13.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
 }
 @#C15
@@ -44,7 +44,7 @@ final class WCharStruct extends ffi::Struct {
   [@vm.inferred-return-type.metadata=dart.core::_Smi]
   [@vm.unboxing-info.metadata=()->i]
   @#C10
-  static get #sizeOf() → core::int
+  static synthetic get #sizeOf() → core::int
     return #C24.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
 }
 @#C15
@@ -69,7 +69,7 @@ final class WCharArrayStruct extends ffi::Struct {
   [@vm.inferred-return-type.metadata=dart.core::_Smi]
   [@vm.unboxing-info.metadata=()->i]
   @#C10
-  static get #sizeOf() → core::int
+  static synthetic get #sizeOf() → core::int
     return #C34.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
 }
 class _DummyAllocator extends core::Object implements ffi::Allocator /*hasConstConstructor*/  {

--- a/pkg/vm/testcases/transformations/ffi/abi_specific_int.dart.expect
+++ b/pkg/vm/testcases/transformations/ffi/abi_specific_int.dart.expect
@@ -13,7 +13,7 @@ final class WChar extends ffi::AbiSpecificInteger /*hasConstConstructor*/  {
     : super ffi::AbiSpecificInteger::•()
     ;
   @#C67
-  static get #sizeOf() → core::int
+  static synthetic get #sizeOf() → core::int
     return #C68.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
 }
 @#C70
@@ -52,7 +52,7 @@ final class WCharStruct extends ffi::Struct {
   static synthetic get a1#offsetOf() → core::int
     return #C68.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
   @#C67
-  static get #sizeOf() → core::int
+  static synthetic get #sizeOf() → core::int
     return #C79.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
 }
 @#C70
@@ -80,7 +80,7 @@ final class WCharArrayStruct extends ffi::Struct {
   static synthetic get a0#offsetOf() → core::int
     return #C77.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
   @#C67
-  static get #sizeOf() → core::int
+  static synthetic get #sizeOf() → core::int
     return #C90.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
 }
 class _DummyAllocator extends core::Object implements ffi::Allocator /*hasConstConstructor*/  {

--- a/pkg/vm/testcases/transformations/ffi/abi_specific_int_incomplete.dart.aot.expect
+++ b/pkg/vm/testcases/transformations/ffi/abi_specific_int_incomplete.dart.aot.expect
@@ -12,7 +12,7 @@ abstract final class Incomplete extends ffi::AbiSpecificInteger /*hasConstConstr
   [@vm.inferred-return-type.metadata=dart.core::_Smi (value: 4)]
   [@vm.unboxing-info.metadata=()->i]
   @#C8
-  static get #sizeOf() → core::int
+  static synthetic get #sizeOf() → core::int
     return [@vm.inferred-type.metadata=dart.core::_Smi (value: 4)] ffi::_checkAbiSpecificIntegerMapping<core::int>(#C10.{core::List::[]}(ffi::_abi()){(core::int) → core::int?});
 }
 @#C12
@@ -44,7 +44,7 @@ final class IncompleteStruct extends ffi::Struct {
   [@vm.inferred-return-type.metadata=dart.core::_Smi (value: 8)]
   [@vm.unboxing-info.metadata=()->i]
   @#C8
-  static get #sizeOf() → core::int
+  static synthetic get #sizeOf() → core::int
     return [@vm.inferred-type.metadata=dart.core::_Smi (value: 8)] ffi::_checkAbiSpecificIntegerMapping<core::int>(#C21.{core::List::[]}(ffi::_abi()){(core::int) → core::int?});
 }
 @#C12
@@ -69,7 +69,7 @@ final class IncompleteArrayStruct extends ffi::Struct {
   [@vm.inferred-return-type.metadata=dart.core::_Smi (value: 400)]
   [@vm.unboxing-info.metadata=()->i]
   @#C8
-  static get #sizeOf() → core::int
+  static synthetic get #sizeOf() → core::int
     return [@vm.inferred-type.metadata=dart.core::_Smi (value: 400)] ffi::_checkAbiSpecificIntegerMapping<core::int>(#C30.{core::List::[]}(ffi::_abi()){(core::int) → core::int?});
 }
 class _DummyAllocator extends core::Object implements ffi::Allocator /*hasConstConstructor*/  {

--- a/pkg/vm/testcases/transformations/ffi/abi_specific_int_incomplete.dart.expect
+++ b/pkg/vm/testcases/transformations/ffi/abi_specific_int_incomplete.dart.expect
@@ -13,7 +13,7 @@ final class Incomplete extends ffi::AbiSpecificInteger /*hasConstConstructor*/  
     : super ffi::AbiSpecificInteger::•()
     ;
   @#C29
-  static get #sizeOf() → core::int
+  static synthetic get #sizeOf() → core::int
     return ffi::_checkAbiSpecificIntegerMapping<core::int>(#C31.{core::List::[]}(ffi::_abi()){(core::int) → core::int?});
 }
 @#C33
@@ -52,7 +52,7 @@ final class IncompleteStruct extends ffi::Struct {
   static synthetic get a1#offsetOf() → core::int
     return ffi::_checkAbiSpecificIntegerMapping<core::int>(#C31.{core::List::[]}(ffi::_abi()){(core::int) → core::int?});
   @#C29
-  static get #sizeOf() → core::int
+  static synthetic get #sizeOf() → core::int
     return ffi::_checkAbiSpecificIntegerMapping<core::int>(#C42.{core::List::[]}(ffi::_abi()){(core::int) → core::int?});
 }
 @#C33
@@ -80,7 +80,7 @@ final class IncompleteArrayStruct extends ffi::Struct {
   static synthetic get a0#offsetOf() → core::int
     return #C40.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
   @#C29
-  static get #sizeOf() → core::int
+  static synthetic get #sizeOf() → core::int
     return ffi::_checkAbiSpecificIntegerMapping<core::int>(#C52.{core::List::[]}(ffi::_abi()){(core::int) → core::int?});
 }
 class _DummyAllocator extends core::Object implements ffi::Allocator /*hasConstConstructor*/  {

--- a/pkg/vm/testcases/transformations/ffi/address_of_cast_compound_element.dart.aot.expect
+++ b/pkg/vm/testcases/transformations/ffi/address_of_cast_compound_element.dart.aot.expect
@@ -52,7 +52,7 @@ final class MyStruct extends ffi::Struct {
   [@vm.inferred-return-type.metadata=dart.core::_Smi]
   [@vm.unboxing-info.metadata=()->i]
   @#C15
-  static get #sizeOf() → core::int
+  static synthetic get #sizeOf() → core::int
     return #C28.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
 }
 @#C3
@@ -65,7 +65,7 @@ final class MyUnion extends ffi::Union {
   [@vm.inferred-return-type.metadata=dart.core::_Smi (value: 1)]
   [@vm.unboxing-info.metadata=()->i]
   @#C15
-  static get #sizeOf() → core::int
+  static synthetic get #sizeOf() → core::int
     return #C20.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
 }
 

--- a/pkg/vm/testcases/transformations/ffi/address_of_cast_compound_element.dart.expect
+++ b/pkg/vm/testcases/transformations/ffi/address_of_cast_compound_element.dart.expect
@@ -64,7 +64,7 @@ final class MyStruct extends ffi::Struct {
   static synthetic get array2#offsetOf() → core::int
     return #C31.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
   @#C15
-  static get #sizeOf() → core::int
+  static synthetic get #sizeOf() → core::int
     return #C34.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
 }
 @#C3
@@ -103,7 +103,7 @@ final class MyUnion extends ffi::Union {
   static synthetic get b#offsetOf() → core::int
     return #C24.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
   @#C15
-  static get #sizeOf() → core::int
+  static synthetic get #sizeOf() → core::int
     return #C26.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
 }
 static method main() → void {

--- a/pkg/vm/testcases/transformations/ffi/address_of_struct.dart.aot.expect
+++ b/pkg/vm/testcases/transformations/ffi/address_of_struct.dart.aot.expect
@@ -28,7 +28,7 @@ final class MyStruct extends ffi::Struct {
   [@vm.inferred-return-type.metadata=dart.core::_Smi (value: 10)]
   [@vm.unboxing-info.metadata=()->i]
   @#C13
-  static get #sizeOf() → core::int
+  static synthetic get #sizeOf() → core::int
     return #C17.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
 }
 @#C3
@@ -41,7 +41,7 @@ final class MyUnion extends ffi::Union {
   [@vm.inferred-return-type.metadata=dart.core::_Smi (value: 1)]
   [@vm.unboxing-info.metadata=()->i]
   @#C13
-  static get #sizeOf() → core::int
+  static synthetic get #sizeOf() → core::int
     return #C22.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
 }
 

--- a/pkg/vm/testcases/transformations/ffi/address_of_struct.dart.expect
+++ b/pkg/vm/testcases/transformations/ffi/address_of_struct.dart.expect
@@ -31,7 +31,7 @@ final class MyStruct extends ffi::Struct {
   static synthetic get a#offsetOf() → core::int
     return #C18.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
   @#C13
-  static get #sizeOf() → core::int
+  static synthetic get #sizeOf() → core::int
     return #C16.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
 }
 @#C3
@@ -59,7 +59,7 @@ final class MyUnion extends ffi::Union {
   static synthetic get a#offsetOf() → core::int
     return #C18.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
   @#C13
-  static get #sizeOf() → core::int
+  static synthetic get #sizeOf() → core::int
     return #C24.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
 }
 static method main() → void {

--- a/pkg/vm/testcases/transformations/ffi/address_of_struct_element.dart.aot.expect
+++ b/pkg/vm/testcases/transformations/ffi/address_of_struct_element.dart.aot.expect
@@ -52,7 +52,7 @@ final class MyStruct extends ffi::Struct {
   [@vm.inferred-return-type.metadata=dart.core::_Smi]
   [@vm.unboxing-info.metadata=()->i]
   @#C15
-  static get #sizeOf() → core::int
+  static synthetic get #sizeOf() → core::int
     return #C28.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
 }
 @#C3
@@ -65,7 +65,7 @@ final class MyUnion extends ffi::Union {
   [@vm.inferred-return-type.metadata=dart.core::_Smi (value: 1)]
   [@vm.unboxing-info.metadata=()->i]
   @#C15
-  static get #sizeOf() → core::int
+  static synthetic get #sizeOf() → core::int
     return #C20.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
 }
 

--- a/pkg/vm/testcases/transformations/ffi/address_of_struct_element.dart.expect
+++ b/pkg/vm/testcases/transformations/ffi/address_of_struct_element.dart.expect
@@ -64,7 +64,7 @@ final class MyStruct extends ffi::Struct {
   static synthetic get array2#offsetOf() → core::int
     return #C31.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
   @#C15
-  static get #sizeOf() → core::int
+  static synthetic get #sizeOf() → core::int
     return #C34.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
 }
 @#C3
@@ -103,7 +103,7 @@ final class MyUnion extends ffi::Union {
   static synthetic get b#offsetOf() → core::int
     return #C24.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
   @#C15
-  static get #sizeOf() → core::int
+  static synthetic get #sizeOf() → core::int
     return #C26.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
 }
 static method main() → void {

--- a/pkg/vm/testcases/transformations/ffi/compound_array_elements.dart.aot.expect
+++ b/pkg/vm/testcases/transformations/ffi/compound_array_elements.dart.aot.expect
@@ -64,7 +64,7 @@ final class TestStruct extends ffi::Struct {
   [@vm.inferred-return-type.metadata=dart.core::_Smi]
   [@vm.unboxing-info.metadata=()->i]
   @#C21
-  static get #sizeOf() → core::int
+  static synthetic get #sizeOf() → core::int
     return #C34.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
 }
 @#C3
@@ -77,7 +77,7 @@ final class MyStruct extends ffi::Struct {
   [@vm.inferred-return-type.metadata=dart.core::_Smi (value: 1)]
   [@vm.unboxing-info.metadata=()->i]
   @#C21
-  static get #sizeOf() → core::int
+  static synthetic get #sizeOf() → core::int
     return #C39.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
 }
 @#C3
@@ -90,7 +90,7 @@ final class MyUnion extends ffi::Union {
   [@vm.inferred-return-type.metadata=dart.core::_Smi (value: 4)]
   [@vm.unboxing-info.metadata=()->i]
   @#C21
-  static get #sizeOf() → core::int
+  static synthetic get #sizeOf() → core::int
     return #C46.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
 }
 

--- a/pkg/vm/testcases/transformations/ffi/compound_array_elements.dart.expect
+++ b/pkg/vm/testcases/transformations/ffi/compound_array_elements.dart.expect
@@ -64,7 +64,7 @@ final class TestStruct extends ffi::Struct {
   static synthetic get abiSpecificIntegerArray#offsetOf() → core::int
     return #C39.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
   @#C20
-  static get #sizeOf() → core::int
+  static synthetic get #sizeOf() → core::int
     return #C42.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
 }
 @#C3
@@ -92,7 +92,7 @@ final class MyStruct extends ffi::Struct {
   static synthetic get structValue#offsetOf() → core::int
     return #C32.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
   @#C20
-  static get #sizeOf() → core::int
+  static synthetic get #sizeOf() → core::int
     return #C48.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
 }
 @#C3
@@ -131,7 +131,7 @@ final class MyUnion extends ffi::Union {
   static synthetic get unionAlt2#offsetOf() → core::int
     return #C32.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
   @#C20
-  static get #sizeOf() → core::int
+  static synthetic get #sizeOf() → core::int
     return #C57.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
 }
 static method main() → void {

--- a/pkg/vm/testcases/transformations/ffi/compound_references.dart.expect
+++ b/pkg/vm/testcases/transformations/ffi/compound_references.dart.expect
@@ -50,7 +50,7 @@ final class Coordinate extends ffi::Struct {
   static synthetic get y#offsetOf() → core::int
     return #C15.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
   @#C10
-  static get #sizeOf() → core::int
+  static synthetic get #sizeOf() → core::int
     return #C17.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
 }
 @#C3
@@ -95,7 +95,7 @@ final class SomeUnion extends ffi::Union {
   static synthetic get id#offsetOf() → core::int
     return #C13.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
   @#C10
-  static get #sizeOf() → core::int
+  static synthetic get #sizeOf() → core::int
     return #C17.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
 }
 static method main() → void {}

--- a/pkg/vm/testcases/transformations/ffi/ffinative_compound_return.dart.expect
+++ b/pkg/vm/testcases/transformations/ffi/ffinative_compound_return.dart.expect
@@ -34,7 +34,7 @@ final class Struct1ByteInt extends ffi::Struct {
   static synthetic get a0#offsetOf() → core::int
     return #C13.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
   @#C10
-  static get #sizeOf() → core::int
+  static synthetic get #sizeOf() → core::int
     return #C15.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
 }
 static method main() → void {

--- a/pkg/vm/testcases/transformations/ffi/native_fields.dart.expect
+++ b/pkg/vm/testcases/transformations/ffi/native_fields.dart.expect
@@ -42,7 +42,7 @@ final class Vec2d extends ffi::Struct {
   static synthetic get y#offsetOf() → core::int
     return #C15.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
   @#C10
-  static get #sizeOf() → core::int
+  static synthetic get #sizeOf() → core::int
     return #C17.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
 }
 @#C3
@@ -70,7 +70,7 @@ final class MyStruct extends ffi::Struct {
   static synthetic get array#offsetOf() → core::int
     return #C13.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
   @#C10
-  static get #sizeOf() → core::int
+  static synthetic get #sizeOf() → core::int
     return #C13.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
 }
 @#C3
@@ -98,7 +98,7 @@ final class MyStruct2 extends ffi::Struct {
   static synthetic get array#offsetOf() → core::int
     return #C13.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
   @#C10
-  static get #sizeOf() → core::int
+  static synthetic get #sizeOf() → core::int
     return #C32.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
 }
 @#C3
@@ -126,7 +126,7 @@ final class MyStruct3 extends ffi::Struct {
   static synthetic get array#offsetOf() → core::int
     return #C13.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
   @#C10
-  static get #sizeOf() → core::int
+  static synthetic get #sizeOf() → core::int
     return #C13.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
 }
 @#C3
@@ -154,7 +154,7 @@ final class MyStruct4 extends ffi::Struct {
   static synthetic get array#offsetOf() → core::int
     return #C13.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
   @#C10
-  static get #sizeOf() → core::int
+  static synthetic get #sizeOf() → core::int
     return #C41.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
 }
 @#C3
@@ -189,7 +189,7 @@ final class MyUnion extends ffi::Union {
   static synthetic get indirectVector#offsetOf() → core::int
     return #C13.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
   @#C10
-  static get #sizeOf() → core::int
+  static synthetic get #sizeOf() → core::int
     return #C17.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
 }
 @#C52

--- a/pkg/vm/testcases/transformations/ffi/regress_61321.dart.expect
+++ b/pkg/vm/testcases/transformations/ffi/regress_61321.dart.expect
@@ -31,7 +31,7 @@ final class version extends ffi::Struct {
   static synthetic get major#offsetOf() → core::int
     return #C13.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
   @#C10
-  static get #sizeOf() → core::int
+  static synthetic get #sizeOf() → core::int
     return #C15.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
 }
 static method main() → void {

--- a/pkg/vm/testcases/transformations/ffi/regress_62087.dart.expect
+++ b/pkg/vm/testcases/transformations/ffi/regress_62087.dart.expect
@@ -29,7 +29,7 @@ final class UA_DataTypeMember extends ffi::Struct {
   static synthetic get memberType#offsetOf() → core::int
     return #C12.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
   @#C10
-  static get #sizeOf() → core::int
+  static synthetic get #sizeOf() → core::int
     return #C15.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
 }
 @#C3
@@ -55,7 +55,7 @@ final class UA_DataType extends ffi::Struct {
   static synthetic get members#offsetOf() → core::int
     return #C12.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
   @#C10
-  static get #sizeOf() → core::int
+  static synthetic get #sizeOf() → core::int
     return #C15.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
 }
 @#C18

--- a/pkg/vm/testcases/transformations/ffi/struct_typed_data.dart.aot.expect
+++ b/pkg/vm/testcases/transformations/ffi/struct_typed_data.dart.aot.expect
@@ -76,7 +76,7 @@ final class Coordinate extends ffi::Struct {
   [@vm.inferred-return-type.metadata=dart.core::_Smi (value: 16)]
   [@vm.unboxing-info.metadata=()->i]
   @#C10
-  static get #sizeOf() → core::int
+  static synthetic get #sizeOf() → core::int
     return #C16.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
 }
 

--- a/pkg/vm/testcases/transformations/ffi/struct_typed_data.dart.expect
+++ b/pkg/vm/testcases/transformations/ffi/struct_typed_data.dart.expect
@@ -53,7 +53,7 @@ final class Coordinate extends ffi::Struct {
   static synthetic get y#offsetOf() → core::int
     return #C15.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
   @#C10
-  static get #sizeOf() → core::int
+  static synthetic get #sizeOf() → core::int
     return #C17.{core::List::[]}(ffi::_abi()){(core::int) → core::int};
 }
 static method main() → void {


### PR DESCRIPTION
The #sizeOf getter generated by _addSizeOfGetter() in pkg/vm/lib/modular/transformations/ffi/definitions.dart is currently not marked as synthetic.

The corresponding #offsetOf getters in the same transformation are already marked with isSynthetic = true. For consistency, the #sizeOf getter should also be marked synthetic.

This issue was identified during GSoC 2026 exploration of the Native Memory Inspector project and suggested by Daco Harkes.

This change adds ..isSynthetic = true to the #sizeOf getter in _addSizeOfGetter().

- [x] I've reviewed the contributor guide and applied the relevant portions to this PR.