### PR TITLE
[analysis_server_plugin] Add short note about single LintCode instance

### DIFF
--- a/pkg/analysis_server_plugin/doc/writing_rules.md
+++ b/pkg/analysis_server_plugin/doc/writing_rules.md
@@ -57,10 +57,14 @@ Let's look at each declaration individually:
   must implement `LintCode get diagnosticCode`, for infrastructure to be able
   to register the diagnostic code that the rule can report.
 
-  A `LintCode` is the template for each diagnostic that is to be reported. It
-  contains the diagnostic name, problem message, and optionally the correction
-  message. We instantiate a `LintCode` as a static field so that it can also be
-  made const.
+  A `LintCode` is the template for each diagnostic that is to be reported. It contains
+  the diagnostic name, problem message, and optionally the correction message. We
+  instantiate a `LintCode` as a `static const` field to ensure a single instance
+  exists — this is a functional requirement, not just convention. If multiple instances
+  of the same code exist, the analysis server cannot properly match them, and
+  users will be unable to suppress the diagnostic using `// ignore:` comments.
+  Alternatively, the class can implement `==` and `hashCode`, but using a `static const`
+  field is simpler and preferred.
 
   Alternatively, if a rule can report several different diagnostic codes
   (typically for differentiated messages), it can instead extend


### PR DESCRIPTION
This PR update explicitly states *why* a `LintCode` needs to be a single instance (or implement equality). Without this clarification, plugin authors can accidentally create un-ignorable diagnostics because the analysis server cannot properly match multiple instances to suppress them using `// ignore:` comments.

Fixes #62256  
---

- [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
