### PR TITLE
Fix unnecessary_null_checks false positive in pattern declarations

### DIFF
--- a/pkg/linter/lib/src/rules/unnecessary_null_checks.dart
+++ b/pkg/linter/lib/src/rules/unnecessary_null_checks.dart
@@ -170,9 +170,27 @@ class _Visitor extends SimpleAstVisitor<void> {
   @override
   void visitNullAssertPattern(NullAssertPattern node) {
     var expectedType = node.matchedValueType;
-    if (expectedType != null && context.typeSystem.isNullable(expectedType)) {
-      rule.reportAtToken(node.operator);
+    if (expectedType == null || !context.typeSystem.isNullable(expectedType)) {
+      return;
     }
+    // In declaration, for-each, and matching (switch case) contexts, the `!`
+    // determines the static type of pattern-bound variables. Removing it would
+    // widen their types to nullable, which changes program semantics (e.g.,
+    // `final (X(n: v!)) = x` declares `v` as non-null; without `!`, `v`
+    // would be nullable, which may make downstream uses of `v` ill-typed).
+    var parent = node.parent;
+    while (parent != null) {
+      if (parent is PatternVariableDeclaration ||
+          parent is ForEachPartsWithPattern ||
+          parent is GuardedPattern) {
+        return;
+      }
+      if (parent is PatternAssignment) {
+        break;
+      }
+      parent = parent.parent;
+    }
+    rule.reportAtToken(node.operator);
   }
 
   @override

--- a/pkg/linter/test/rules/unnecessary_null_checks_test.dart
+++ b/pkg/linter/test/rules/unnecessary_null_checks_test.dart
@@ -162,6 +162,52 @@ void f(int? v, int? p) {
 ''');
   }
 
+  /// Regression test for https://github.com/dart-lang/sdk/issues/59407.
+  /// In a declaration context, `!` determines the static type of the bound
+  /// variable (e.g., `int` instead of `int?`), so it should not be flagged.
+  test_nullAssertPattern_inDeclaration_objectPattern() async {
+    await assertNoDiagnostics(r'''
+class X {
+  const X(this.number);
+  final int? number;
+}
+void f(X x) {
+  final (X(number: n!)) = x;
+  print(n);
+}
+''');
+  }
+
+  /// A `!` in a for-each pattern declaration also determines bound types.
+  test_nullAssertPattern_inForEach_objectPattern() async {
+    await assertNoDiagnostics(r'''
+class X {
+  const X(this.number);
+  final int? number;
+}
+void f(List<X> list) {
+  for (final X(number: n!) in list) {
+    print(n);
+  }
+}
+''');
+  }
+
+  /// A `!` in a switch case (GuardedPattern) also determines bound types.
+  test_nullAssertPattern_inSwitchCase_objectPattern() async {
+    await assertNoDiagnostics(r'''
+class X {
+  const X(this.number);
+  final int? number;
+}
+void f(X x) {
+  if (x case X(number: final n!)) {
+    print(n);
+  }
+}
+''');
+  }
+
   test_recordPattern() async {
     await assertDiagnostics(
       r'''


### PR DESCRIPTION
## Fix `unnecessary_null_checks` false positive in pattern declarations

Fixes https://github.com/dart-lang/sdk/issues/59407

The `unnecessary_null_checks` lint rule incorrectly flagged `!` in `NullAssertPattern` nodes within declaration, for-each, and matching (switch/if-case) contexts.

In these contexts, the `!` determines the static type of the pattern-bound variable (e.g., `int` instead of `int?`). Removing it would widen the variable's type to nullable, changing program semantics and potentially causing compile errors at use sites.

### Example (false positive before this fix):

```dart
class X {
  const X(this.number);
  final int? number;
}

void f(X x) {
  final (X(number: n!)) = x;  // lint: "Unnecessary null check" — but removing ! makes n an int?, breaking downstream usage
  print(n);  // n is int (non-nullable) only because of !
}