### PR TITLE
analyzer: handle glob patterns in workspace field validator

### DIFF
--- a/pkg/analyzer/lib/src/pubspec/validators/workspace_validator.dart
+++ b/pkg/analyzer/lib/src/pubspec/validators/workspace_validator.dart
@@ -5,6 +5,7 @@
 import 'package:analyzer/src/diagnostic/diagnostic.dart' as diag;
 import 'package:analyzer/src/pubspec/pubspec_validator.dart';
 import 'package:analyzer/src/util/yaml.dart';
+import 'package:glob/glob.dart';
 import 'package:path/path.dart' as path;
 import 'package:yaml/yaml.dart';
 
@@ -33,9 +34,25 @@ void workspaceValidator(PubspecValidationContext ctx) {
   }
 }
 
+String? _globBasePath(String pathValue) {
+  var parts = path.posix.split(pathValue);
+  var nonGlobParts = <String>[];
+  for (var part in parts) {
+    if (_isGlobPattern(part)) break;
+    nonGlobParts.add(part);
+  }
+  if (nonGlobParts.isEmpty) return null;
+  return path.posix.joinAll(nonGlobParts);
+}
+
+bool _isGlobPattern(String pathValue) => Glob.quote(pathValue) != pathValue;
+
 /// Validates that [pathValue] is a sub directory of the directory containing
 /// the pubspec.yaml file, and that it exists, reporting any error on
 /// [errorField].
+///
+/// For glob patterns, validates only that the base directory (prefix before
+/// the first wildcard segment) exists.
 void _validateDirectoryPath(
   PubspecValidationContext ctx,
   String pathValue,
@@ -46,12 +63,27 @@ void _validateDirectoryPath(
   var packageRootFolder = ctx.provider.getFolder(packageRoot);
   var normalizedEntry = context.joinAll(path.posix.split(pathValue));
   var dirPath = context.join(packageRoot, normalizedEntry);
-  // Check if given path is a sub directory of the package root.
   if (!packageRootFolder.contains(dirPath)) {
     ctx.reportErrorForNode(
       errorField,
       diag.workspaceValueNotSubdirectory.withArguments(path: packageRoot),
     );
+    return;
+  }
+  if (_isGlobPattern(pathValue)) {
+    var basePath = _globBasePath(pathValue);
+    if (basePath != null) {
+      var normalizedBase = context.joinAll(path.posix.split(basePath));
+      var baseDir = ctx.provider.getFolder(
+        context.join(packageRoot, normalizedBase),
+      );
+      if (!baseDir.exists) {
+        ctx.reportErrorForNode(
+          errorField,
+          diag.pathDoesNotExist.withArguments(path: basePath),
+        );
+      }
+    }
     return;
   }
   var subDirectory = ctx.provider.getFolder(dirPath);

--- a/pkg/analyzer/test/src/pubspec/diagnostics/workspace_field_test.dart
+++ b/pkg/analyzer/test/src/pubspec/diagnostics/workspace_field_test.dart
@@ -15,6 +15,62 @@ main() {
 
 @reflectiveTest
 class WorkspaceFieldTest extends PubspecDiagnosticTest {
+  test_workspaceGlob_baseMissing_error() {
+    assertErrors(
+      '''
+name: sample
+workspace:
+  - packages/*
+''',
+      [diag.pathDoesNotExist],
+    );
+  }
+
+  test_workspaceGlob_braces_baseExists_noError() {
+    newFolder('/sample/packages');
+    assertNoErrors('''
+name: sample
+workspace:
+  - packages/{a,b}
+''');
+  }
+
+  test_workspaceGlob_nestedBase_baseExists_noError() {
+    newFolder('/sample/apps/nested');
+    assertNoErrors('''
+name: sample
+workspace:
+  - apps/nested/*
+''');
+  }
+
+  test_workspaceGlob_noBase_noError() {
+    // Pattern starts with a glob character — no base directory to check.
+    assertNoErrors('''
+name: sample
+workspace:
+  - *
+''');
+  }
+
+  test_workspaceGlob_questionMark_baseExists_noError() {
+    newFolder('/sample/packages');
+    assertNoErrors('''
+name: sample
+workspace:
+  - packages/pkg?
+''');
+  }
+
+  test_workspaceGlob_star_baseExists_noError() {
+    newFolder('/sample/packages');
+    assertNoErrors('''
+name: sample
+workspace:
+  - packages/*
+''');
+  }
+
   test_workspaceIsList() {
     assertErrors(
       '''

--- a/pkg/analyzer/test/src/pubspec/diagnostics/workspace_field_test.dart
+++ b/pkg/analyzer/test/src/pubspec/diagnostics/workspace_field_test.dart
@@ -49,7 +49,7 @@ workspace:
     assertNoErrors('''
 name: sample
 workspace:
-  - *
+  - '*'
 ''');
   }
 


### PR DESCRIPTION
## Problem

Since Dart 3.11, pub supports glob patterns in the `workspace` field of `pubspec.yaml` (e.g. `packages/*`). The analyzer's workspace validator was never updated to handle this, so it incorrectly reported `path_does_not_exist` for any glob pattern — because it tried to check the literal path `packages/*` on disk, which doesn't exist.

`dart pub get` worked fine; only the analyzer showed a false error.

Fixes #62661

## Solution

For glob patterns (detected via `Glob.quote(s) != s`, consistent with pub's own `_looksLikeGlob`), validate only the base directory — the path prefix before the first wildcard segment:

| Pattern | What we check |
|---|---|
| `packages/*` | `packages/` exists |
| `apps/nested/pkg?` | `apps/nested/` exists |
| `*` | nothing (root always exists) |

Non-glob paths continue to be validated as before.

## Tests

Added tests covering:
- Glob patterns with existing base directory → no error
- Glob patterns with missing base directory → `path_does_not_exist`
- Patterns starting with a wildcard → no error