### PR TITLE
FIX #62280 Parser and analyzer AST should be updated to reject augmented enum values

### DIFF
--- a/pkg/_fe_analyzer_shared/lib/src/parser/parser_impl.dart
+++ b/pkg/_fe_analyzer_shared/lib/src/parser/parser_impl.dart
@@ -2878,10 +2878,14 @@ class Parser {
     Token beginToken = token;
     token = parseMetadataStar(token);
 
-    Token? augmentToken;
-    if (token.next!.isA(Keyword.AUGMENT)) {
-      augmentToken = token.next!;
+    // Enum values can no longer be augmented. Preserve `augment` as a valid
+    // built-in identifier when it's the actual value name, but recover from the
+    // removed `augment foo` syntax by treating the leading `augment` as an
+    // extraneous modifier and continuing with `foo`.
+    while (token.next!.isA(Keyword.AUGMENT) &&
+        token.next!.next!.isKeywordOrIdentifier) {
       token = token.next!;
+      reportRecoverableErrorWithToken(token, diag.extraneousModifier);
     }
 
     token = ensureIdentifier(token, IdentifierContext.enumValueDeclaration);
@@ -2923,7 +2927,7 @@ class Parser {
     } else {
       listener.handleNoArguments(token);
     }
-    listener.handleEnumElement(beginToken, augmentToken);
+    listener.handleEnumElement(beginToken, null);
     return token;
   }
 

--- a/pkg/analyzer/api.txt
+++ b/pkg/analyzer/api.txt
@@ -1065,7 +1065,7 @@ package:analyzer/dart/ast/ast.dart:
     typeArguments (getter: TypeArgumentList?)
   EnumConstantDeclaration (class extends Object implements Declaration, abstract, final):
     arguments (getter: EnumConstantArguments?)
-    augmentKeyword (getter: Token?)
+    augmentKeyword (getter: Token?, deprecated)
     constructorElement (getter: ConstructorElement?)
     declaredFragment (getter: FieldFragment?)
     name (getter: Token)

--- a/pkg/analyzer/lib/src/dart/ast/ast.dart
+++ b/pkg/analyzer/lib/src/dart/ast/ast.dart
@@ -9028,7 +9028,14 @@ abstract final class EnumConstantDeclaration implements Declaration {
   /// doesn't provide any explicit arguments.
   EnumConstantArguments? get arguments;
 
-  /// The `augment` keyword, or `null` if the keyword was absent.
+  /// The `augment` keyword.
+  ///
+  /// Enum values can no longer be augmented, so this getter always returns
+  /// `null`.
+  @Deprecated(
+    'Enum values can no longer be augmented, so this getter is always null '
+    'and will be removed in a future analyzer major version.',
+  )
   Token? get augmentKeyword;
 
   /// The constructor that's invoked by this enum constant.
@@ -9053,6 +9060,10 @@ abstract final class EnumConstantDeclaration implements Declaration {
 )
 final class EnumConstantDeclarationImpl extends DeclarationImpl
     implements EnumConstantDeclaration {
+  @Deprecated(
+    'Enum values can no longer be augmented, so this getter is always null '
+    'and will be removed in a future analyzer major version.',
+  )
   @generated
   @override
   final Token? augmentKeyword;

--- a/pkg/analyzer/lib/src/fasta/ast_builder.dart
+++ b/pkg/analyzer/lib/src/fasta/ast_builder.dart
@@ -4134,7 +4134,7 @@ class AstBuilder extends StackListener {
       constant = EnumConstantDeclarationImpl(
         comment: constant.documentationComment,
         metadata: constant.metadata,
-        augmentKeyword: augmentToken,
+        augmentKeyword: null,
         name: constant.name,
         arguments: EnumConstantArgumentsImpl(
           typeArguments: typeArguments,
@@ -4488,18 +4488,11 @@ class AstBuilder extends StackListener {
       var metadata = pop() as List<AnnotationImpl>?;
       var comment = _findComment(metadata, token);
 
-      Token? augmentKeyword;
-      if (token.previous case var previous?) {
-        if (optional('augment', previous)) {
-          augmentKeyword = previous;
-        }
-      }
-
       push(
         EnumConstantDeclarationImpl(
           comment: comment,
           metadata: metadata,
-          augmentKeyword: augmentKeyword,
+          augmentKeyword: null,
           name: token,
           arguments: null,
         ),

--- a/pkg/analyzer/lib/src/summary2/element_builder.dart
+++ b/pkg/analyzer/lib/src/summary2/element_builder.dart
@@ -1179,7 +1179,7 @@ class FragmentBuilder extends ThrowingAstVisitor<void> {
         var field = FieldFragmentImpl(name: _getFragmentName(nameToken))
           ..hasImplicitType = true
           ..hasInitializer = true
-          ..isAugmentation = constant.augmentKeyword != null
+          ..isAugmentation = false
           ..isConst = true
           ..isEnumConstant = true
           ..isOriginDeclaration = true

--- a/pkg/analyzer/test/src/dart/parser/enum_test.dart
+++ b/pkg/analyzer/test/src/dart/parser/enum_test.dart
@@ -45,7 +45,7 @@ augment enum E {
   augment v
 }
 ''');
-    parseResult.assertNoErrors();
+    parseResult.assertErrors([error(diag.extraneousModifier, 19, 7)]);
 
     var node = parseResult.findNode.singleEnumDeclaration;
     assertParsedNodeText(node, r'''
@@ -58,7 +58,6 @@ EnumDeclaration
     leftBracket: {
     constants
       EnumConstantDeclaration
-        augmentKeyword: augment
         name: v
     rightBracket: }
 ''');
@@ -70,7 +69,7 @@ augment enum E {
   augment v.foo()
 }
 ''');
-    parseResult.assertNoErrors();
+    parseResult.assertErrors([error(diag.extraneousModifier, 19, 7)]);
 
     var node = parseResult.findNode.singleEnumDeclaration;
     assertParsedNodeText(node, r'''
@@ -83,7 +82,6 @@ EnumDeclaration
     leftBracket: {
     constants
       EnumConstantDeclaration
-        augmentKeyword: augment
         name: v
         arguments: EnumConstantArguments
           constructorSelector: ConstructorSelector
@@ -93,6 +91,29 @@ EnumDeclaration
           argumentList: ArgumentList
             leftParenthesis: (
             rightParenthesis: )
+    rightBracket: }
+''');
+  }
+
+  test_constant_named_augment() {
+    var parseResult = parseStringWithErrors(r'''
+enum E {
+  augment
+}
+''');
+    parseResult.assertNoErrors();
+
+    var node = parseResult.findNode.singleEnumDeclaration;
+    assertParsedNodeText(node, r'''
+EnumDeclaration
+  enumKeyword: enum
+  namePart: NameWithTypeParameters
+    typeName: E
+  body: BlockEnumBody
+    leftBracket: {
+    constants
+      EnumConstantDeclaration
+        name: augment
     rightBracket: }
 ''');
   }

--- a/pkg/analyzer/test/src/summary/elements/enum_test.dart
+++ b/pkg/analyzer/test/src/summary/elements/enum_test.dart
@@ -11505,11 +11505,11 @@ library
                       staticType: A
                     SimpleIdentifier
                       token: v2 @-1
-                      element: <testLibrary>::@enum::A::@getter::v2
+                      element: <testLibrary>::@enum::A::@getter::v2::@def::0
                       staticType: A
                     SimpleIdentifier
                       token: v2 @-1
-                      element: <testLibrary>::@enum::A::@getter::v2
+                      element: <testLibrary>::@enum::A::@getter::v2::@def::0
                       staticType: A
                   rightBracket: ] @0
                   staticType: List<A>
@@ -11527,22 +11527,21 @@ library
           previousFragment: #F1
           fields
             #F8 hasInitializer isOriginDeclaration v2 (nameOffset:36) (firstTokenOffset:36) (offset:36)
-              element: <testLibrary>::@enum::A::@field::v2
+              element: <testLibrary>::@enum::A::@field::v2::@def::0
               initializer: expression_2
                 InstanceCreationExpression
                   constructorName: ConstructorName
                     type: NamedType
                       name: A @-1
-                      element: <null>
-                      type: null
-                    element: <null>
+                      element: <testLibrary>::@enum::A
+                      type: A
+                    element: <testLibrary>::@enum::A::@constructor::new
                   argumentList: ArgumentList
                     leftParenthesis: ( @0
                     rightParenthesis: ) @0
-                  staticType: null
-              nextFragment: #F9
-            #F9 augment hasInitializer isOriginDeclaration v2 (nameOffset:50) (firstTokenOffset:42) (offset:50)
-              element: <testLibrary>::@enum::A::@field::v2
+                  staticType: A
+            #F9 hasInitializer isOriginDeclaration v2 (nameOffset:50) (firstTokenOffset:50) (offset:50)
+              element: <testLibrary>::@enum::A::@field::v2::@def::1
               initializer: expression_3
                 InstanceCreationExpression
                   constructorName: ConstructorName
@@ -11555,10 +11554,11 @@ library
                     leftParenthesis: ( @0
                     rightParenthesis: ) @0
                   staticType: A
-              previousFragment: #F8
           getters
             #F10 isOriginVariable v2 (nameOffset:<null>) (firstTokenOffset:<null>) (offset:36)
-              element: <testLibrary>::@enum::A::@getter::v2
+              element: <testLibrary>::@enum::A::@getter::v2::@def::0
+            #F11 isOriginVariable v2 (nameOffset:<null>) (firstTokenOffset:<null>) (offset:50)
+              element: <testLibrary>::@enum::A::@getter::v2::@def::1
   enums
     enum A
       reference: <testLibrary>::@enum::A
@@ -11582,13 +11582,21 @@ library
             expression: expression_1
           getter: <testLibrary>::@enum::A::@getter::values
         static const enumConstant hasImplicitType hasInitializer isOriginDeclaration v2
-          reference: <testLibrary>::@enum::A::@field::v2
+          reference: <testLibrary>::@enum::A::@field::v2::@def::0
           firstFragment: #F8
+          type: A
+          constantInitializer
+            fragment: #F8
+            expression: expression_2
+          getter: <testLibrary>::@enum::A::@getter::v2::@def::0
+        static const enumConstant hasImplicitType hasInitializer isOriginDeclaration v2
+          reference: <testLibrary>::@enum::A::@field::v2::@def::1
+          firstFragment: #F9
           type: A
           constantInitializer
             fragment: #F9
             expression: expression_3
-          getter: <testLibrary>::@enum::A::@getter::v2
+          getter: <testLibrary>::@enum::A::@getter::v2::@def::1
       constructors
         const isOriginImplicitDefault new
           reference: <testLibrary>::@enum::A::@constructor::new
@@ -11606,10 +11614,15 @@ library
           returnType: List<A>
           variable: <testLibrary>::@enum::A::@field::values
         static isOriginVariable v2
-          reference: <testLibrary>::@enum::A::@getter::v2
+          reference: <testLibrary>::@enum::A::@getter::v2::@def::0
           firstFragment: #F10
           returnType: A
-          variable: <testLibrary>::@enum::A::@field::v2
+          variable: <testLibrary>::@enum::A::@field::v2::@def::0
+        static isOriginVariable v2
+          reference: <testLibrary>::@enum::A::@getter::v2::@def::1
+          firstFragment: #F11
+          returnType: A
+          variable: <testLibrary>::@enum::A::@field::v2::@def::1
 ''');
   }
 
@@ -11650,21 +11663,20 @@ library
                     rightParenthesis: ) @0
                   staticType: A
             #F4 hasInitializer isOriginDeclaration v2 (nameOffset:15) (firstTokenOffset:15) (offset:15)
-              element: <testLibrary>::@enum::A::@field::v2
+              element: <testLibrary>::@enum::A::@field::v2::@def::0
               initializer: expression_1
                 InstanceCreationExpression
                   constructorName: ConstructorName
                     type: NamedType
                       name: A @-1
-                      element: <null>
-                      type: null
-                    element: <null>
+                      element: <testLibrary>::@enum::A
+                      type: A
+                    element: <testLibrary>::@enum::A::@constructor::new
                   argumentList: ArgumentList
                     leftParenthesis: ( @0
                     rightParenthesis: ) @0
-                  staticType: null
-              nextFragment: #F5
-            #F6 hasInitializer isOriginDeclaration v3 (nameOffset:19) (firstTokenOffset:19) (offset:19)
+                  staticType: A
+            #F5 hasInitializer isOriginDeclaration v3 (nameOffset:19) (firstTokenOffset:19) (offset:19)
               element: <testLibrary>::@enum::A::@field::v3
               initializer: expression_2
                 InstanceCreationExpression
@@ -11678,7 +11690,7 @@ library
                     leftParenthesis: ( @0
                     rightParenthesis: ) @0
                   staticType: A
-            #F7 isOriginEnumValues values (nameOffset:<null>) (firstTokenOffset:<null>) (offset:5)
+            #F6 isOriginEnumValues values (nameOffset:<null>) (firstTokenOffset:<null>) (offset:5)
               element: <testLibrary>::@enum::A::@field::values
               initializer: expression_3
                 ListLiteral
@@ -11690,7 +11702,7 @@ library
                       staticType: A
                     SimpleIdentifier
                       token: v2 @-1
-                      element: <testLibrary>::@enum::A::@getter::v2
+                      element: <testLibrary>::@enum::A::@getter::v2::@def::0
                       staticType: A
                     SimpleIdentifier
                       token: v3 @-1
@@ -11698,29 +11710,29 @@ library
                       staticType: A
                     SimpleIdentifier
                       token: v2 @-1
-                      element: <testLibrary>::@enum::A::@getter::v2
+                      element: <testLibrary>::@enum::A::@getter::v2::@def::0
                       staticType: A
                   rightBracket: ] @0
                   staticType: List<A>
           constructors
-            #F8 const isOriginImplicitDefault new (nameOffset:<null>) (firstTokenOffset:<null>) (offset:5)
+            #F7 const isOriginImplicitDefault new (nameOffset:<null>) (firstTokenOffset:<null>) (offset:5)
               element: <testLibrary>::@enum::A::@constructor::new
               typeName: A
           getters
-            #F9 isOriginVariable v1 (nameOffset:<null>) (firstTokenOffset:<null>) (offset:11)
+            #F8 isOriginVariable v1 (nameOffset:<null>) (firstTokenOffset:<null>) (offset:11)
               element: <testLibrary>::@enum::A::@getter::v1
-            #F10 isOriginVariable v2 (nameOffset:<null>) (firstTokenOffset:<null>) (offset:15)
-              element: <testLibrary>::@enum::A::@getter::v2
-            #F11 isOriginVariable v3 (nameOffset:<null>) (firstTokenOffset:<null>) (offset:19)
+            #F9 isOriginVariable v2 (nameOffset:<null>) (firstTokenOffset:<null>) (offset:15)
+              element: <testLibrary>::@enum::A::@getter::v2::@def::0
+            #F10 isOriginVariable v3 (nameOffset:<null>) (firstTokenOffset:<null>) (offset:19)
               element: <testLibrary>::@enum::A::@getter::v3
-            #F12 isOriginVariable values (nameOffset:<null>) (firstTokenOffset:<null>) (offset:5)
+            #F11 isOriginVariable values (nameOffset:<null>) (firstTokenOffset:<null>) (offset:5)
               element: <testLibrary>::@enum::A::@getter::values
         #F2 enum A (nameOffset:38) (firstTokenOffset:25) (offset:38)
           element: <testLibrary>::@enum::A
           previousFragment: #F1
           fields
-            #F5 augment hasInitializer isOriginDeclaration v2 (nameOffset:52) (firstTokenOffset:44) (offset:52)
-              element: <testLibrary>::@enum::A::@field::v2
+            #F12 hasInitializer isOriginDeclaration v2 (nameOffset:52) (firstTokenOffset:52) (offset:52)
+              element: <testLibrary>::@enum::A::@field::v2::@def::1
               initializer: expression_4
                 InstanceCreationExpression
                   constructorName: ConstructorName
@@ -11733,7 +11745,9 @@ library
                     leftParenthesis: ( @0
                     rightParenthesis: ) @0
                   staticType: A
-              previousFragment: #F4
+          getters
+            #F13 isOriginVariable v2 (nameOffset:<null>) (firstTokenOffset:<null>) (offset:52)
+              element: <testLibrary>::@enum::A::@getter::v2::@def::1
   enums
     enum A
       reference: <testLibrary>::@enum::A
@@ -11749,55 +11763,68 @@ library
             expression: expression_0
           getter: <testLibrary>::@enum::A::@getter::v1
         static const enumConstant hasImplicitType hasInitializer isOriginDeclaration v2
-          reference: <testLibrary>::@enum::A::@field::v2
+          reference: <testLibrary>::@enum::A::@field::v2::@def::0
           firstFragment: #F4
           type: A
           constantInitializer
-            fragment: #F5
-            expression: expression_4
-          getter: <testLibrary>::@enum::A::@getter::v2
+            fragment: #F4
+            expression: expression_1
+          getter: <testLibrary>::@enum::A::@getter::v2::@def::0
         static const enumConstant hasImplicitType hasInitializer isOriginDeclaration v3
           reference: <testLibrary>::@enum::A::@field::v3
-          firstFragment: #F6
+          firstFragment: #F5
           type: A
           constantInitializer
-            fragment: #F6
+            fragment: #F5
             expression: expression_2
           getter: <testLibrary>::@enum::A::@getter::v3
         static const isOriginEnumValues values
           reference: <testLibrary>::@enum::A::@field::values
-          firstFragment: #F7
+          firstFragment: #F6
           type: List<A>
           constantInitializer
-            fragment: #F7
+            fragment: #F6
             expression: expression_3
           getter: <testLibrary>::@enum::A::@getter::values
+        static const enumConstant hasImplicitType hasInitializer isOriginDeclaration v2
+          reference: <testLibrary>::@enum::A::@field::v2::@def::1
+          firstFragment: #F12
+          type: A
+          constantInitializer
+            fragment: #F12
+            expression: expression_4
+          getter: <testLibrary>::@enum::A::@getter::v2::@def::1
       constructors
         const isOriginImplicitDefault new
           reference: <testLibrary>::@enum::A::@constructor::new
-          firstFragment: #F8
+          firstFragment: #F7
           superConstructor: dart:core::@class::Enum::@constructor::new
       getters
         static isOriginVariable v1
           reference: <testLibrary>::@enum::A::@getter::v1
-          firstFragment: #F9
+          firstFragment: #F8
           returnType: A
           variable: <testLibrary>::@enum::A::@field::v1
         static isOriginVariable v2
-          reference: <testLibrary>::@enum::A::@getter::v2
-          firstFragment: #F10
+          reference: <testLibrary>::@enum::A::@getter::v2::@def::0
+          firstFragment: #F9
           returnType: A
-          variable: <testLibrary>::@enum::A::@field::v2
+          variable: <testLibrary>::@enum::A::@field::v2::@def::0
         static isOriginVariable v3
           reference: <testLibrary>::@enum::A::@getter::v3
-          firstFragment: #F11
+          firstFragment: #F10
           returnType: A
           variable: <testLibrary>::@enum::A::@field::v3
         static isOriginVariable values
           reference: <testLibrary>::@enum::A::@getter::values
-          firstFragment: #F12
+          firstFragment: #F11
           returnType: List<A>
           variable: <testLibrary>::@enum::A::@field::values
+        static isOriginVariable v2
+          reference: <testLibrary>::@enum::A::@getter::v2::@def::1
+          firstFragment: #F13
+          returnType: A
+          variable: <testLibrary>::@enum::A::@field::v2::@def::1
 ''');
   }
 
@@ -11825,25 +11852,24 @@ library
           nextFragment: #F2
           fields
             #F3 hasInitializer isOriginDeclaration v1 (nameOffset:11) (firstTokenOffset:11) (offset:11)
-              element: <testLibrary>::@enum::A::@field::v1
+              element: <testLibrary>::@enum::A::@field::v1::@def::0
               initializer: expression_0
                 InstanceCreationExpression
                   constructorName: ConstructorName
                     type: NamedType
                       name: A @-1
-                      element: <null>
-                      type: null
-                    element: <null>
+                      element: <testLibrary>::@enum::A
+                      type: A
+                    element: <testLibrary>::@enum::A::@constructor::new
                   argumentList: ArgumentList
                     leftParenthesis: ( @13
                     arguments
                       IntegerLiteral
                         literal: 1 @14
-                        staticType: null
+                        staticType: int
                     rightParenthesis: ) @15
-                  staticType: null
-              nextFragment: #F4
-            #F5 hasInitializer isOriginDeclaration v2 (nameOffset:18) (firstTokenOffset:18) (offset:18)
+                  staticType: A
+            #F4 hasInitializer isOriginDeclaration v2 (nameOffset:18) (firstTokenOffset:18) (offset:18)
               element: <testLibrary>::@enum::A::@field::v2
               initializer: expression_1
                 InstanceCreationExpression
@@ -11861,7 +11887,7 @@ library
                         staticType: int
                     rightParenthesis: ) @22
                   staticType: A
-            #F6 isOriginEnumValues values (nameOffset:<null>) (firstTokenOffset:<null>) (offset:5)
+            #F5 isOriginEnumValues values (nameOffset:<null>) (firstTokenOffset:<null>) (offset:5)
               element: <testLibrary>::@enum::A::@field::values
               initializer: expression_2
                 ListLiteral
@@ -11869,7 +11895,7 @@ library
                   elements
                     SimpleIdentifier
                       token: v1 @-1
-                      element: <testLibrary>::@enum::A::@getter::v1
+                      element: <testLibrary>::@enum::A::@getter::v1::@def::0
                       staticType: A
                     SimpleIdentifier
                       token: v2 @-1
@@ -11877,31 +11903,31 @@ library
                       staticType: A
                     SimpleIdentifier
                       token: v1 @-1
-                      element: <testLibrary>::@enum::A::@getter::v1
+                      element: <testLibrary>::@enum::A::@getter::v1::@def::0
                       staticType: A
                   rightBracket: ] @0
                   staticType: List<A>
           constructors
-            #F7 const isOriginDeclaration new (nameOffset:<null>) (firstTokenOffset:27) (offset:33)
+            #F6 const isOriginDeclaration new (nameOffset:<null>) (firstTokenOffset:27) (offset:33)
               element: <testLibrary>::@enum::A::@constructor::new
               typeName: A
               typeNameOffset: 33
               formalParameters
-                #F8 requiredPositional value (nameOffset:39) (firstTokenOffset:35) (offset:39)
+                #F7 requiredPositional value (nameOffset:39) (firstTokenOffset:35) (offset:39)
                   element: <testLibrary>::@enum::A::@constructor::new::@formalParameter::value
           getters
-            #F9 isOriginVariable v1 (nameOffset:<null>) (firstTokenOffset:<null>) (offset:11)
-              element: <testLibrary>::@enum::A::@getter::v1
-            #F10 isOriginVariable v2 (nameOffset:<null>) (firstTokenOffset:<null>) (offset:18)
+            #F8 isOriginVariable v1 (nameOffset:<null>) (firstTokenOffset:<null>) (offset:11)
+              element: <testLibrary>::@enum::A::@getter::v1::@def::0
+            #F9 isOriginVariable v2 (nameOffset:<null>) (firstTokenOffset:<null>) (offset:18)
               element: <testLibrary>::@enum::A::@getter::v2
-            #F11 isOriginVariable values (nameOffset:<null>) (firstTokenOffset:<null>) (offset:5)
+            #F10 isOriginVariable values (nameOffset:<null>) (firstTokenOffset:<null>) (offset:5)
               element: <testLibrary>::@enum::A::@getter::values
         #F2 enum A (nameOffset:63) (firstTokenOffset:50) (offset:63)
           element: <testLibrary>::@enum::A
           previousFragment: #F1
           fields
-            #F4 augment hasInitializer isOriginDeclaration v1 (nameOffset:77) (firstTokenOffset:69) (offset:77)
-              element: <testLibrary>::@enum::A::@field::v1
+            #F11 hasInitializer isOriginDeclaration v1 (nameOffset:77) (firstTokenOffset:77) (offset:77)
+              element: <testLibrary>::@enum::A::@field::v1::@def::1
               initializer: expression_3
                 InstanceCreationExpression
                   constructorName: ConstructorName
@@ -11918,7 +11944,9 @@ library
                         staticType: int
                     rightParenthesis: ) @81
                   staticType: A
-              previousFragment: #F3
+          getters
+            #F12 isOriginVariable v1 (nameOffset:<null>) (firstTokenOffset:<null>) (offset:77)
+              element: <testLibrary>::@enum::A::@getter::v1::@def::1
   enums
     enum A
       reference: <testLibrary>::@enum::A
@@ -11926,54 +11954,67 @@ library
       supertype: Enum
       fields
         static const enumConstant hasImplicitType hasInitializer isOriginDeclaration v1
-          reference: <testLibrary>::@enum::A::@field::v1
+          reference: <testLibrary>::@enum::A::@field::v1::@def::0
           firstFragment: #F3
           type: A
           constantInitializer
-            fragment: #F4
-            expression: expression_3
-          getter: <testLibrary>::@enum::A::@getter::v1
+            fragment: #F3
+            expression: expression_0
+          getter: <testLibrary>::@enum::A::@getter::v1::@def::0
         static const enumConstant hasImplicitType hasInitializer isOriginDeclaration v2
           reference: <testLibrary>::@enum::A::@field::v2
-          firstFragment: #F5
+          firstFragment: #F4
           type: A
           constantInitializer
-            fragment: #F5
+            fragment: #F4
             expression: expression_1
           getter: <testLibrary>::@enum::A::@getter::v2
         static const isOriginEnumValues values
           reference: <testLibrary>::@enum::A::@field::values
-          firstFragment: #F6
+          firstFragment: #F5
           type: List<A>
           constantInitializer
-            fragment: #F6
+            fragment: #F5
             expression: expression_2
           getter: <testLibrary>::@enum::A::@getter::values
+        static const enumConstant hasImplicitType hasInitializer isOriginDeclaration v1
+          reference: <testLibrary>::@enum::A::@field::v1::@def::1
+          firstFragment: #F11
+          type: A
+          constantInitializer
+            fragment: #F11
+            expression: expression_3
+          getter: <testLibrary>::@enum::A::@getter::v1::@def::1
       constructors
         const isOriginDeclaration new
           reference: <testLibrary>::@enum::A::@constructor::new
-          firstFragment: #F7
+          firstFragment: #F6
           formalParameters
             #E0 requiredPositional value
-              firstFragment: #F8
+              firstFragment: #F7
               type: int
           superConstructor: dart:core::@class::Enum::@constructor::new
       getters
         static isOriginVariable v1
-          reference: <testLibrary>::@enum::A::@getter::v1
-          firstFragment: #F9
+          reference: <testLibrary>::@enum::A::@getter::v1::@def::0
+          firstFragment: #F8
           returnType: A
-          variable: <testLibrary>::@enum::A::@field::v1
+          variable: <testLibrary>::@enum::A::@field::v1::@def::0
         static isOriginVariable v2
           reference: <testLibrary>::@enum::A::@getter::v2
-          firstFragment: #F10
+          firstFragment: #F9
           returnType: A
           variable: <testLibrary>::@enum::A::@field::v2
         static isOriginVariable values
           reference: <testLibrary>::@enum::A::@getter::values
-          firstFragment: #F11
+          firstFragment: #F10
           returnType: List<A>
           variable: <testLibrary>::@enum::A::@field::values
+        static isOriginVariable v1
+          reference: <testLibrary>::@enum::A::@getter::v1::@def::1
+          firstFragment: #F12
+          returnType: A
+          variable: <testLibrary>::@enum::A::@field::v1::@def::1
 ''');
   }
 
@@ -12003,21 +12044,20 @@ library
           nextFragment: #F2
           fields
             #F3 hasInitializer isOriginDeclaration v (nameOffset:11) (firstTokenOffset:11) (offset:11)
-              element: <testLibrary>::@enum::A::@field::v
+              element: <testLibrary>::@enum::A::@field::v::@def::0
               initializer: expression_0
                 InstanceCreationExpression
                   constructorName: ConstructorName
                     type: NamedType
                       name: A @-1
-                      element: <null>
-                      type: null
-                    element: <null>
+                      element: <testLibrary>::@enum::A
+                      type: A
+                    element: <testLibrary>::@enum::A::@constructor::new
                   argumentList: ArgumentList
                     leftParenthesis: ( @0
                     rightParenthesis: ) @0
-                  staticType: null
-              nextFragment: #F4
-            #F5 hasInitializer isOriginDeclaration v2 (nameOffset:14) (firstTokenOffset:14) (offset:14)
+                  staticType: A
+            #F4 hasInitializer isOriginDeclaration v2 (nameOffset:14) (firstTokenOffset:14) (offset:14)
               element: <testLibrary>::@enum::A::@field::v2
               initializer: expression_1
                 InstanceCreationExpression
@@ -12031,7 +12071,7 @@ library
                     leftParenthesis: ( @0
                     rightParenthesis: ) @0
                   staticType: A
-            #F6 isOriginEnumValues values (nameOffset:<null>) (firstTokenOffset:<null>) (offset:5)
+            #F5 isOriginEnumValues values (nameOffset:<null>) (firstTokenOffset:<null>) (offset:5)
               element: <testLibrary>::@enum::A::@field::values
               initializer: expression_2
                 ListLiteral
@@ -12039,7 +12079,7 @@ library
                   elements
                     SimpleIdentifier
                       token: v @-1
-                      element: <testLibrary>::@enum::A::@getter::v
+                      element: <testLibrary>::@enum::A::@getter::v::@def::0
                       staticType: A
                     SimpleIdentifier
                       token: v2 @-1
@@ -12047,23 +12087,23 @@ library
                       staticType: A
                     SimpleIdentifier
                       token: v @-1
-                      element: <testLibrary>::@enum::A::@getter::v
+                      element: <testLibrary>::@enum::A::@getter::v::@def::0
                       staticType: A
                   rightBracket: ] @0
                   staticType: List<A>
           getters
-            #F7 isOriginVariable v (nameOffset:<null>) (firstTokenOffset:<null>) (offset:11)
-              element: <testLibrary>::@enum::A::@getter::v
-            #F8 isOriginVariable v2 (nameOffset:<null>) (firstTokenOffset:<null>) (offset:14)
+            #F6 isOriginVariable v (nameOffset:<null>) (firstTokenOffset:<null>) (offset:11)
+              element: <testLibrary>::@enum::A::@getter::v::@def::0
+            #F7 isOriginVariable v2 (nameOffset:<null>) (firstTokenOffset:<null>) (offset:14)
               element: <testLibrary>::@enum::A::@getter::v2
-            #F9 isOriginVariable values (nameOffset:<null>) (firstTokenOffset:<null>) (offset:5)
+            #F8 isOriginVariable values (nameOffset:<null>) (firstTokenOffset:<null>) (offset:5)
               element: <testLibrary>::@enum::A::@getter::values
         #F2 enum A (nameOffset:33) (firstTokenOffset:20) (offset:33)
           element: <testLibrary>::@enum::A
           previousFragment: #F1
           fields
-            #F4 augment hasInitializer isOriginDeclaration v (nameOffset:50) (firstTokenOffset:42) (offset:50)
-              element: <testLibrary>::@enum::A::@field::v
+            #F9 hasInitializer isOriginDeclaration v (nameOffset:50) (firstTokenOffset:50) (offset:50)
+              element: <testLibrary>::@enum::A::@field::v::@def::1
               initializer: expression_3
                 InstanceCreationExpression
                   constructorName: ConstructorName
@@ -12076,7 +12116,9 @@ library
                     leftParenthesis: ( @0
                     rightParenthesis: ) @0
                   staticType: A
-              previousFragment: #F3
+          getters
+            #F10 isOriginVariable v (nameOffset:<null>) (firstTokenOffset:<null>) (offset:50)
+              element: <testLibrary>::@enum::A::@getter::v::@def::1
   enums
     enum A
       reference: <testLibrary>::@enum::A
@@ -12084,45 +12126,58 @@ library
       supertype: Enum
       fields
         static const enumConstant hasImplicitType hasInitializer isOriginDeclaration v
-          reference: <testLibrary>::@enum::A::@field::v
+          reference: <testLibrary>::@enum::A::@field::v::@def::0
           firstFragment: #F3
           type: A
           constantInitializer
-            fragment: #F4
-            expression: expression_3
-          getter: <testLibrary>::@enum::A::@getter::v
+            fragment: #F3
+            expression: expression_0
+          getter: <testLibrary>::@enum::A::@getter::v::@def::0
         static const enumConstant hasImplicitType hasInitializer isOriginDeclaration v2
           reference: <testLibrary>::@enum::A::@field::v2
-          firstFragment: #F5
+          firstFragment: #F4
           type: A
           constantInitializer
-            fragment: #F5
+            fragment: #F4
             expression: expression_1
           getter: <testLibrary>::@enum::A::@getter::v2
         static const isOriginEnumValues values
           reference: <testLibrary>::@enum::A::@field::values
-          firstFragment: #F6
+          firstFragment: #F5
           type: List<A>
           constantInitializer
-            fragment: #F6
+            fragment: #F5
             expression: expression_2
           getter: <testLibrary>::@enum::A::@getter::values
+        static const enumConstant hasImplicitType hasInitializer isOriginDeclaration v
+          reference: <testLibrary>::@enum::A::@field::v::@def::1
+          firstFragment: #F9
+          type: A
+          constantInitializer
+            fragment: #F9
+            expression: expression_3
+          getter: <testLibrary>::@enum::A::@getter::v::@def::1
       getters
         static isOriginVariable v
-          reference: <testLibrary>::@enum::A::@getter::v
-          firstFragment: #F7
+          reference: <testLibrary>::@enum::A::@getter::v::@def::0
+          firstFragment: #F6
           returnType: A
-          variable: <testLibrary>::@enum::A::@field::v
+          variable: <testLibrary>::@enum::A::@field::v::@def::0
         static isOriginVariable v2
           reference: <testLibrary>::@enum::A::@getter::v2
-          firstFragment: #F8
+          firstFragment: #F7
           returnType: A
           variable: <testLibrary>::@enum::A::@field::v2
         static isOriginVariable values
           reference: <testLibrary>::@enum::A::@getter::values
-          firstFragment: #F9
+          firstFragment: #F8
           returnType: List<A>
           variable: <testLibrary>::@enum::A::@field::values
+        static isOriginVariable v
+          reference: <testLibrary>::@enum::A::@getter::v::@def::1
+          firstFragment: #F10
+          returnType: A
+          variable: <testLibrary>::@enum::A::@field::v::@def::1
 ''');
   }
 


### PR DESCRIPTION
This PR aligns the parser and analyzer with `dart-lang/language@ebd9e18`, which removed support for augmenting enum values.

It changes the parser so code like:

```dart
enum E {
  foo
}

augment enum E {
  augment foo
}
```
is no longer accepted as a valid augmented enum constant declaration. Instead, the parser reports the leading augment as an extraneous modifier and recovers on the enum value name.

On the analyzer side, this PR also removes the internal use of enum-value augmentation data and deprecates EnumConstantDeclaration.augmentKeyword. That getter is part of the public analyzer API and is not experimental, so deprecating it now preserves semantic versioning and makes its future removal explicit.

The PR also updates parser and summary tests to reflect the new behavior.

Fix  #62280 