### PR TITLE
Add TODO for misleading dot shorthand diagnostic message (#62863)

### DIFF
--- a/pkg/analyzer/lib/src/dart/resolver/instance_creation_expression_resolver.dart
+++ b/pkg/analyzer/lib/src/dart/resolver/instance_creation_expression_resolver.dart
@@ -118,7 +118,7 @@ class InstanceCreationExpressionResolver {
         );
       }
     } else {
-    // TODO: Improve this message. Context type exists in some cases (e.g. dynamic, void)
+    // TODO: Improve this message. Context type exists in some cases (e.g. dynamic, void) 
     // but has no static scope. Current message is misleading (see issue #62863).
     _resolver.diagnosticReporter.report(
       diag.dotShorthandMissingContext.at(node),

--- a/pkg/analyzer/lib/src/dart/resolver/instance_creation_expression_resolver.dart
+++ b/pkg/analyzer/lib/src/dart/resolver/instance_creation_expression_resolver.dart
@@ -118,9 +118,11 @@ class InstanceCreationExpressionResolver {
         );
       }
     } else {
-      _resolver.diagnosticReporter.report(
-        diag.dotShorthandMissingContext.at(node),
-      );
+    // TODO: Improve this message. Context type exists in some cases (e.g. dynamic, void)
+    // but has no static scope. Current message is misleading (see issue #62863).
+    _resolver.diagnosticReporter.report(
+      diag.dotShorthandMissingContext.at(node),
+    );
       // Prevents `constructorElementToInfer` (called by
       // `_resolveDotShorthandConstructorInvocation`) from considering the
       // context type to be valid.


### PR DESCRIPTION
Fixes #62863

The analyzer message for dot shorthand suggests that there is no context type.
However, in cases like `dynamic` or `void`, a context type exists but it does not have a static scope.

This change adds a TODO comment highlighting that the current diagnostic message is misleading.

No functional behavior is changed.