### PR TITLE
Fix enum quick-fix insertion for multi-line enums

### DIFF
--- a/pkg/analysis_server/test/src/services/correction/fix/create_field_test.dart
+++ b/pkg/analysis_server/test/src/services/correction/fix/create_field_test.dart
@@ -102,6 +102,35 @@ int f(E e) {
 ''');
   }
 
+  Future<void> test_usedAsGetter_multiline_withoutSemicolon() async {
+    await resolveTestCode('''
+enum E {
+  longEnumName,
+  anotherLongEnumName,
+  yetAnotherLongEnumName,
+  thisOneIsLongToo,
+}
+
+int f(E e) {
+  return e.a;
+}
+''');
+    await assertHasFix('''
+enum E {
+  longEnumName,
+  anotherLongEnumName,
+  yetAnotherLongEnumName,
+  thisOneIsLongToo;
+
+  final int a;
+}
+
+int f(E e) {
+  return e.a;
+}
+''');
+  }
+
   Future<void> test_usedAsGetter_dotShorthand() async {
     await resolveTestCode('''
 enum E {

--- a/pkg/analysis_server/test/src/services/correction/fix/create_getter_test.dart
+++ b/pkg/analysis_server/test/src/services/correction/fix/create_getter_test.dart
@@ -261,6 +261,35 @@ void f(A a) {
 ''');
   }
 
+  Future<void> test_enum_multiline_withoutSemicolon() async {
+    await resolveTestCode('''
+enum E {
+  longEnumName,
+  anotherLongEnumName,
+  yetAnotherLongEnumName,
+  thisOneIsLongToo,
+}
+
+int f(E e) {
+  return e.test;
+}
+''');
+    await assertHasFix('''
+enum E {
+  longEnumName,
+  anotherLongEnumName,
+  yetAnotherLongEnumName,
+  thisOneIsLongToo;
+
+  int get test => null;
+}
+
+int f(E e) {
+  return e.test;
+}
+''');
+  }
+
   Future<void> test_futureIterable_int() async {
     await resolveTestCode('''
 class C {

--- a/pkg/analyzer_plugin/lib/src/utilities/change_builder/change_builder_dart.dart
+++ b/pkg/analyzer_plugin/lib/src/utilities/change_builder/change_builder_dart.dart
@@ -3091,8 +3091,8 @@ class _InsertionPreparer {
       if (semicolon != null) {
         return semicolon.end;
       } else if (declaration.body.constants.isNotEmpty) {
-        var lastConstant = declaration.body.constants.last;
-        return lastConstant.end;
+        var tokenBeforeRightBracket = declaration.body.rightBracket.previous;
+        return tokenBeforeRightBracket?.end ?? declaration.body.constants.last.end;
       }
     }
 

--- a/pkg/analyzer_plugin/test/src/utilities/change_builder/change_builder_dart_test.dart
+++ b/pkg/analyzer_plugin/test/src/utilities/change_builder/change_builder_dart_test.dart
@@ -402,6 +402,25 @@ class DartEditBuilderImplTest extends AbstractContextTest
     expect(edit.replacement, equalsIgnoringWhitespace('var f;'));
   }
 
+  Future<void> test_insertField_enum_multiline_trailingComma() async {
+    var path = convertPath('/home/test/lib/test.dart');
+    var content = 'enum E {\n  one,\n}';
+    addSource(path, content);
+
+    var resolvedUnit = await resolveFile(path);
+    var findNode = FindNode(resolvedUnit.content, resolvedUnit.unit);
+    var enumNode = findNode.enumDeclaration('E {\n  one,\n}');
+
+    var builder = await newBuilder();
+    await builder.addDartFileEdit(path, (builder) {
+      builder.insertField(enumNode, (builder) {
+        builder.writeFieldDeclaration('f');
+      });
+    });
+    var edit = getEdit(builder);
+    expect(edit.replacement, equalsIgnoringWhitespace(';\n\n  var f;'));
+  }
+
   Future<void> test_writeClassDeclaration_interfaces() async {
     var path = convertPath('$testPackageRootPath/lib/test.dart');
     addSource(path, 'class A {}');


### PR DESCRIPTION
Fixes #62874.

This addresses a quick-fix insertion bug for multi-line enums that do not yet
have an explicit semicolon after their constants.

When `Create field` or `Create getter` adds the first enhanced enum member, the
shared enum-member insertion logic was using the last enum constant's end
offset. For enums written with a trailing comma, that can place the insertion
before the comma, producing invalid output such as `field;,`.

This change updates the shared insertion helper to insert after the token before
`}`, which correctly handles enums with trailing commas but no semicolon.

It also adds regression coverage for:
- the shared enum field insertion helper
- `Create field` on a multi-line enum without a semicolon
- `Create getter` on a multi-line enum without a semicolon

Tests run locally:
- Not run in this environment

Why tests were not run locally:
- The Dart SDK repo documents that a functional environment requires `fetch` /
  `gclient` rather than a plain `git clone`.
- This environment does not have a `dart` binary available, so the relevant
  analyzer/analysis_server tests could not be executed honestly here.
