### PR TITLE
Fix unused_element false positive for constructors used via mixin 

### DIFF
--- a/pkg/analyzer/lib/src/error/unused_local_elements_verifier.dart
+++ b/pkg/analyzer/lib/src/error/unused_local_elements_verifier.dart
@@ -1233,6 +1233,11 @@ class UsedLocalElements {
       elements.add(element.baseElement);
     } else if (element != null) {
       elements.add(element);
+      if (element is ConstructorElementImpl &&
+          element.enclosingElement is ClassElementImpl &&
+          (element.enclosingElement as ClassElementImpl).isMixinApplication) {
+        addElement(element.superConstructor);
+      }
     }
   }
 

--- a/pkg/analyzer/lib/src/error/unused_local_elements_verifier.dart
+++ b/pkg/analyzer/lib/src/error/unused_local_elements_verifier.dart
@@ -1233,9 +1233,10 @@ class UsedLocalElements {
       elements.add(element.baseElement);
     } else if (element != null) {
       elements.add(element);
+      var enclosingElement = element.enclosingElement;
       if (element is ConstructorElementImpl &&
-          element.enclosingElement is ClassElementImpl &&
-          (element.enclosingElement as ClassElementImpl).isMixinApplication) {
+          enclosingElement is ClassElementImpl &&
+          enclosingElement.isMixinApplication) {
         addElement(element.superConstructor);
       }
     }

--- a/pkg/analyzer/test/src/diagnostics/unused_element_test.dart
+++ b/pkg/analyzer/test/src/diagnostics/unused_element_test.dart
@@ -372,6 +372,26 @@ A f() => A._constructor();
 ''');
   }
 
+  test_constructor_isUsed_mixinApplicationRedirect() async {
+    await assertNoErrorsInCode(r'''
+abstract class Foo {
+  factory Foo({required String thing}) = _Foo._;
+  Foo._({required this.thing});
+
+  final String thing;
+
+  void bar();
+}
+
+mixin _$Foo on Foo {
+  @override
+  void bar() {}
+}
+
+class _Foo = Foo with _$Foo;
+''');
+  }
+
   test_constructor_notUsed_multiple() async {
     await assertErrorsInCode(
       r'''


### PR DESCRIPTION
## Summary
Fixes a false positive from `unused_element` for private constructors that are used through mixin application class declarations.

## Context
Issue: https://github.com/dart-lang/sdk/issues/62869

In patterns like:

```dart
abstract class Foo {
  factory Foo({required String thing}) = _Foo._;
  Foo._({required this.thing});
  final String thing;
  void bar();
}

mixin _$Foo on Foo {
  @override
  void bar() {}
}

class _Foo = Foo with _$Foo;
