### PR TITLE
[analyzer] Fix cache size counter drift in EvictingFileByteStore._cleanUpFolder

### DIFF
--- a/pkg/analyzer/lib/src/dart/analysis/file_byte_store.dart
+++ b/pkg/analyzer/lib/src/dart/analysis/file_byte_store.dart
@@ -139,8 +139,8 @@ class EvictingFileByteStore implements ByteStore {
       }
       try {
         file.deleteSync();
+        currentSizeBytes -= fileStatMap[file]!.size;
       } catch (_) {}
-      currentSizeBytes -= fileStatMap[file]!.size;
     }
   }
 }


### PR DESCRIPTION
## Problem

`EvictingFileByteStore._cleanUpFolder` was decrementing `currentSizeBytes` unconditionally,
even when `file.deleteSync()` threw an exception:

```dart
try {
  file.deleteSync();
} catch (_) {}
currentSizeBytes -= fileStatMap[file]!.size; // <- always runs, even on failure
```

If a file cannot be deleted (e.g. due to a permissions error or a race with another process),
the counter is decremented as though the deletion succeeded.  This causes the cache to
**underestimate** its own size, which can prevent the eviction loop from running again even
though the cache is still over its `maxSizeBytes` limit.

## Fix

Move the decrement inside the `try` block so it only executes when the deletion actually succeeds:

```dart
try {
  file.deleteSync();
  currentSizeBytes -= fileStatMap[file]!.size; // <- only runs on success
} catch (_) {}
```

## Tests

Two regression tests are added to a new `EvictingFileByteStoreCleanUpTest` class:

* `test_cleanUpFolder_successfulDeletion_decrementsSizeCounter` - basic happy-path eviction.
* * `test_cleanUpFolder_failedDeletion_doesNotDecrementSizeCounter` - simulates a failed
*   deletion by revoking `chmod 000` on the parent directory and verifies that the files
*   remain on disk (i.e. the loop is not fooled by a corrupted size counter). Skipped on Windows.
Fixes #63118