### PR TITLE
analyzer: handle glob patterns in workspace field validator

### DIFF
--- a/pkg/analyzer/test/src/pubspec/diagnostics/workspace_field_test.dart
+++ b/pkg/analyzer/test/src/pubspec/diagnostics/workspace_field_test.dart
@@ -66,4 +66,60 @@ workspace:
     - package1
 ''');
   }
+
+  test_workspaceGlob_star_baseExists_noError() {
+    newFolder('/sample/packages');
+    assertNoErrors('''
+name: sample
+workspace:
+  - packages/*
+''');
+  }
+
+  test_workspaceGlob_questionMark_baseExists_noError() {
+    newFolder('/sample/packages');
+    assertNoErrors('''
+name: sample
+workspace:
+  - packages/pkg?
+''');
+  }
+
+  test_workspaceGlob_braces_baseExists_noError() {
+    newFolder('/sample/packages');
+    assertNoErrors('''
+name: sample
+workspace:
+  - packages/{a,b}
+''');
+  }
+
+  test_workspaceGlob_nestedBase_baseExists_noError() {
+    newFolder('/sample/apps/nested');
+    assertNoErrors('''
+name: sample
+workspace:
+  - apps/nested/*
+''');
+  }
+
+  test_workspaceGlob_baseMissing_error() {
+    assertErrors(
+      '''
+name: sample
+workspace:
+  - packages/*
+''',
+      [diag.pathDoesNotExist],
+    );
+  }
+
+  test_workspaceGlob_noBase_noError() {
+    // Pattern starts with a glob character — no base directory to check.
+    assertNoErrors('''
+name: sample
+workspace:
+  - *
+''');
+  }
 }


### PR DESCRIPTION
## Problem

Since Dart 3.11, pub supports glob patterns in the `workspace` field of `pubspec.yaml` (e.g. `packages/*`). The analyzer's workspace validator was never updated to handle this, so it incorrectly reported `path_does_not_exist` for any glob pattern — because it tried to check the literal path `packages/*` on disk, which doesn't exist.

`dart pub get` worked fine; only the analyzer showed a false error.

Fixes #62661

## Solution

For glob patterns (detected via `Glob.quote(s) != s`, consistent with pub's own `_looksLikeGlob`), validate only the base directory — the path prefix before the first wildcard segment:

| Pattern | What we check |
|---|---|
| `packages/*` | `packages/` exists |
| `apps/nested/pkg?` | `apps/nested/` exists |
| `*` | nothing (root always exists) |

Non-glob paths continue to be validated as before.

## Tests

Added tests covering:
- Glob patterns with existing base directory → no error
- Glob patterns with missing base directory → `path_does_not_exist`
- Patterns starting with a wildcard → no error