### PR TITLE
#62878 quick fix incorrectly treats positional arguments

### DIFF
--- a/pkg/analysis_server/test/src/services/correction/fix/create_method_test.dart
+++ b/pkg/analysis_server/test/src/services/correction/fix/create_method_test.dart
@@ -1437,6 +1437,44 @@ class A {
     );
   }
 
+  Future<void> test_createUnqualified_parameters_named_only() async {
+    await resolveTestCode('''
+class C {}
+
+f(C c) {
+  c.m(arg1: true, arg3: 'string');
+}
+''');
+    await assertHasFix('''
+class C {
+  void m({required bool arg1, required String arg3}) {}
+}
+
+f(C c) {
+  c.m(arg1: true, arg3: 'string');
+}
+''');
+  }
+
+  Future<void> test_createUnqualified_parameters_named_mixedOrder() async {
+    await resolveTestCode('''
+class C {}
+
+f(C c) {
+  c.m(arg1: true, 0, arg3: 'string');
+}
+''');
+    await assertHasFix('''
+class C {
+  void m(int i, {required bool arg1, required String arg3}) {}
+}
+
+f(C c) {
+  c.m(arg1: true, 0, arg3: 'string');
+}
+''');
+  }
+
   Future<void> test_createUnqualified_returnType() async {
     await resolveTestCode('''
 class A {

--- a/pkg/analysis_server/test/src/services/correction/fix/create_method_test.dart
+++ b/pkg/analysis_server/test/src/services/correction/fix/create_method_test.dart
@@ -1437,25 +1437,6 @@ class A {
     );
   }
 
-  Future<void> test_createUnqualified_parameters_named_only() async {
-    await resolveTestCode('''
-class C {}
-
-f(C c) {
-  c.m(arg1: true, arg3: 'string');
-}
-''');
-    await assertHasFix('''
-class C {
-  void m({required bool arg1, required String arg3}) {}
-}
-
-f(C c) {
-  c.m(arg1: true, arg3: 'string');
-}
-''');
-  }
-
   Future<void> test_createUnqualified_parameters_named_mixedOrder() async {
     await resolveTestCode('''
 class C {}
@@ -1471,6 +1452,25 @@ class C {
 
 f(C c) {
   c.m(arg1: true, 0, arg3: 'string');
+}
+''');
+  }
+
+  Future<void> test_createUnqualified_parameters_named_only() async {
+    await resolveTestCode('''
+class C {}
+
+f(C c) {
+  c.m(arg1: true, arg3: 'string');
+}
+''');
+    await assertHasFix('''
+class C {
+  void m({required bool arg1, required String arg3}) {}
+}
+
+f(C c) {
+  c.m(arg1: true, arg3: 'string');
 }
 ''');
   }

--- a/pkg/analyzer_plugin/lib/src/utilities/change_builder/change_builder_dart.dart
+++ b/pkg/analyzer_plugin/lib/src/utilities/change_builder/change_builder_dart.dart
@@ -825,28 +825,51 @@ class DartEditBuilderImpl extends EditBuilderImpl implements DartEditBuilder {
     ArgumentList argumentList, {
     List<TypeParameterElement>? typeParametersInScope,
   }) {
-    // TODO(brianwilkerson): Handle the case when there are required parameters
-    // after named parameters.
     var usedNames = <String>{};
     var arguments = argumentList.arguments;
-    var hasNamedParameters = false;
-    for (var i = 0; i < argumentList.arguments.length; i++) {
+    var positionalArguments = <(int, Expression)>[];
+    var namedArguments = <(int, NamedExpression)>[];
+    for (var i = 0; i < arguments.length; i++) {
       var argument = arguments[i];
-      if (i > 0) {
+      if (argument is NamedExpression) {
+        namedArguments.add((i, argument));
+        usedNames.add(argument.name.label.name);
+      } else {
+        positionalArguments.add((i, argument));
+      }
+    }
+
+    var hasWrittenParameter = false;
+    for (var (index, argument) in positionalArguments) {
+      if (hasWrittenParameter) {
         write(', ');
       }
-      if (argument is NamedExpression && !hasNamedParameters) {
-        hasNamedParameters = true;
-        write('{');
-      }
+      hasWrittenParameter = true;
       writeParameterMatchingArgument(
         argument,
-        i,
+        index,
         usedNames,
         typeParametersInScope: typeParametersInScope,
       );
     }
-    if (hasNamedParameters) {
+
+    if (namedArguments.isNotEmpty) {
+      if (hasWrittenParameter) {
+        write(', ');
+      }
+      write('{');
+      for (var i = 0; i < namedArguments.length; i++) {
+        if (i > 0) {
+          write(', ');
+        }
+        var (index, argument) = namedArguments[i];
+        writeParameterMatchingArgument(
+          argument,
+          index,
+          usedNames,
+          typeParametersInScope: typeParametersInScope,
+        );
+      }
       write('}');
     }
   }

--- a/pkg/analyzer_plugin/test/src/utilities/change_builder/change_builder_dart_test.dart
+++ b/pkg/analyzer_plugin/test/src/utilities/change_builder/change_builder_dart_test.dart
@@ -1543,6 +1543,34 @@ f(int i, String s) {
     );
   }
 
+  Future<void> test_writeParametersMatchingArguments_named_mixedOrder() async {
+    var path = convertPath('/home/test/lib/test.dart');
+    var content = '''
+f(bool b, int i, String s) {
+  g(arg1: b, i, arg3: s);
+}''';
+    addSource(path, content);
+    var unit = (await resolveFile(path)).unit;
+    var f = unit.declarations[0] as FunctionDeclaration;
+    var body = f.functionExpression.body as BlockFunctionBody;
+    var statement = body.block.statements[0] as ExpressionStatement;
+    var invocation = statement.expression as MethodInvocation;
+
+    var builder = await newBuilder();
+    await builder.addDartFileEdit(path, (builder) {
+      builder.addInsertion(content.length - 1, (builder) {
+        builder.writeParametersMatchingArguments(invocation.argumentList);
+      });
+    });
+    var edit = getEdit(builder);
+    expect(
+      edit.replacement,
+      equalsIgnoringWhitespace(
+        'int i, {required bool arg1, required String arg3}',
+      ),
+    );
+  }
+
   Future<void> test_writeParametersMatchingArguments_required() async {
     var path = convertPath('/home/test/lib/test.dart');
     var content = '''


### PR DESCRIPTION
Fixes create-method parameter generation for invocations with mixed positional and named arguments.

Previously, when generating a method signature from an undefined method invocation like c.m(arg1: true, 0, arg3: 'string'), the fix could incorrectly treat all arguments after the first named argument as named parameters, producing an invalid signature. This change classifies each argument independently based on its AST type, preserves positional arguments as positional, and emits the generated method signature in valid Dart order: positional parameters first, then named parameters in {}.

This PR also adds regression coverage for the mixed-order case in the create-method fix tests, along with a lower-level test for writeParametersMatchingArguments.

Related issue: https://github.com/dart-lang/sdk/issues/62878