### PR TITLE
[analyzer] Fix record top-merge check for positional field count

### DIFF
--- a/pkg/analyzer/lib/src/dart/element/top_merge.dart
+++ b/pkg/analyzer/lib/src/dart/element/top_merge.dart
@@ -272,7 +272,7 @@ class TopMergeHelper {
   RecordTypeImpl _recordTypes(RecordTypeImpl T1, RecordTypeImpl T2) {
     var positional1 = T1.positionalFields;
     var positional2 = T2.positionalFields;
-    if (positional1.length != positional1.length) {
+    if (positional1.length != positional2.length) {
       throw _TopMergeStateError(T1, T2, 'Different number of position fields');
     }
 


### PR DESCRIPTION
## Summary

Fix a copy-paste bug in `TopMergeHelper._recordTypes`: the arity check compared `positional1.length` to itself instead of `positional2.length`, so mismatched positional field counts between two record types were never caught during NNBD top merge.

## Testing

- Not run (one-line condition fix; consider running analyzer tests if CI requires).

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

Note: This PR was opened from fork `cuiweixie/sdk`; review may proceed on Gerrit per repository workflow.