### PR TITLE
Fix #62883 String buffer clear()

### DIFF
--- a/sdk/lib/_internal/vm_shared/lib/string_buffer_patch.dart
+++ b/sdk/lib/_internal/vm_shared/lib/string_buffer_patch.dart
@@ -176,6 +176,7 @@ class StringBuffer {
     } else {
       localParts.add(str);
       int partsSinceCompaction = localParts.length - _partsCompactionIndex;
+      assert(partsSinceCompaction > 0);
       if (partsSinceCompaction == _PARTS_TO_COMPACT) {
         _compact();
       }

--- a/sdk/lib/_internal/vm_shared/lib/string_buffer_patch.dart
+++ b/sdk/lib/_internal/vm_shared/lib/string_buffer_patch.dart
@@ -123,7 +123,8 @@ class StringBuffer {
   @patch
   void clear() {
     _parts = null;
-    _partsCodeUnits = _bufferPosition = _bufferCodeUnitMagnitude = 0;
+    _partsCodeUnits = _bufferPosition = _bufferCodeUnitMagnitude =
+        _partsCompactionIndex = _partsCodeUnitsSinceCompaction = 0;
   }
 
   /** Returns the contents of buffer as a string. */

--- a/tests/corelib/corelib.status
+++ b/tests/corelib/corelib.status
@@ -55,9 +55,6 @@ regexp/unicode-regexp-restricted-syntax_test: Skip # evades flake detection http
 [ $runtime != dart_precompiled && $runtime != vm ]
 reg_exp_receive_port_test: SkipByDesign # uses SendPort/ReceivePort
 
-[ $runtime != vm ]
-string_buffer_clear_compaction_regression_test: SkipByDesign # VM-only white-box test via dart:mirrors.
-
 [ $runtime != none && ($compiler == dart2js || $compiler == ddc) ]
 int_parse_with_limited_ints_test: SkipByDesign # Requires fixed-size int64 support.
 iterable_return_type_int64_test: SkipByDesign # Requires int64 support.

--- a/tests/corelib/corelib.status
+++ b/tests/corelib/corelib.status
@@ -55,6 +55,9 @@ regexp/unicode-regexp-restricted-syntax_test: Skip # evades flake detection http
 [ $runtime != dart_precompiled && $runtime != vm ]
 reg_exp_receive_port_test: SkipByDesign # uses SendPort/ReceivePort
 
+[ $runtime != vm ]
+string_buffer_clear_compaction_regression_test: SkipByDesign # VM-only white-box test via dart:mirrors.
+
 [ $runtime != none && ($compiler == dart2js || $compiler == ddc) ]
 int_parse_with_limited_ints_test: SkipByDesign # Requires fixed-size int64 support.
 iterable_return_type_int64_test: SkipByDesign # Requires int64 support.

--- a/tests/corelib/string_buffer_clear_compaction_regression_test.dart
+++ b/tests/corelib/string_buffer_clear_compaction_regression_test.dart
@@ -1,12 +1,15 @@
 // Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
-
-import "dart:mirrors";
+// VMOptions=--enable-asserts
 
 import "package:expect/expect.dart";
 
 const int _iterations = 10000;
+final String _expected = List.generate(
+  _iterations,
+  (int i) => i.isEven ? "foo " : "bar ",
+).join();
 
 void _writeFooBar(StringBuffer buffer) {
   for (int i = 0; i < _iterations; i++) {
@@ -15,51 +18,13 @@ void _writeFooBar(StringBuffer buffer) {
   }
 }
 
-Symbol _privateSymbol(InstanceMirror mirror, String fieldName) {
-  final owner = mirror.type.owner;
-  if (owner is! LibraryMirror) {
-    throw StateError(
-      "Expected StringBuffer owner to be LibraryMirror, got $owner",
-    );
-  }
-  return MirrorSystem.getSymbol(fieldName, owner);
-}
-
-T _readPrivateField<T>(Object object, String fieldName) {
-  final mirror = reflect(object);
-  return mirror.getField(_privateSymbol(mirror, fieldName)).reflectee as T;
-}
-
-int _leadingNonCompactedPrefixLength(List<String> parts) {
-  int prefixLength = 0;
-  for (final part in parts) {
-    if (part.length <= 4) {
-      prefixLength++;
-      continue;
-    }
-    break;
-  }
-  return prefixLength;
-}
-
 void main() {
   final buffer = StringBuffer();
 
   _writeFooBar(buffer);
   buffer.clear();
-
-  Expect.equals(0, _readPrivateField<int>(buffer, "_partsCompactionIndex"));
-  Expect.equals(
-    0,
-    _readPrivateField<int>(buffer, "_partsCodeUnitsSinceCompaction"),
-  );
-
   _writeFooBar(buffer);
-  final parts = _readPrivateField<List<String>?>(buffer, "_parts");
-  Expect.isNotNull(parts);
-  final leadingPrefixLength = _leadingNonCompactedPrefixLength(parts!);
-  Expect.isTrue(
-    leadingPrefixLength < 16,
-    "Unexpected large uncompacted prefix in _parts: $leadingPrefixLength",
-  );
+
+  Expect.equals(_expected.length, buffer.length);
+  Expect.equals(_expected, buffer.toString());
 }

--- a/tests/corelib/string_buffer_clear_compaction_regression_test.dart
+++ b/tests/corelib/string_buffer_clear_compaction_regression_test.dart
@@ -1,0 +1,65 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import "dart:mirrors";
+
+import "package:expect/expect.dart";
+
+const int _iterations = 10000;
+
+void _writeFooBar(StringBuffer buffer) {
+  for (int i = 0; i < _iterations; i++) {
+    buffer.write(i.isEven ? "foo" : "bar");
+    buffer.write(" ");
+  }
+}
+
+Symbol _privateSymbol(InstanceMirror mirror, String fieldName) {
+  final owner = mirror.type.owner;
+  if (owner is! LibraryMirror) {
+    throw StateError(
+      "Expected StringBuffer owner to be LibraryMirror, got $owner",
+    );
+  }
+  return MirrorSystem.getSymbol(fieldName, owner);
+}
+
+T _readPrivateField<T>(Object object, String fieldName) {
+  final mirror = reflect(object);
+  return mirror.getField(_privateSymbol(mirror, fieldName)).reflectee as T;
+}
+
+int _leadingNonCompactedPrefixLength(List<String> parts) {
+  int prefixLength = 0;
+  for (final part in parts) {
+    if (part.length <= 4) {
+      prefixLength++;
+      continue;
+    }
+    break;
+  }
+  return prefixLength;
+}
+
+void main() {
+  final buffer = StringBuffer();
+
+  _writeFooBar(buffer);
+  buffer.clear();
+
+  Expect.equals(0, _readPrivateField<int>(buffer, "_partsCompactionIndex"));
+  Expect.equals(
+    0,
+    _readPrivateField<int>(buffer, "_partsCodeUnitsSinceCompaction"),
+  );
+
+  _writeFooBar(buffer);
+  final parts = _readPrivateField<List<String>?>(buffer, "_parts");
+  Expect.isNotNull(parts);
+  final leadingPrefixLength = _leadingNonCompactedPrefixLength(parts!);
+  Expect.isTrue(
+    leadingPrefixLength < 16,
+    "Unexpected large uncompacted prefix in _parts: $leadingPrefixLength",
+  );
+}

--- a/tests/corelib/string_buffer_clear_compaction_regression_test.dart
+++ b/tests/corelib/string_buffer_clear_compaction_regression_test.dart
@@ -11,7 +11,7 @@ final String _expected = List.generate(
   (int i) => i.isEven ? "foo " : "bar ",
 ).join();
 
-void _writeFooBar(StringBuffer buffer) {
+void writeFooBar(StringBuffer buffer) {
   for (int i = 0; i < _iterations; i++) {
     buffer.write(i.isEven ? "foo" : "bar");
     buffer.write(" ");
@@ -21,9 +21,9 @@ void _writeFooBar(StringBuffer buffer) {
 void main() {
   final buffer = StringBuffer();
 
-  _writeFooBar(buffer);
+  writeFooBar(buffer);
   buffer.clear();
-  _writeFooBar(buffer);
+  writeFooBar(buffer);
 
   Expect.equals(_expected.length, buffer.length);
   Expect.equals(_expected, buffer.toString());


### PR DESCRIPTION
- This PR fixes a VM `StringBuffer` regression in `clear()`.

### What changed

- Updated `StringBuffer.clear()` in `sdk/lib/_internal/vm_shared/lib/string_buffer_patch.dart` to fully reset compaction state:
  - `_partsCompactionIndex = 0`
  - `_partsCodeUnitsSinceCompaction = 0`
- Kept existing VM patch style by using chained assignment in `clear()`.
- Added a VM-only regression test:
  - `tests/corelib/string_buffer_clear_compaction_regression_test.dart`
  - Verifies that after `clear()` both compaction fields are reset to `0`.
  - Verifies that after reusing the buffer there is no large uncompacted prefix in `_parts`.
- Added status entry so this white-box test is VM-only:
  - `tests/corelib/corelib.status`

### Why

`clear()` previously removed visible content but did not reset internal compaction bookkeeping. Reusing the same buffer could leave the beginning of `_parts` uncompacted for many entries, causing the observed regression.

### Public API impact

No public API changes.

### Testing

- `python3 tools/test.py -n vm-linux-release-x64 corelib/string_buffer_clear_compaction_regression_test` (pass)
- `python3 tools/test.py -n vm-linux-release-x64 corelib/string_buffer_test` (pass)

---

Fix #62883 