### PR TITLE
FIX #56335 [Augmentations] Analyzer doesn't support augmenting functions with empty bodies 

### DIFF
--- a/pkg/analyzer/lib/src/dart/scanner/scanner.dart
+++ b/pkg/analyzer/lib/src/dart/scanner/scanner.dart
@@ -203,6 +203,6 @@ class Scanner {
       ? fasta.ScannerConfiguration()
       : fasta.ScannerConfiguration(
           enableTripleShift: featureSet.isEnabled(Feature.triple_shift),
-          forAugmentationLibrary: featureSet.isEnabled(Feature.macros),
+          forAugmentationLibrary: featureSet.isEnabled(Feature.augmentations),
         );
 }

--- a/pkg/analyzer/test/src/diagnostics/concrete_class_with_abstract_member_test.dart
+++ b/pkg/analyzer/test/src/diagnostics/concrete_class_with_abstract_member_test.dart
@@ -51,6 +51,24 @@ class A {
     );
   }
 
+  test_augment_emptyBody() async {
+    newFile('$testPackageLibPath/a.dart', r'''
+part 'test.dart';
+
+class C {
+  void foo() {}
+}
+''');
+
+    await assertNoErrorsInCode(r'''
+part of 'a.dart';
+
+augment class C {
+  augment void foo();
+}
+''');
+  }
+
   test_direct() async {
     await assertErrorsInCode(
       '''

--- a/pkg/analyzer/test/src/diagnostics/concrete_class_with_abstract_member_test.dart
+++ b/pkg/analyzer/test/src/diagnostics/concrete_class_with_abstract_member_test.dart
@@ -53,18 +53,18 @@ class A {
 
   test_augment_emptyBody() async {
     newFile('$testPackageLibPath/a.dart', r'''
-part 'test.dart';
+part of 'test.dart';
 
-class C {
-  void foo() {}
+augment class C {
+  augment void foo();
 }
 ''');
 
     await assertNoErrorsInCode(r'''
-part of 'a.dart';
+part 'a.dart';
 
-augment class C {
-  augment void foo();
+class C {
+  void foo() {}
 }
 ''');
   }


### PR DESCRIPTION
This PR fixes analyzer handling for augmenting functions with empty bodies.

According to the augmentation specification, an augmenting function declaration may use an empty body (`;`) to augment only metadata or documentation comments, without changing the body of the augmented member. In analyzer, this currently led to a false positive on code like:

```dart
class C {
  void foo() {}
}

augment class C {
  augment void foo();
}
```


The root cause was that the analyzer scanner only enabled augmentation-library scanning when Feature.macros was enabled. That caused augmentation syntax to be scanned incorrectly unless macros were enabled, which then cascaded into bogus parse/analysis errors, including CONCRETE_CLASS_WITH_ABSTRACT_MEMBER.

This change updates the scanner to use Feature.augmentations for forAugmentationLibrary, which matches the feature actually being tested, and adds a regression test to verify that an empty-body augmenting method no longer reports an error.

Fix #56335 