### PR TITLE
[analysis_server] Fix tab stop issue for single-parameter function completions

### DIFF
--- a/pkg/analysis_server/lib/src/lsp/mapping.dart
+++ b/pkg/analysis_server/lib/src/lsp/mapping.dart
@@ -123,10 +123,11 @@ lsp.Either2<lsp.MarkupContent, String> asMarkupContentOrString(
           ? buildSnippetStringWithTabStops(
               requiredArgumentListString,
               requiredArgumentListTextRanges,
+              markSingleTabStopAsFinal: false,
             )
-          // Optional params still gets a final tab stop in the parens.
+          // Optional params still gets a tab stop in the parens so the user can tab out.
           : hasOptionalParameters
-          ? SnippetBuilder.finalTabStop
+          ? SnippetBuilder.firstTabStop
           // And no parameters at all we skip the tabstop in the parens.
           : '';
       insertText =

--- a/pkg/analysis_server/lib/src/lsp/snippets.dart
+++ b/pkg/analysis_server/lib/src/lsp/snippets.dart
@@ -39,11 +39,13 @@ String buildSnippetStringForEditGroups(
 /// [tabStopOffsetLengthPairs] are relative to the supplied text.
 String buildSnippetStringWithTabStops(
   String text,
-  List<int>? tabStopOffsetLengthPairs,
-) => _buildSnippetString(
+  List<int>? tabStopOffsetLengthPairs, {
+  bool markSingleTabStopAsFinal = true,
+}) => _buildSnippetString(
   text,
   filePath: null,
   tabStopOffsetLengthPairs: tabStopOffsetLengthPairs,
+  markSingleTabStopAsFinal: markSingleTabStopAsFinal,
 );
 
 /// Builds an LSP snippet string with supplied ranges as tab stops.
@@ -63,6 +65,7 @@ String _buildSnippetString(
   int? selectionLength,
   List<server.LinkedEditGroup>? editGroups,
   int editGroupsOffset = 0,
+  bool markSingleTabStopAsFinal = true,
 }) {
   tabStopOffsetLengthPairs ??= const [];
   editGroups ??= const [];
@@ -115,6 +118,7 @@ String _buildSnippetString(
         // If there's only a single tab stop (and no selection/editGroups), mark
         // it as the final stop so it exit "snippet mode" when tabbed to.
         isFinal:
+            markSingleTabStopAsFinal &&
             selectionOffset == null &&
             editGroups.isEmpty &&
             tabStopOffsetLengthPairs.length == 2,
@@ -151,6 +155,9 @@ String _buildSnippetString(
 class SnippetBuilder {
   /// The constant `$0` used do indicate a final tab stop in the snippet syntax.
   static const finalTabStop = r'$0';
+
+  /// The constant `$1` used to indicate a first tab stop in the snippet syntax.
+  static const firstTabStop = r'$1';
 
   /// Regex used by [escapeSnippetChoiceText].
   static final _escapeSnippetChoiceTextRegex = RegExp(

--- a/pkg/analysis_server/test/lsp/completion_dart_test.dart
+++ b/pkg/analysis_server/test/lsp/completion_dart_test.dart
@@ -1763,7 +1763,7 @@ void f(int aaa) {
 ''',
       'Aaaaa(…)',
       insertTextFormat: InsertTextFormat.Snippet,
-      editText: r'Aaaaa(${0:a})',
+      editText: r'Aaaaa(${1:a})',
     );
   }
 
@@ -1961,7 +1961,7 @@ void f() {
 ''',
       'foo(…)',
       insertTextFormat: InsertTextFormat.Snippet,
-      editText: r'foo(${0:a})',
+      editText: r'foo(${1:a})',
     );
   }
 
@@ -1995,7 +1995,7 @@ void f() {
       content,
       'myFunction(…)',
       // With optional params, there should still be parens/tab stop inside.
-      editText: r'myFunction($0)',
+      editText: r'myFunction($1)',
       insertTextFormat: InsertTextFormat.Snippet,
     );
   }
@@ -2081,7 +2081,7 @@ final a = Stri^
       expect(item.insertText, isNull);
       expect(
         item.textEdit!.map((edit) => edit.newText, (edit) => edit.newText),
-        r'String.fromCharCode(${0:charCode})',
+        r'String.fromCharCode(${1:charCode})',
       );
     }
 
@@ -2129,7 +2129,7 @@ void f(int a) {
 ''',
       'f(…)',
       insertTextFormat: InsertTextFormat.Snippet,
-      editText: r'f(${0:a})',
+      editText: r'f(${1:a})',
     );
   }
 
@@ -2142,7 +2142,7 @@ void f(int a) {
 ''',
       'print(…)',
       insertTextFormat: InsertTextFormat.Snippet,
-      editText: r'print(${0:object})',
+      editText: r'print(${1:object})',
     );
   }
 

--- a/pkg/analysis_server/test/lsp/snippets_test.dart
+++ b/pkg/analysis_server/test/lsp/snippets_test.dart
@@ -274,6 +274,14 @@ class ${0:A} {
     expect(result, equals(r'a, ${0:b}, c'));
   }
 
+  Future<void> test_tabStops_contains_notFinal() async {
+    var result = lsp.buildSnippetStringWithTabStops('a, b, c', [
+      3,
+      1,
+    ], markSingleTabStopAsFinal: false);
+    expect(result, equals(r'a, ${1:b}, c'));
+  }
+
   Future<void> test_tabStops_empty() async {
     var result = lsp.buildSnippetStringWithTabStops('a, b', []);
     expect(result, equals(r'a, b'));


### PR DESCRIPTION
When `completeFunctionCalls` is enabled, completing a function with exactly one required parameter (or only optional parameters) generated a snippet using `$0` as the final tab stop (e.g. `foo(${0:a})` or `foo($0)`). This trapped the user's cursor inside the parentheses, preventing them from pressing 'Tab' to move past the closing parenthesis after typing the argument.

This change introduces a `markSingleTabStopAsFinal` option to `buildSnippetStringWithTabStops` (defaulting to true for backward compatibility). When building completion items for function calls, we now pass `false`, so the parameter uses `$1` instead of `$0`. This allows the editor to infer `$0` at the end of the snippet, letting users tab out of the parentheses.


---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
