### PR TITLE
[dart2wasm] Avoid redundant typed_data buffer allocations in setRange

### DIFF
--- a/sdk/lib/_internal/wasm/lib/typed_data.dart
+++ b/sdk/lib/_internal/wasm/lib/typed_data.dart
@@ -1996,12 +1996,6 @@ mixin _TypedIntListMixin<SpawnedType extends TypedDataList<int>>
       final destDartElementSizeInBytes = destTypedData.elementSizeInBytes;
       final fromDartElementSizeInBytes = fromTypedData.elementSizeInBytes;
 
-      final fromBufferByteOffset =
-          fromTypedData.offsetInBytes +
-          (skipCount * fromDartElementSizeInBytes);
-      final destBufferByteOffset =
-          destTypedData.offsetInBytes + (start * destDartElementSizeInBytes);
-
       // Use `array.copy` when:
       //
       // 1. Dart array element types are the same.
@@ -2015,77 +2009,13 @@ mixin _TypedIntListMixin<SpawnedType extends TypedDataList<int>>
       // receiver is an int array and if the buffer is a F32/F64 buffer that
       // means casting needs to happen when reading.
       if (destDartElementSizeInBytes == fromDartElementSizeInBytes) {
-        if (destDartElementSizeInBytes == 1 &&
-            destTypedData is WasmI8ArrayBase &&
-            fromTypedData is WasmI8ArrayBase) {
-          if (destTypedData is! U8ClampedList &&
-              destTypedData is! _SlowU8ClampedList) {
-            final WasmI8ArrayBase destI8 = unsafeCast<WasmI8ArrayBase>(
-              destTypedData,
-            );
-            final WasmI8ArrayBase fromI8 = unsafeCast<WasmI8ArrayBase>(
-              fromTypedData,
-            );
-            destI8.data.copy(
-              destI8.offsetInElements + start,
-              fromI8.data,
-              fromI8.offsetInElements + skipCount,
-              count,
-            );
-            return;
-          }
-        } else if (destDartElementSizeInBytes == 2 &&
-            destTypedData is WasmI16ArrayBase &&
-            fromTypedData is WasmI16ArrayBase) {
-          final WasmI16ArrayBase destI16 = unsafeCast<WasmI16ArrayBase>(
-            destTypedData,
-          );
-          final WasmI16ArrayBase fromI16 = unsafeCast<WasmI16ArrayBase>(
-            fromTypedData,
-          );
-          destI16.data.copy(
-            destI16.offsetInElements + start,
-            fromI16.data,
-            fromI16.offsetInElements + skipCount,
-            count,
-          );
-          return;
-        } else if (destDartElementSizeInBytes == 4 &&
-            destTypedData is _WasmI32ArrayBase &&
-            fromTypedData is _WasmI32ArrayBase) {
-          final _WasmI32ArrayBase destI32 = unsafeCast<_WasmI32ArrayBase>(
-            destTypedData,
-          );
-          final _WasmI32ArrayBase fromI32 = unsafeCast<_WasmI32ArrayBase>(
-            fromTypedData,
-          );
-          destI32.data.copy(
-            destI32.offsetInElements + start,
-            fromI32.data,
-            fromI32.offsetInElements + skipCount,
-            count,
-          );
-          return;
-        } else if (destDartElementSizeInBytes == 8 &&
-            destTypedData is _WasmI64ArrayBase &&
-            fromTypedData is _WasmI64ArrayBase) {
-          final _WasmI64ArrayBase destI64 = unsafeCast<_WasmI64ArrayBase>(
-            destTypedData,
-          );
-          final _WasmI64ArrayBase fromI64 = unsafeCast<_WasmI64ArrayBase>(
-            fromTypedData,
-          );
-          destI64.data.copy(
-            destI64.offsetInElements + start,
-            fromI64.data,
-            fromI64.offsetInElements + skipCount,
-            count,
-          );
-          return;
-        }
-
         final ByteBuffer destBuffer = destTypedData.buffer;
         final ByteBuffer fromBuffer = fromTypedData.buffer;
+        final fromBufferByteOffset =
+            fromTypedData.offsetInBytes +
+            (skipCount * fromDartElementSizeInBytes);
+        final destBufferByteOffset =
+            destTypedData.offsetInBytes + (start * destDartElementSizeInBytes);
 
         if (destDartElementSizeInBytes == 1 &&
             destBuffer is _I8ByteBuffer &&
@@ -2512,47 +2442,13 @@ mixin _TypedDoubleListMixin<SpawnedType extends TypedDataList<double>>
 
       // See comments in `_TypedIntListMixin.setRange`.
       if (destDartElementSizeInBytes == fromDartElementSizeInBytes) {
+        final ByteBuffer destBuffer = destTypedData.buffer;
+        final ByteBuffer fromBuffer = fromTypedData.buffer;
         final fromBufferByteOffset =
             fromTypedData.offsetInBytes +
             (skipCount * fromDartElementSizeInBytes);
         final destBufferByteOffset =
             destTypedData.offsetInBytes + (start * destDartElementSizeInBytes);
-        if (destDartElementSizeInBytes == 4 &&
-            destTypedData is _WasmF32ArrayBase &&
-            fromTypedData is _WasmF32ArrayBase) {
-          final _WasmF32ArrayBase destF32 = unsafeCast<_WasmF32ArrayBase>(
-            destTypedData,
-          );
-          final _WasmF32ArrayBase fromF32 = unsafeCast<_WasmF32ArrayBase>(
-            fromTypedData,
-          );
-          destF32.data.copy(
-            destF32.offsetInElements + start,
-            fromF32.data,
-            fromF32.offsetInElements + skipCount,
-            count,
-          );
-          return;
-        } else if (destDartElementSizeInBytes == 8 &&
-            destTypedData is _WasmF64ArrayBase &&
-            fromTypedData is _WasmF64ArrayBase) {
-          final _WasmF64ArrayBase destF64 = unsafeCast<_WasmF64ArrayBase>(
-            destTypedData,
-          );
-          final _WasmF64ArrayBase fromF64 = unsafeCast<_WasmF64ArrayBase>(
-            fromTypedData,
-          );
-          destF64.data.copy(
-            destF64.offsetInElements + start,
-            fromF64.data,
-            fromF64.offsetInElements + skipCount,
-            count,
-          );
-          return;
-        }
-
-        final ByteBuffer destBuffer = destTypedData.buffer;
-        final ByteBuffer fromBuffer = fromTypedData.buffer;
 
         if (destDartElementSizeInBytes == 4 &&
             destBuffer is _F32ByteBuffer &&
@@ -2654,6 +2550,29 @@ abstract class WasmI8ArrayBase extends WasmTypedDataBase {
 
   @pragma('wasm:prefer-inline')
   _I8ByteBuffer get buffer => _I8ByteBuffer(_data);
+
+  bool _trySetRangeFastPath(
+    int start,
+    int end,
+    Iterable<int> from,
+    int skipCount,
+  ) {
+    if (from is! WasmI8ArrayBase) return false;
+    RangeErrorUtils.checkValidRange(start, end, length);
+    RangeErrorUtils.checkNotNegative(skipCount, "skipCount");
+    final count = end - start;
+    if ((from.length - skipCount) < count) {
+      throw IterableElementError.tooFew();
+    }
+    if (count == 0) return true;
+    _data.copy(
+      _offsetInElements + start,
+      from._data,
+      from._offsetInElements + skipCount,
+      count,
+    );
+    return true;
+  }
 }
 
 abstract class WasmI16ArrayBase extends WasmTypedDataBase {
@@ -2673,6 +2592,29 @@ abstract class WasmI16ArrayBase extends WasmTypedDataBase {
 
   @pragma('wasm:prefer-inline')
   _I16ByteBuffer get buffer => _I16ByteBuffer(_data);
+
+  bool _trySetRangeFastPath(
+    int start,
+    int end,
+    Iterable<int> from,
+    int skipCount,
+  ) {
+    if (from is! WasmI16ArrayBase) return false;
+    RangeErrorUtils.checkValidRange(start, end, length);
+    RangeErrorUtils.checkNotNegative(skipCount, "skipCount");
+    final count = end - start;
+    if ((from.length - skipCount) < count) {
+      throw IterableElementError.tooFew();
+    }
+    if (count == 0) return true;
+    _data.copy(
+      _offsetInElements + start,
+      from._data,
+      from._offsetInElements + skipCount,
+      count,
+    );
+    return true;
+  }
 }
 
 abstract class _WasmI32ArrayBase extends WasmTypedDataBase {
@@ -2692,6 +2634,29 @@ abstract class _WasmI32ArrayBase extends WasmTypedDataBase {
 
   @pragma('wasm:prefer-inline')
   _I32ByteBuffer get buffer => _I32ByteBuffer(_data);
+
+  bool _trySetRangeFastPath(
+    int start,
+    int end,
+    Iterable<int> from,
+    int skipCount,
+  ) {
+    if (from is! _WasmI32ArrayBase) return false;
+    RangeErrorUtils.checkValidRange(start, end, length);
+    RangeErrorUtils.checkNotNegative(skipCount, "skipCount");
+    final count = end - start;
+    if ((from.length - skipCount) < count) {
+      throw IterableElementError.tooFew();
+    }
+    if (count == 0) return true;
+    _data.copy(
+      _offsetInElements + start,
+      from._data,
+      from._offsetInElements + skipCount,
+      count,
+    );
+    return true;
+  }
 }
 
 abstract class _WasmI64ArrayBase extends WasmTypedDataBase {
@@ -2711,6 +2676,29 @@ abstract class _WasmI64ArrayBase extends WasmTypedDataBase {
 
   @pragma('wasm:prefer-inline')
   _I64ByteBuffer get buffer => _I64ByteBuffer(_data);
+
+  bool _trySetRangeFastPath(
+    int start,
+    int end,
+    Iterable<int> from,
+    int skipCount,
+  ) {
+    if (from is! _WasmI64ArrayBase) return false;
+    RangeErrorUtils.checkValidRange(start, end, length);
+    RangeErrorUtils.checkNotNegative(skipCount, "skipCount");
+    final count = end - start;
+    if ((from.length - skipCount) < count) {
+      throw IterableElementError.tooFew();
+    }
+    if (count == 0) return true;
+    _data.copy(
+      _offsetInElements + start,
+      from._data,
+      from._offsetInElements + skipCount,
+      count,
+    );
+    return true;
+  }
 }
 
 abstract class _WasmF32ArrayBase extends WasmTypedDataBase {
@@ -2730,6 +2718,29 @@ abstract class _WasmF32ArrayBase extends WasmTypedDataBase {
 
   @pragma('wasm:prefer-inline')
   _F32ByteBuffer get buffer => _F32ByteBuffer(_data);
+
+  bool _trySetRangeFastPath(
+    int start,
+    int end,
+    Iterable<double> from,
+    int skipCount,
+  ) {
+    if (from is! _WasmF32ArrayBase) return false;
+    RangeErrorUtils.checkValidRange(start, end, length);
+    RangeErrorUtils.checkNotNegative(skipCount);
+    final count = end - start;
+    if ((from.length - skipCount) < count) {
+      throw IterableElementError.tooFew();
+    }
+    if (count == 0) return true;
+    _data.copy(
+      _offsetInElements + start,
+      from._data,
+      from._offsetInElements + skipCount,
+      count,
+    );
+    return true;
+  }
 }
 
 abstract class _WasmF64ArrayBase extends WasmTypedDataBase {
@@ -2749,6 +2760,29 @@ abstract class _WasmF64ArrayBase extends WasmTypedDataBase {
 
   @pragma('wasm:prefer-inline')
   _F64ByteBuffer get buffer => _F64ByteBuffer(_data);
+
+  bool _trySetRangeFastPath(
+    int start,
+    int end,
+    Iterable<double> from,
+    int skipCount,
+  ) {
+    if (from is! _WasmF64ArrayBase) return false;
+    RangeErrorUtils.checkValidRange(start, end, length);
+    RangeErrorUtils.checkNotNegative(skipCount);
+    final count = end - start;
+    if ((from.length - skipCount) < count) {
+      throw IterableElementError.tooFew();
+    }
+    if (count == 0) return true;
+    _data.copy(
+      _offsetInElements + start,
+      from._data,
+      from._offsetInElements + skipCount,
+      count,
+    );
+    return true;
+  }
 }
 
 extension WasmI8ArrayBaseExt on WasmI8ArrayBase {
@@ -2826,6 +2860,15 @@ class I8List extends WasmI8ArrayBase
   I8List _createList(int length) => I8List(length);
 
   @override
+  void setRange(int start, int end, Iterable<int> from, [int skipCount = 0]) {
+    if (this is! _UnmodifiableIntListMixin &&
+        _trySetRangeFastPath(start, end, from, skipCount)) {
+      return;
+    }
+    super.setRange(start, end, from, skipCount);
+  }
+
+  @override
   @pragma("wasm:prefer-inline")
   int operator [](int index) {
     IndexErrorUtils.checkIndexBCE(index, length);
@@ -2865,6 +2908,15 @@ class U8List extends WasmI8ArrayBase
 
   @override
   U8List _createList(int length) => U8List(length);
+
+  @override
+  void setRange(int start, int end, Iterable<int> from, [int skipCount = 0]) {
+    if (this is! _UnmodifiableIntListMixin &&
+        _trySetRangeFastPath(start, end, from, skipCount)) {
+      return;
+    }
+    super.setRange(start, end, from, skipCount);
+  }
 
   @override
   @pragma("wasm:prefer-inline")
@@ -2960,6 +3012,15 @@ class I16List extends WasmI16ArrayBase
   I16List _createList(int length) => I16List(length);
 
   @override
+  void setRange(int start, int end, Iterable<int> from, [int skipCount = 0]) {
+    if (this is! _UnmodifiableIntListMixin &&
+        _trySetRangeFastPath(start, end, from, skipCount)) {
+      return;
+    }
+    super.setRange(start, end, from, skipCount);
+  }
+
+  @override
   @pragma("wasm:prefer-inline")
   int operator [](int index) {
     IndexErrorUtils.checkIndexBCE(index, length);
@@ -2999,6 +3060,15 @@ class U16List extends WasmI16ArrayBase
 
   @override
   U16List _createList(int length) => U16List(length);
+
+  @override
+  void setRange(int start, int end, Iterable<int> from, [int skipCount = 0]) {
+    if (this is! _UnmodifiableIntListMixin &&
+        _trySetRangeFastPath(start, end, from, skipCount)) {
+      return;
+    }
+    super.setRange(start, end, from, skipCount);
+  }
 
   @override
   @pragma("wasm:prefer-inline")
@@ -3052,6 +3122,15 @@ class I32List extends _WasmI32ArrayBase
   I32List _createList(int length) => I32List(length);
 
   @override
+  void setRange(int start, int end, Iterable<int> from, [int skipCount = 0]) {
+    if (this is! _UnmodifiableIntListMixin &&
+        _trySetRangeFastPath(start, end, from, skipCount)) {
+      return;
+    }
+    super.setRange(start, end, from, skipCount);
+  }
+
+  @override
   @pragma("wasm:prefer-inline")
   int operator [](int index) {
     IndexErrorUtils.checkIndexBCE(index, length);
@@ -3091,6 +3170,15 @@ class U32List extends _WasmI32ArrayBase
 
   @override
   U32List _createList(int length) => U32List(length);
+
+  @override
+  void setRange(int start, int end, Iterable<int> from, [int skipCount = 0]) {
+    if (this is! _UnmodifiableIntListMixin &&
+        _trySetRangeFastPath(start, end, from, skipCount)) {
+      return;
+    }
+    super.setRange(start, end, from, skipCount);
+  }
 
   @override
   @pragma("wasm:prefer-inline")
@@ -3134,6 +3222,15 @@ class I64List extends _WasmI64ArrayBase
   I64List _createList(int length) => I64List(length);
 
   @override
+  void setRange(int start, int end, Iterable<int> from, [int skipCount = 0]) {
+    if (this is! _UnmodifiableIntListMixin &&
+        _trySetRangeFastPath(start, end, from, skipCount)) {
+      return;
+    }
+    super.setRange(start, end, from, skipCount);
+  }
+
+  @override
   @pragma("wasm:prefer-inline")
   int operator [](int index) {
     IndexErrorUtils.checkIndexBCE(index, length);
@@ -3173,6 +3270,15 @@ class U64List extends _WasmI64ArrayBase
 
   @override
   U64List _createList(int length) => U64List(length);
+
+  @override
+  void setRange(int start, int end, Iterable<int> from, [int skipCount = 0]) {
+    if (this is! _UnmodifiableIntListMixin &&
+        _trySetRangeFastPath(start, end, from, skipCount)) {
+      return;
+    }
+    super.setRange(start, end, from, skipCount);
+  }
 
   @override
   @pragma("wasm:prefer-inline")
@@ -3216,6 +3322,20 @@ class F32List extends _WasmF32ArrayBase
   F32List _createList(int length) => F32List(length);
 
   @override
+  void setRange(
+    int start,
+    int end,
+    Iterable<double> from, [
+    int skipCount = 0,
+  ]) {
+    if (this is! _UnmodifiableDoubleListMixin &&
+        _trySetRangeFastPath(start, end, from, skipCount)) {
+      return;
+    }
+    super.setRange(start, end, from, skipCount);
+  }
+
+  @override
   @pragma("wasm:prefer-inline")
   double operator [](int index) {
     IndexErrorUtils.checkIndexBCE(index, length);
@@ -3255,6 +3375,20 @@ class F64List extends _WasmF64ArrayBase
 
   @override
   F64List _createList(int length) => F64List(length);
+
+  @override
+  void setRange(
+    int start,
+    int end,
+    Iterable<double> from, [
+    int skipCount = 0,
+  ]) {
+    if (this is! _UnmodifiableDoubleListMixin &&
+        _trySetRangeFastPath(start, end, from, skipCount)) {
+      return;
+    }
+    super.setRange(start, end, from, skipCount);
+  }
 
   @override
   @pragma("wasm:prefer-inline")

--- a/sdk/lib/_internal/wasm/lib/typed_data.dart
+++ b/sdk/lib/_internal/wasm/lib/typed_data.dart
@@ -1992,83 +1992,6 @@ mixin _TypedIntListMixin<SpawnedType extends TypedDataList<int>>
       // `this` is `TypedData`.
       final TypedData destTypedData = this;
       final TypedData fromTypedData = unsafeCast<TypedData>(from);
-
-      final destDartElementSizeInBytes = destTypedData.elementSizeInBytes;
-      final fromDartElementSizeInBytes = fromTypedData.elementSizeInBytes;
-
-      // Use `array.copy` when:
-      //
-      // 1. Dart array element types are the same.
-      // 2. Wasm array element sizes are the same.
-      // 3. Source and destination offsets are multiples of element size.
-      //
-      // (1) is to make sure no sign extension, clamping, or truncation needs
-      // to happen when copying. (2) and (3) are requirements for `array.copy`.
-      //
-      // We don't check for `_F32ByteBuffer` and `_F64ByteBuffer` here as the
-      // receiver is an int array and if the buffer is a F32/F64 buffer that
-      // means casting needs to happen when reading.
-      if (destDartElementSizeInBytes == fromDartElementSizeInBytes) {
-        final ByteBuffer destBuffer = destTypedData.buffer;
-        final ByteBuffer fromBuffer = fromTypedData.buffer;
-        final fromBufferByteOffset =
-            fromTypedData.offsetInBytes +
-            (skipCount * fromDartElementSizeInBytes);
-        final destBufferByteOffset =
-            destTypedData.offsetInBytes + (start * destDartElementSizeInBytes);
-
-        if (destDartElementSizeInBytes == 1 &&
-            destBuffer is _I8ByteBuffer &&
-            fromBuffer is _I8ByteBuffer) {
-          if (destTypedData is! U8ClampedList &&
-              destTypedData is! _SlowU8ClampedList) {
-            destBuffer._data.copy(
-              destBufferByteOffset,
-              fromBuffer._data,
-              fromBufferByteOffset,
-              count,
-            );
-            return;
-          }
-        } else if (destDartElementSizeInBytes == 2 &&
-            destBuffer is _I16ByteBuffer &&
-            fromBuffer is _I16ByteBuffer) {
-          if (fromBufferByteOffset & 1 == 0 && destBufferByteOffset & 1 == 0) {
-            destBuffer._data.copy(
-              destBufferByteOffset ~/ 2,
-              fromBuffer._data,
-              fromBufferByteOffset ~/ 2,
-              count,
-            );
-            return;
-          }
-        } else if (destDartElementSizeInBytes == 4 &&
-            destBuffer is _I32ByteBuffer &&
-            fromBuffer is _I32ByteBuffer) {
-          if (fromBufferByteOffset & 3 == 0 && destBufferByteOffset & 3 == 0) {
-            destBuffer._data.copy(
-              destBufferByteOffset ~/ 4,
-              fromBuffer._data,
-              fromBufferByteOffset ~/ 4,
-              count,
-            );
-            return;
-          }
-        } else if (destDartElementSizeInBytes == 8 &&
-            destBuffer is _I64ByteBuffer &&
-            fromBuffer is _I64ByteBuffer) {
-          if (fromBufferByteOffset & 7 == 0 && destBufferByteOffset & 7 == 0) {
-            destBuffer._data.copy(
-              destBufferByteOffset ~/ 8,
-              fromBuffer._data,
-              fromBufferByteOffset ~/ 8,
-              count,
-            );
-            return;
-          }
-        }
-      }
-
       final ByteBuffer destBuffer = destTypedData.buffer;
       final ByteBuffer fromBuffer = fromTypedData.buffer;
 
@@ -2436,47 +2359,6 @@ mixin _TypedDoubleListMixin<SpawnedType extends TypedDataList<double>>
       // `this` is `TypedData`.
       final TypedData destTypedData = this;
       final TypedData fromTypedData = unsafeCast<TypedData>(from);
-
-      final destDartElementSizeInBytes = destTypedData.elementSizeInBytes;
-      final fromDartElementSizeInBytes = fromTypedData.elementSizeInBytes;
-
-      // See comments in `_TypedIntListMixin.setRange`.
-      if (destDartElementSizeInBytes == fromDartElementSizeInBytes) {
-        final ByteBuffer destBuffer = destTypedData.buffer;
-        final ByteBuffer fromBuffer = fromTypedData.buffer;
-        final fromBufferByteOffset =
-            fromTypedData.offsetInBytes +
-            (skipCount * fromDartElementSizeInBytes);
-        final destBufferByteOffset =
-            destTypedData.offsetInBytes + (start * destDartElementSizeInBytes);
-
-        if (destDartElementSizeInBytes == 4 &&
-            destBuffer is _F32ByteBuffer &&
-            fromBuffer is _F32ByteBuffer) {
-          if (fromBufferByteOffset & 3 == 0 && destBufferByteOffset & 3 == 0) {
-            destBuffer._data.copy(
-              destBufferByteOffset ~/ 4,
-              fromBuffer._data,
-              fromBufferByteOffset ~/ 4,
-              count,
-            );
-            return;
-          }
-        } else if (destDartElementSizeInBytes == 8 &&
-            destBuffer is _F64ByteBuffer &&
-            fromBuffer is _F64ByteBuffer) {
-          if (fromBufferByteOffset & 7 == 0 && destBufferByteOffset & 7 == 0) {
-            destBuffer._data.copy(
-              destBufferByteOffset ~/ 8,
-              fromBuffer._data,
-              fromBufferByteOffset ~/ 8,
-              count,
-            );
-            return;
-          }
-        }
-      }
-
       final ByteBuffer destBuffer = destTypedData.buffer;
       final ByteBuffer fromBuffer = fromTypedData.buffer;
 
@@ -2634,7 +2516,6 @@ abstract class WasmI8ArrayBase extends WasmTypedDataBase {
       skipCount,
       skipCountName: "skipCount",
     );
-    if (count == 0) return true;
     _data.copy(
       _offsetInElements + start,
       typedFrom._data,
@@ -2679,7 +2560,6 @@ abstract class WasmI16ArrayBase extends WasmTypedDataBase {
       skipCount,
       skipCountName: "skipCount",
     );
-    if (count == 0) return true;
     _data.copy(
       _offsetInElements + start,
       typedFrom._data,
@@ -2724,7 +2604,6 @@ abstract class _WasmI32ArrayBase extends WasmTypedDataBase {
       skipCount,
       skipCountName: "skipCount",
     );
-    if (count == 0) return true;
     _data.copy(
       _offsetInElements + start,
       typedFrom._data,
@@ -2769,7 +2648,6 @@ abstract class _WasmI64ArrayBase extends WasmTypedDataBase {
       skipCount,
       skipCountName: "skipCount",
     );
-    if (count == 0) return true;
     _data.copy(
       _offsetInElements + start,
       typedFrom._data,
@@ -2813,7 +2691,6 @@ abstract class _WasmF32ArrayBase extends WasmTypedDataBase {
       typedFrom.length,
       skipCount,
     );
-    if (count == 0) return true;
     _data.copy(
       _offsetInElements + start,
       typedFrom._data,
@@ -2857,7 +2734,6 @@ abstract class _WasmF64ArrayBase extends WasmTypedDataBase {
       typedFrom.length,
       skipCount,
     );
-    if (count == 0) return true;
     _data.copy(
       _offsetInElements + start,
       typedFrom._data,

--- a/sdk/lib/_internal/wasm/lib/typed_data.dart
+++ b/sdk/lib/_internal/wasm/lib/typed_data.dart
@@ -2506,23 +2506,24 @@ abstract class WasmI8ArrayBase extends WasmTypedDataBase {
     Iterable<int> from,
     int skipCount,
   ) {
-    if (from is! WasmI8ArrayBase) return false;
-    final typedFrom = from as WasmI8ArrayBase;
-    final count = _setRangeFastPathCount(
-      start,
-      end,
-      length,
-      typedFrom.length,
-      skipCount,
-      skipCountName: "skipCount",
-    );
-    _data.copy(
-      _offsetInElements + start,
-      typedFrom._data,
-      typedFrom._offsetInElements + skipCount,
-      count,
-    );
-    return true;
+    if (from case final WasmI8ArrayBase typedFrom) {
+      final count = _setRangeFastPathCount(
+        start,
+        end,
+        length,
+        typedFrom.length,
+        skipCount,
+        skipCountName: "skipCount",
+      );
+      _data.copy(
+        _offsetInElements + start,
+        typedFrom._data,
+        typedFrom._offsetInElements + skipCount,
+        count,
+      );
+      return true;
+    }
+    return false;
   }
 }
 
@@ -2550,23 +2551,24 @@ abstract class WasmI16ArrayBase extends WasmTypedDataBase {
     Iterable<int> from,
     int skipCount,
   ) {
-    if (from is! WasmI16ArrayBase) return false;
-    final typedFrom = from as WasmI16ArrayBase;
-    final count = _setRangeFastPathCount(
-      start,
-      end,
-      length,
-      typedFrom.length,
-      skipCount,
-      skipCountName: "skipCount",
-    );
-    _data.copy(
-      _offsetInElements + start,
-      typedFrom._data,
-      typedFrom._offsetInElements + skipCount,
-      count,
-    );
-    return true;
+    if (from case final WasmI16ArrayBase typedFrom) {
+      final count = _setRangeFastPathCount(
+        start,
+        end,
+        length,
+        typedFrom.length,
+        skipCount,
+        skipCountName: "skipCount",
+      );
+      _data.copy(
+        _offsetInElements + start,
+        typedFrom._data,
+        typedFrom._offsetInElements + skipCount,
+        count,
+      );
+      return true;
+    }
+    return false;
   }
 }
 
@@ -2594,23 +2596,24 @@ abstract class _WasmI32ArrayBase extends WasmTypedDataBase {
     Iterable<int> from,
     int skipCount,
   ) {
-    if (from is! _WasmI32ArrayBase) return false;
-    final typedFrom = from as _WasmI32ArrayBase;
-    final count = _setRangeFastPathCount(
-      start,
-      end,
-      length,
-      typedFrom.length,
-      skipCount,
-      skipCountName: "skipCount",
-    );
-    _data.copy(
-      _offsetInElements + start,
-      typedFrom._data,
-      typedFrom._offsetInElements + skipCount,
-      count,
-    );
-    return true;
+    if (from case final _WasmI32ArrayBase typedFrom) {
+      final count = _setRangeFastPathCount(
+        start,
+        end,
+        length,
+        typedFrom.length,
+        skipCount,
+        skipCountName: "skipCount",
+      );
+      _data.copy(
+        _offsetInElements + start,
+        typedFrom._data,
+        typedFrom._offsetInElements + skipCount,
+        count,
+      );
+      return true;
+    }
+    return false;
   }
 }
 
@@ -2638,23 +2641,24 @@ abstract class _WasmI64ArrayBase extends WasmTypedDataBase {
     Iterable<int> from,
     int skipCount,
   ) {
-    if (from is! _WasmI64ArrayBase) return false;
-    final typedFrom = from as _WasmI64ArrayBase;
-    final count = _setRangeFastPathCount(
-      start,
-      end,
-      length,
-      typedFrom.length,
-      skipCount,
-      skipCountName: "skipCount",
-    );
-    _data.copy(
-      _offsetInElements + start,
-      typedFrom._data,
-      typedFrom._offsetInElements + skipCount,
-      count,
-    );
-    return true;
+    if (from case final _WasmI64ArrayBase typedFrom) {
+      final count = _setRangeFastPathCount(
+        start,
+        end,
+        length,
+        typedFrom.length,
+        skipCount,
+        skipCountName: "skipCount",
+      );
+      _data.copy(
+        _offsetInElements + start,
+        typedFrom._data,
+        typedFrom._offsetInElements + skipCount,
+        count,
+      );
+      return true;
+    }
+    return false;
   }
 }
 
@@ -2682,22 +2686,23 @@ abstract class _WasmF32ArrayBase extends WasmTypedDataBase {
     Iterable<double> from,
     int skipCount,
   ) {
-    if (from is! _WasmF32ArrayBase) return false;
-    final typedFrom = from as _WasmF32ArrayBase;
-    final count = _setRangeFastPathCount(
-      start,
-      end,
-      length,
-      typedFrom.length,
-      skipCount,
-    );
-    _data.copy(
-      _offsetInElements + start,
-      typedFrom._data,
-      typedFrom._offsetInElements + skipCount,
-      count,
-    );
-    return true;
+    if (from case final _WasmF32ArrayBase typedFrom) {
+      final count = _setRangeFastPathCount(
+        start,
+        end,
+        length,
+        typedFrom.length,
+        skipCount,
+      );
+      _data.copy(
+        _offsetInElements + start,
+        typedFrom._data,
+        typedFrom._offsetInElements + skipCount,
+        count,
+      );
+      return true;
+    }
+    return false;
   }
 }
 
@@ -2725,22 +2730,23 @@ abstract class _WasmF64ArrayBase extends WasmTypedDataBase {
     Iterable<double> from,
     int skipCount,
   ) {
-    if (from is! _WasmF64ArrayBase) return false;
-    final typedFrom = from as _WasmF64ArrayBase;
-    final count = _setRangeFastPathCount(
-      start,
-      end,
-      length,
-      typedFrom.length,
-      skipCount,
-    );
-    _data.copy(
-      _offsetInElements + start,
-      typedFrom._data,
-      typedFrom._offsetInElements + skipCount,
-      count,
-    );
-    return true;
+    if (from case final _WasmF64ArrayBase typedFrom) {
+      final count = _setRangeFastPathCount(
+        start,
+        end,
+        length,
+        typedFrom.length,
+        skipCount,
+      );
+      _data.copy(
+        _offsetInElements + start,
+        typedFrom._data,
+        typedFrom._offsetInElements + skipCount,
+        count,
+      );
+      return true;
+    }
+    return false;
   }
 }
 

--- a/sdk/lib/_internal/wasm/lib/typed_data.dart
+++ b/sdk/lib/_internal/wasm/lib/typed_data.dart
@@ -2625,19 +2625,20 @@ abstract class WasmI8ArrayBase extends WasmTypedDataBase {
     int skipCount,
   ) {
     if (from is! WasmI8ArrayBase) return false;
+    final typedFrom = from as WasmI8ArrayBase;
     final count = _setRangeFastPathCount(
       start,
       end,
       length,
-      from.length,
+      typedFrom.length,
       skipCount,
       skipCountName: "skipCount",
     );
     if (count == 0) return true;
     _data.copy(
       _offsetInElements + start,
-      from._data,
-      from._offsetInElements + skipCount,
+      typedFrom._data,
+      typedFrom._offsetInElements + skipCount,
       count,
     );
     return true;
@@ -2669,19 +2670,20 @@ abstract class WasmI16ArrayBase extends WasmTypedDataBase {
     int skipCount,
   ) {
     if (from is! WasmI16ArrayBase) return false;
+    final typedFrom = from as WasmI16ArrayBase;
     final count = _setRangeFastPathCount(
       start,
       end,
       length,
-      from.length,
+      typedFrom.length,
       skipCount,
       skipCountName: "skipCount",
     );
     if (count == 0) return true;
     _data.copy(
       _offsetInElements + start,
-      from._data,
-      from._offsetInElements + skipCount,
+      typedFrom._data,
+      typedFrom._offsetInElements + skipCount,
       count,
     );
     return true;
@@ -2713,19 +2715,20 @@ abstract class _WasmI32ArrayBase extends WasmTypedDataBase {
     int skipCount,
   ) {
     if (from is! _WasmI32ArrayBase) return false;
+    final typedFrom = from as _WasmI32ArrayBase;
     final count = _setRangeFastPathCount(
       start,
       end,
       length,
-      from.length,
+      typedFrom.length,
       skipCount,
       skipCountName: "skipCount",
     );
     if (count == 0) return true;
     _data.copy(
       _offsetInElements + start,
-      from._data,
-      from._offsetInElements + skipCount,
+      typedFrom._data,
+      typedFrom._offsetInElements + skipCount,
       count,
     );
     return true;
@@ -2757,19 +2760,20 @@ abstract class _WasmI64ArrayBase extends WasmTypedDataBase {
     int skipCount,
   ) {
     if (from is! _WasmI64ArrayBase) return false;
+    final typedFrom = from as _WasmI64ArrayBase;
     final count = _setRangeFastPathCount(
       start,
       end,
       length,
-      from.length,
+      typedFrom.length,
       skipCount,
       skipCountName: "skipCount",
     );
     if (count == 0) return true;
     _data.copy(
       _offsetInElements + start,
-      from._data,
-      from._offsetInElements + skipCount,
+      typedFrom._data,
+      typedFrom._offsetInElements + skipCount,
       count,
     );
     return true;
@@ -2801,18 +2805,19 @@ abstract class _WasmF32ArrayBase extends WasmTypedDataBase {
     int skipCount,
   ) {
     if (from is! _WasmF32ArrayBase) return false;
+    final typedFrom = from as _WasmF32ArrayBase;
     final count = _setRangeFastPathCount(
       start,
       end,
       length,
-      from.length,
+      typedFrom.length,
       skipCount,
     );
     if (count == 0) return true;
     _data.copy(
       _offsetInElements + start,
-      from._data,
-      from._offsetInElements + skipCount,
+      typedFrom._data,
+      typedFrom._offsetInElements + skipCount,
       count,
     );
     return true;
@@ -2844,18 +2849,19 @@ abstract class _WasmF64ArrayBase extends WasmTypedDataBase {
     int skipCount,
   ) {
     if (from is! _WasmF64ArrayBase) return false;
+    final typedFrom = from as _WasmF64ArrayBase;
     final count = _setRangeFastPathCount(
       start,
       end,
       length,
-      from.length,
+      typedFrom.length,
       skipCount,
     );
     if (count == 0) return true;
     _data.copy(
       _offsetInElements + start,
-      from._data,
-      from._offsetInElements + skipCount,
+      typedFrom._data,
+      typedFrom._offsetInElements + skipCount,
       count,
     );
     return true;

--- a/sdk/lib/_internal/wasm/lib/typed_data.dart
+++ b/sdk/lib/_internal/wasm/lib/typed_data.dart
@@ -2529,6 +2529,73 @@ mixin _UnmodifiableDoubleListMixin {
   }
 }
 
+@pragma('wasm:prefer-inline')
+int _setRangeFastPathCount(
+  int start,
+  int end,
+  int length,
+  int fromLength,
+  int skipCount, {
+  String? skipCountName,
+}) {
+  RangeErrorUtils.checkValidRange(start, end, length);
+  if (skipCountName == null) {
+    RangeErrorUtils.checkNotNegative(skipCount);
+  } else {
+    RangeErrorUtils.checkNotNegative(skipCount, skipCountName);
+  }
+  final count = end - start;
+  if ((fromLength - skipCount) < count) {
+    throw IterableElementError.tooFew();
+  }
+  return count;
+}
+
+mixin _SpecializedWasmIntSetRangeMixin<SpawnedType extends TypedDataList<int>>
+    on _TypedIntListMixin<SpawnedType> {
+  bool _trySetRangeFastPath(
+    int start,
+    int end,
+    Iterable<int> from,
+    int skipCount,
+  );
+
+  @override
+  void setRange(int start, int end, Iterable<int> from, [int skipCount = 0]) {
+    if (this is! _UnmodifiableIntListMixin &&
+        _trySetRangeFastPath(start, end, from, skipCount)) {
+      return;
+    }
+    super.setRange(start, end, from, skipCount);
+  }
+}
+
+mixin _SpecializedWasmDoubleSetRangeMixin<
+  SpawnedType extends TypedDataList<double>
+>
+    on _TypedDoubleListMixin<SpawnedType> {
+  bool _trySetRangeFastPath(
+    int start,
+    int end,
+    Iterable<double> from,
+    int skipCount,
+  );
+
+  @override
+  void setRange(
+    int start,
+    int end,
+    Iterable<double> from, [
+    int skipCount = 0,
+  ]) {
+    if (this is! _UnmodifiableDoubleListMixin &&
+        _trySetRangeFastPath(start, end, from, skipCount)) {
+      return;
+    }
+    super.setRange(start, end, from, skipCount);
+  }
+}
+
 //
 // Fast lists
 //
@@ -2558,12 +2625,14 @@ abstract class WasmI8ArrayBase extends WasmTypedDataBase {
     int skipCount,
   ) {
     if (from is! WasmI8ArrayBase) return false;
-    RangeErrorUtils.checkValidRange(start, end, length);
-    RangeErrorUtils.checkNotNegative(skipCount, "skipCount");
-    final count = end - start;
-    if ((from.length - skipCount) < count) {
-      throw IterableElementError.tooFew();
-    }
+    final count = _setRangeFastPathCount(
+      start,
+      end,
+      length,
+      from.length,
+      skipCount,
+      skipCountName: "skipCount",
+    );
     if (count == 0) return true;
     _data.copy(
       _offsetInElements + start,
@@ -2600,12 +2669,14 @@ abstract class WasmI16ArrayBase extends WasmTypedDataBase {
     int skipCount,
   ) {
     if (from is! WasmI16ArrayBase) return false;
-    RangeErrorUtils.checkValidRange(start, end, length);
-    RangeErrorUtils.checkNotNegative(skipCount, "skipCount");
-    final count = end - start;
-    if ((from.length - skipCount) < count) {
-      throw IterableElementError.tooFew();
-    }
+    final count = _setRangeFastPathCount(
+      start,
+      end,
+      length,
+      from.length,
+      skipCount,
+      skipCountName: "skipCount",
+    );
     if (count == 0) return true;
     _data.copy(
       _offsetInElements + start,
@@ -2642,12 +2713,14 @@ abstract class _WasmI32ArrayBase extends WasmTypedDataBase {
     int skipCount,
   ) {
     if (from is! _WasmI32ArrayBase) return false;
-    RangeErrorUtils.checkValidRange(start, end, length);
-    RangeErrorUtils.checkNotNegative(skipCount, "skipCount");
-    final count = end - start;
-    if ((from.length - skipCount) < count) {
-      throw IterableElementError.tooFew();
-    }
+    final count = _setRangeFastPathCount(
+      start,
+      end,
+      length,
+      from.length,
+      skipCount,
+      skipCountName: "skipCount",
+    );
     if (count == 0) return true;
     _data.copy(
       _offsetInElements + start,
@@ -2684,12 +2757,14 @@ abstract class _WasmI64ArrayBase extends WasmTypedDataBase {
     int skipCount,
   ) {
     if (from is! _WasmI64ArrayBase) return false;
-    RangeErrorUtils.checkValidRange(start, end, length);
-    RangeErrorUtils.checkNotNegative(skipCount, "skipCount");
-    final count = end - start;
-    if ((from.length - skipCount) < count) {
-      throw IterableElementError.tooFew();
-    }
+    final count = _setRangeFastPathCount(
+      start,
+      end,
+      length,
+      from.length,
+      skipCount,
+      skipCountName: "skipCount",
+    );
     if (count == 0) return true;
     _data.copy(
       _offsetInElements + start,
@@ -2726,12 +2801,13 @@ abstract class _WasmF32ArrayBase extends WasmTypedDataBase {
     int skipCount,
   ) {
     if (from is! _WasmF32ArrayBase) return false;
-    RangeErrorUtils.checkValidRange(start, end, length);
-    RangeErrorUtils.checkNotNegative(skipCount);
-    final count = end - start;
-    if ((from.length - skipCount) < count) {
-      throw IterableElementError.tooFew();
-    }
+    final count = _setRangeFastPathCount(
+      start,
+      end,
+      length,
+      from.length,
+      skipCount,
+    );
     if (count == 0) return true;
     _data.copy(
       _offsetInElements + start,
@@ -2768,12 +2844,13 @@ abstract class _WasmF64ArrayBase extends WasmTypedDataBase {
     int skipCount,
   ) {
     if (from is! _WasmF64ArrayBase) return false;
-    RangeErrorUtils.checkValidRange(start, end, length);
-    RangeErrorUtils.checkNotNegative(skipCount);
-    final count = end - start;
-    if ((from.length - skipCount) < count) {
-      throw IterableElementError.tooFew();
-    }
+    final count = _setRangeFastPathCount(
+      start,
+      end,
+      length,
+      from.length,
+      skipCount,
+    );
     if (count == 0) return true;
     _data.copy(
       _offsetInElements + start,
@@ -2837,6 +2914,7 @@ class I8List extends WasmI8ArrayBase
     with
         _IntListMixin,
         _TypedIntListMixin<I8List>,
+        _SpecializedWasmIntSetRangeMixin<I8List>,
         _TypedListCommonOperationsMixin
     implements Int8List {
   I8List(int length) : super(length);
@@ -2860,15 +2938,6 @@ class I8List extends WasmI8ArrayBase
   I8List _createList(int length) => I8List(length);
 
   @override
-  void setRange(int start, int end, Iterable<int> from, [int skipCount = 0]) {
-    if (this is! _UnmodifiableIntListMixin &&
-        _trySetRangeFastPath(start, end, from, skipCount)) {
-      return;
-    }
-    super.setRange(start, end, from, skipCount);
-  }
-
-  @override
   @pragma("wasm:prefer-inline")
   int operator [](int index) {
     IndexErrorUtils.checkIndexBCE(index, length);
@@ -2887,6 +2956,7 @@ class U8List extends WasmI8ArrayBase
     with
         _IntListMixin,
         _TypedIntListMixin<U8List>,
+        _SpecializedWasmIntSetRangeMixin<U8List>,
         _TypedListCommonOperationsMixin
     implements Uint8List {
   U8List(int length) : super(length);
@@ -2908,15 +2978,6 @@ class U8List extends WasmI8ArrayBase
 
   @override
   U8List _createList(int length) => U8List(length);
-
-  @override
-  void setRange(int start, int end, Iterable<int> from, [int skipCount = 0]) {
-    if (this is! _UnmodifiableIntListMixin &&
-        _trySetRangeFastPath(start, end, from, skipCount)) {
-      return;
-    }
-    super.setRange(start, end, from, skipCount);
-  }
 
   @override
   @pragma("wasm:prefer-inline")
@@ -2989,6 +3050,7 @@ class I16List extends WasmI16ArrayBase
     with
         _IntListMixin,
         _TypedIntListMixin<I16List>,
+        _SpecializedWasmIntSetRangeMixin<I16List>,
         _TypedListCommonOperationsMixin
     implements Int16List {
   I16List(int length) : super(length);
@@ -3012,15 +3074,6 @@ class I16List extends WasmI16ArrayBase
   I16List _createList(int length) => I16List(length);
 
   @override
-  void setRange(int start, int end, Iterable<int> from, [int skipCount = 0]) {
-    if (this is! _UnmodifiableIntListMixin &&
-        _trySetRangeFastPath(start, end, from, skipCount)) {
-      return;
-    }
-    super.setRange(start, end, from, skipCount);
-  }
-
-  @override
   @pragma("wasm:prefer-inline")
   int operator [](int index) {
     IndexErrorUtils.checkIndexBCE(index, length);
@@ -3039,6 +3092,7 @@ class U16List extends WasmI16ArrayBase
     with
         _IntListMixin,
         _TypedIntListMixin<U16List>,
+        _SpecializedWasmIntSetRangeMixin<U16List>,
         _TypedListCommonOperationsMixin
     implements Uint16List {
   U16List(int length) : super(length);
@@ -3060,15 +3114,6 @@ class U16List extends WasmI16ArrayBase
 
   @override
   U16List _createList(int length) => U16List(length);
-
-  @override
-  void setRange(int start, int end, Iterable<int> from, [int skipCount = 0]) {
-    if (this is! _UnmodifiableIntListMixin &&
-        _trySetRangeFastPath(start, end, from, skipCount)) {
-      return;
-    }
-    super.setRange(start, end, from, skipCount);
-  }
 
   @override
   @pragma("wasm:prefer-inline")
@@ -3099,6 +3144,7 @@ class I32List extends _WasmI32ArrayBase
     with
         _IntListMixin,
         _TypedIntListMixin<I32List>,
+        _SpecializedWasmIntSetRangeMixin<I32List>,
         _TypedListCommonOperationsMixin
     implements Int32List {
   I32List(int length) : super(length);
@@ -3122,15 +3168,6 @@ class I32List extends _WasmI32ArrayBase
   I32List _createList(int length) => I32List(length);
 
   @override
-  void setRange(int start, int end, Iterable<int> from, [int skipCount = 0]) {
-    if (this is! _UnmodifiableIntListMixin &&
-        _trySetRangeFastPath(start, end, from, skipCount)) {
-      return;
-    }
-    super.setRange(start, end, from, skipCount);
-  }
-
-  @override
   @pragma("wasm:prefer-inline")
   int operator [](int index) {
     IndexErrorUtils.checkIndexBCE(index, length);
@@ -3149,6 +3186,7 @@ class U32List extends _WasmI32ArrayBase
     with
         _IntListMixin,
         _TypedIntListMixin<U32List>,
+        _SpecializedWasmIntSetRangeMixin<U32List>,
         _TypedListCommonOperationsMixin
     implements Uint32List {
   U32List(int length) : super(length);
@@ -3172,15 +3210,6 @@ class U32List extends _WasmI32ArrayBase
   U32List _createList(int length) => U32List(length);
 
   @override
-  void setRange(int start, int end, Iterable<int> from, [int skipCount = 0]) {
-    if (this is! _UnmodifiableIntListMixin &&
-        _trySetRangeFastPath(start, end, from, skipCount)) {
-      return;
-    }
-    super.setRange(start, end, from, skipCount);
-  }
-
-  @override
   @pragma("wasm:prefer-inline")
   int operator [](int index) {
     IndexErrorUtils.checkIndexBCE(index, length);
@@ -3199,6 +3228,7 @@ class I64List extends _WasmI64ArrayBase
     with
         _IntListMixin,
         _TypedIntListMixin<I64List>,
+        _SpecializedWasmIntSetRangeMixin<I64List>,
         _TypedListCommonOperationsMixin
     implements Int64List {
   I64List(int length) : super(length);
@@ -3222,15 +3252,6 @@ class I64List extends _WasmI64ArrayBase
   I64List _createList(int length) => I64List(length);
 
   @override
-  void setRange(int start, int end, Iterable<int> from, [int skipCount = 0]) {
-    if (this is! _UnmodifiableIntListMixin &&
-        _trySetRangeFastPath(start, end, from, skipCount)) {
-      return;
-    }
-    super.setRange(start, end, from, skipCount);
-  }
-
-  @override
   @pragma("wasm:prefer-inline")
   int operator [](int index) {
     IndexErrorUtils.checkIndexBCE(index, length);
@@ -3249,6 +3270,7 @@ class U64List extends _WasmI64ArrayBase
     with
         _IntListMixin,
         _TypedIntListMixin<U64List>,
+        _SpecializedWasmIntSetRangeMixin<U64List>,
         _TypedListCommonOperationsMixin
     implements Uint64List {
   U64List(int length) : super(length);
@@ -3272,15 +3294,6 @@ class U64List extends _WasmI64ArrayBase
   U64List _createList(int length) => U64List(length);
 
   @override
-  void setRange(int start, int end, Iterable<int> from, [int skipCount = 0]) {
-    if (this is! _UnmodifiableIntListMixin &&
-        _trySetRangeFastPath(start, end, from, skipCount)) {
-      return;
-    }
-    super.setRange(start, end, from, skipCount);
-  }
-
-  @override
   @pragma("wasm:prefer-inline")
   int operator [](int index) {
     IndexErrorUtils.checkIndexBCE(index, length);
@@ -3299,6 +3312,7 @@ class F32List extends _WasmF32ArrayBase
     with
         _DoubleListMixin,
         _TypedDoubleListMixin<Float32List>,
+        _SpecializedWasmDoubleSetRangeMixin<Float32List>,
         _TypedListCommonOperationsMixin
     implements Float32List {
   F32List(int length) : super(length);
@@ -3322,20 +3336,6 @@ class F32List extends _WasmF32ArrayBase
   F32List _createList(int length) => F32List(length);
 
   @override
-  void setRange(
-    int start,
-    int end,
-    Iterable<double> from, [
-    int skipCount = 0,
-  ]) {
-    if (this is! _UnmodifiableDoubleListMixin &&
-        _trySetRangeFastPath(start, end, from, skipCount)) {
-      return;
-    }
-    super.setRange(start, end, from, skipCount);
-  }
-
-  @override
   @pragma("wasm:prefer-inline")
   double operator [](int index) {
     IndexErrorUtils.checkIndexBCE(index, length);
@@ -3354,6 +3354,7 @@ class F64List extends _WasmF64ArrayBase
     with
         _DoubleListMixin,
         _TypedDoubleListMixin<Float64List>,
+        _SpecializedWasmDoubleSetRangeMixin<Float64List>,
         _TypedListCommonOperationsMixin
     implements Float64List {
   F64List(int length) : super(length);
@@ -3375,20 +3376,6 @@ class F64List extends _WasmF64ArrayBase
 
   @override
   F64List _createList(int length) => F64List(length);
-
-  @override
-  void setRange(
-    int start,
-    int end,
-    Iterable<double> from, [
-    int skipCount = 0,
-  ]) {
-    if (this is! _UnmodifiableDoubleListMixin &&
-        _trySetRangeFastPath(start, end, from, skipCount)) {
-      return;
-    }
-    super.setRange(start, end, from, skipCount);
-  }
 
   @override
   @pragma("wasm:prefer-inline")

--- a/sdk/lib/_internal/wasm/lib/typed_data.dart
+++ b/sdk/lib/_internal/wasm/lib/typed_data.dart
@@ -1993,9 +1993,6 @@ mixin _TypedIntListMixin<SpawnedType extends TypedDataList<int>>
       final TypedData destTypedData = this;
       final TypedData fromTypedData = unsafeCast<TypedData>(from);
 
-      final ByteBuffer destBuffer = destTypedData.buffer;
-      final ByteBuffer fromBuffer = fromTypedData.buffer;
-
       final destDartElementSizeInBytes = destTypedData.elementSizeInBytes;
       final fromDartElementSizeInBytes = fromTypedData.elementSizeInBytes;
 
@@ -2018,6 +2015,78 @@ mixin _TypedIntListMixin<SpawnedType extends TypedDataList<int>>
       // receiver is an int array and if the buffer is a F32/F64 buffer that
       // means casting needs to happen when reading.
       if (destDartElementSizeInBytes == fromDartElementSizeInBytes) {
+        if (destDartElementSizeInBytes == 1 &&
+            destTypedData is WasmI8ArrayBase &&
+            fromTypedData is WasmI8ArrayBase) {
+          if (destTypedData is! U8ClampedList &&
+              destTypedData is! _SlowU8ClampedList) {
+            final WasmI8ArrayBase destI8 = unsafeCast<WasmI8ArrayBase>(
+              destTypedData,
+            );
+            final WasmI8ArrayBase fromI8 = unsafeCast<WasmI8ArrayBase>(
+              fromTypedData,
+            );
+            destI8.data.copy(
+              destI8.offsetInElements + start,
+              fromI8.data,
+              fromI8.offsetInElements + skipCount,
+              count,
+            );
+            return;
+          }
+        } else if (destDartElementSizeInBytes == 2 &&
+            destTypedData is WasmI16ArrayBase &&
+            fromTypedData is WasmI16ArrayBase) {
+          final WasmI16ArrayBase destI16 = unsafeCast<WasmI16ArrayBase>(
+            destTypedData,
+          );
+          final WasmI16ArrayBase fromI16 = unsafeCast<WasmI16ArrayBase>(
+            fromTypedData,
+          );
+          destI16.data.copy(
+            destI16.offsetInElements + start,
+            fromI16.data,
+            fromI16.offsetInElements + skipCount,
+            count,
+          );
+          return;
+        } else if (destDartElementSizeInBytes == 4 &&
+            destTypedData is _WasmI32ArrayBase &&
+            fromTypedData is _WasmI32ArrayBase) {
+          final _WasmI32ArrayBase destI32 = unsafeCast<_WasmI32ArrayBase>(
+            destTypedData,
+          );
+          final _WasmI32ArrayBase fromI32 = unsafeCast<_WasmI32ArrayBase>(
+            fromTypedData,
+          );
+          destI32.data.copy(
+            destI32.offsetInElements + start,
+            fromI32.data,
+            fromI32.offsetInElements + skipCount,
+            count,
+          );
+          return;
+        } else if (destDartElementSizeInBytes == 8 &&
+            destTypedData is _WasmI64ArrayBase &&
+            fromTypedData is _WasmI64ArrayBase) {
+          final _WasmI64ArrayBase destI64 = unsafeCast<_WasmI64ArrayBase>(
+            destTypedData,
+          );
+          final _WasmI64ArrayBase fromI64 = unsafeCast<_WasmI64ArrayBase>(
+            fromTypedData,
+          );
+          destI64.data.copy(
+            destI64.offsetInElements + start,
+            fromI64.data,
+            fromI64.offsetInElements + skipCount,
+            count,
+          );
+          return;
+        }
+
+        final ByteBuffer destBuffer = destTypedData.buffer;
+        final ByteBuffer fromBuffer = fromTypedData.buffer;
+
         if (destDartElementSizeInBytes == 1 &&
             destBuffer is _I8ByteBuffer &&
             fromBuffer is _I8ByteBuffer) {
@@ -2069,6 +2138,9 @@ mixin _TypedIntListMixin<SpawnedType extends TypedDataList<int>>
           }
         }
       }
+
+      final ByteBuffer destBuffer = destTypedData.buffer;
+      final ByteBuffer fromBuffer = fromTypedData.buffer;
 
       // TODO(#52971): Use unchecked list access functions below.
       if (destBuffer == fromBuffer) {
@@ -2435,9 +2507,6 @@ mixin _TypedDoubleListMixin<SpawnedType extends TypedDataList<double>>
       final TypedData destTypedData = this;
       final TypedData fromTypedData = unsafeCast<TypedData>(from);
 
-      final ByteBuffer destBuffer = destTypedData.buffer;
-      final ByteBuffer fromBuffer = fromTypedData.buffer;
-
       final destDartElementSizeInBytes = destTypedData.elementSizeInBytes;
       final fromDartElementSizeInBytes = fromTypedData.elementSizeInBytes;
 
@@ -2448,6 +2517,43 @@ mixin _TypedDoubleListMixin<SpawnedType extends TypedDataList<double>>
             (skipCount * fromDartElementSizeInBytes);
         final destBufferByteOffset =
             destTypedData.offsetInBytes + (start * destDartElementSizeInBytes);
+        if (destDartElementSizeInBytes == 4 &&
+            destTypedData is _WasmF32ArrayBase &&
+            fromTypedData is _WasmF32ArrayBase) {
+          final _WasmF32ArrayBase destF32 = unsafeCast<_WasmF32ArrayBase>(
+            destTypedData,
+          );
+          final _WasmF32ArrayBase fromF32 = unsafeCast<_WasmF32ArrayBase>(
+            fromTypedData,
+          );
+          destF32.data.copy(
+            destF32.offsetInElements + start,
+            fromF32.data,
+            fromF32.offsetInElements + skipCount,
+            count,
+          );
+          return;
+        } else if (destDartElementSizeInBytes == 8 &&
+            destTypedData is _WasmF64ArrayBase &&
+            fromTypedData is _WasmF64ArrayBase) {
+          final _WasmF64ArrayBase destF64 = unsafeCast<_WasmF64ArrayBase>(
+            destTypedData,
+          );
+          final _WasmF64ArrayBase fromF64 = unsafeCast<_WasmF64ArrayBase>(
+            fromTypedData,
+          );
+          destF64.data.copy(
+            destF64.offsetInElements + start,
+            fromF64.data,
+            fromF64.offsetInElements + skipCount,
+            count,
+          );
+          return;
+        }
+
+        final ByteBuffer destBuffer = destTypedData.buffer;
+        final ByteBuffer fromBuffer = fromTypedData.buffer;
+
         if (destDartElementSizeInBytes == 4 &&
             destBuffer is _F32ByteBuffer &&
             fromBuffer is _F32ByteBuffer) {
@@ -2474,6 +2580,9 @@ mixin _TypedDoubleListMixin<SpawnedType extends TypedDataList<double>>
           }
         }
       }
+
+      final ByteBuffer destBuffer = destTypedData.buffer;
+      final ByteBuffer fromBuffer = fromTypedData.buffer;
 
       if (destBuffer == fromBuffer) {
         final fromAsList = from as List<double>;
@@ -2661,6 +2770,14 @@ extension WasmI16ArrayBaseExt on WasmI16ArrayBase {
 extension WasmI32ArrayBaseExt on _WasmI32ArrayBase {
   @pragma('wasm:prefer-inline')
   WasmArray<WasmI32> get data => _data;
+
+  @pragma('wasm:prefer-inline')
+  int get offsetInElements => _offsetInElements;
+}
+
+extension WasmI64ArrayBaseExt on _WasmI64ArrayBase {
+  @pragma('wasm:prefer-inline')
+  WasmArray<WasmI64> get data => _data;
 
   @pragma('wasm:prefer-inline')
   int get offsetInElements => _offsetInElements;

--- a/tests/web/wasm/typed_data_setrange_test.dart
+++ b/tests/web/wasm/typed_data_setrange_test.dart
@@ -38,6 +38,21 @@ main() {
   verifyDoubleArray(Float64List(size)..setRange(start, end, jsF64, offset));
 
   verifyIntViewToView(
+    Int8List.new,
+    (buffer, byteOffset, length) => Int8List.view(buffer, byteOffset, length),
+    1,
+  );
+  verifyIntViewToView(
+    Int16List.new,
+    (buffer, byteOffset, length) => Int16List.view(buffer, byteOffset, length),
+    2,
+  );
+  verifyIntViewToView(
+    Int32List.new,
+    (buffer, byteOffset, length) => Int32List.view(buffer, byteOffset, length),
+    4,
+  );
+  verifyIntViewToView(
     Uint8List.new,
     (buffer, byteOffset, length) => Uint8List.view(buffer, byteOffset, length),
     1,
@@ -69,6 +84,11 @@ main() {
         Float64List.view(buffer, byteOffset, length),
     8,
   );
+
+  verifyUnmodifiableIntSetRange();
+  verifyUnmodifiableDoubleSetRange();
+  verifyOverlappingIntSelfCopy();
+  verifyOverlappingDoubleSelfCopy();
 }
 
 void initIntArray(List<int> list) {
@@ -138,4 +158,62 @@ void verifyDoubleViewToView(
   initDoubleArray(srcView);
   destView.setRange(start, end, srcView, offset);
   verifyDoubleArray(destView);
+}
+
+void verifyUnmodifiableIntSetRange() {
+  final src = Int16List(size + offset + 1);
+  initIntArray(src);
+  final dest = Int16List(size).asUnmodifiableView();
+
+  bool didThrow = false;
+  try {
+    dest.setRange(start, end, src, offset);
+  } on UnsupportedError {
+    didThrow = true;
+  }
+  Expect.isTrue(didThrow);
+}
+
+void verifyUnmodifiableDoubleSetRange() {
+  final src = Float32List(size + offset + 1);
+  initDoubleArray(src);
+  final dest = Float32List(size).asUnmodifiableView();
+
+  bool didThrow = false;
+  try {
+    dest.setRange(start, end, src, offset);
+  } on UnsupportedError {
+    didThrow = true;
+  }
+  Expect.isTrue(didThrow);
+}
+
+void verifyOverlappingIntSelfCopy() {
+  final values = Int16List(size + offset + 1);
+  initIntArray(values);
+  final expected = values.toList(growable: false);
+  for (int i = 0; i < end - start; ++i) {
+    expected[start + i] = values[offset + i];
+  }
+
+  values.setRange(start, end, values, offset);
+
+  for (int i = 0; i < values.length; ++i) {
+    Expect.equals(expected[i], values[i]);
+  }
+}
+
+void verifyOverlappingDoubleSelfCopy() {
+  final values = Float32List(size + offset + 1);
+  initDoubleArray(values);
+  final expected = values.toList(growable: false);
+  for (int i = 0; i < end - start; ++i) {
+    expected[start + i] = values[offset + i];
+  }
+
+  values.setRange(start, end, values, offset);
+
+  for (int i = 0; i < values.length; ++i) {
+    Expect.equals(expected[i], values[i]);
+  }
 }

--- a/tests/web/wasm/typed_data_setrange_test.dart
+++ b/tests/web/wasm/typed_data_setrange_test.dart
@@ -36,6 +36,25 @@ main() {
   verifyIntArray(Uint32List(size)..setRange(start, end, jsInt32, offset), 4);
   verifyDoubleArray(Float32List(size)..setRange(start, end, jsF32, offset));
   verifyDoubleArray(Float64List(size)..setRange(start, end, jsF64, offset));
+
+  verifyIntViewToView(
+    (buffer, byteOffset, length) => Uint16List.view(buffer, byteOffset, length),
+    2,
+  );
+  verifyIntViewToView(
+    (buffer, byteOffset, length) => Uint32List.view(buffer, byteOffset, length),
+    4,
+  );
+  verifyDoubleViewToView(
+    (buffer, byteOffset, length) =>
+        Float32List.view(buffer, byteOffset, length),
+    4,
+  );
+  verifyDoubleViewToView(
+    (buffer, byteOffset, length) =>
+        Float64List.view(buffer, byteOffset, length),
+    8,
+  );
 }
 
 void initIntArray(List<int> list) {
@@ -58,6 +77,20 @@ void verifyIntArray(List<int> list, int elementSize) {
   }
 }
 
+void verifyIntViewToView(
+  List<int> Function(ByteBuffer, int, int) makeView,
+  int elementSize,
+) {
+  final srcBacking = Uint8List((size + offset + 1) * elementSize);
+  final destBacking = Uint8List((size + 1) * elementSize);
+  final srcView = makeView(srcBacking.buffer, elementSize, size);
+  final destView = makeView(destBacking.buffer, elementSize, size);
+
+  initIntArray(srcView);
+  destView.setRange(start, end, srcView, offset);
+  verifyIntArray(destView, elementSize);
+}
+
 void initDoubleArray(List<double> list) {
   for (int i = 0; i < list.length; ++i) {
     list[i] = 1.1314 * i;
@@ -75,4 +108,18 @@ void verifyDoubleArray(List<double> list) {
       Expect.equals(0.0, value);
     }
   }
+}
+
+void verifyDoubleViewToView(
+  List<double> Function(ByteBuffer, int, int) makeView,
+  int elementSize,
+) {
+  final srcBacking = Uint8List((size + offset + 1) * elementSize);
+  final destBacking = Uint8List((size + 1) * elementSize);
+  final srcView = makeView(srcBacking.buffer, elementSize, size);
+  final destView = makeView(destBacking.buffer, elementSize, size);
+
+  initDoubleArray(srcView);
+  destView.setRange(start, end, srcView, offset);
+  verifyDoubleArray(destView);
 }

--- a/tests/web/wasm/typed_data_setrange_test.dart
+++ b/tests/web/wasm/typed_data_setrange_test.dart
@@ -38,19 +38,33 @@ main() {
   verifyDoubleArray(Float64List(size)..setRange(start, end, jsF64, offset));
 
   verifyIntViewToView(
+    Uint8List.new,
+    (buffer, byteOffset, length) => Uint8List.view(buffer, byteOffset, length),
+    1,
+  );
+  verifyIntViewToView(
+    Uint16List.new,
     (buffer, byteOffset, length) => Uint16List.view(buffer, byteOffset, length),
     2,
   );
   verifyIntViewToView(
+    Uint32List.new,
     (buffer, byteOffset, length) => Uint32List.view(buffer, byteOffset, length),
     4,
   );
+  verifyIntViewToView(
+    Int64List.new,
+    (buffer, byteOffset, length) => Int64List.view(buffer, byteOffset, length),
+    8,
+  );
   verifyDoubleViewToView(
+    Float32List.new,
     (buffer, byteOffset, length) =>
         Float32List.view(buffer, byteOffset, length),
     4,
   );
   verifyDoubleViewToView(
+    Float64List.new,
     (buffer, byteOffset, length) =>
         Float64List.view(buffer, byteOffset, length),
     8,
@@ -78,13 +92,14 @@ void verifyIntArray(List<int> list, int elementSize) {
 }
 
 void verifyIntViewToView(
+  TypedData Function(int) makeStorage,
   List<int> Function(ByteBuffer, int, int) makeView,
   int elementSize,
 ) {
-  final srcBacking = Uint8List((size + offset + 1) * elementSize);
-  final destBacking = Uint8List((size + 1) * elementSize);
-  final srcView = makeView(srcBacking.buffer, elementSize, size);
-  final destView = makeView(destBacking.buffer, elementSize, size);
+  final srcStorage = makeStorage(size + offset + 1);
+  final destStorage = makeStorage(size + 1);
+  final srcView = makeView(srcStorage.buffer, elementSize, size);
+  final destView = makeView(destStorage.buffer, elementSize, size);
 
   initIntArray(srcView);
   destView.setRange(start, end, srcView, offset);
@@ -111,13 +126,14 @@ void verifyDoubleArray(List<double> list) {
 }
 
 void verifyDoubleViewToView(
+  TypedData Function(int) makeStorage,
   List<double> Function(ByteBuffer, int, int) makeView,
   int elementSize,
 ) {
-  final srcBacking = Uint8List((size + offset + 1) * elementSize);
-  final destBacking = Uint8List((size + 1) * elementSize);
-  final srcView = makeView(srcBacking.buffer, elementSize, size);
-  final destView = makeView(destBacking.buffer, elementSize, size);
+  final srcStorage = makeStorage(size + offset + 1);
+  final destStorage = makeStorage(size + 1);
+  final srcView = makeView(srcStorage.buffer, elementSize, size);
+  final destView = makeView(destStorage.buffer, elementSize, size);
 
   initDoubleArray(srcView);
   destView.setRange(start, end, srcView, offset);


### PR DESCRIPTION
Fixes #56663.

## What

This changes the same-type Wasm typed array `setRange` fast path to copy
directly through the underlying Wasm array instead of going through `buffer`
first.

That avoids materializing `ByteBuffer` wrappers for the common same-type cases:

- `I8`
- `I16`
- `I32`
- `I64`
- `F32`
- `F64`

It also adds wasm regression coverage for same-type view-to-view `setRange`.

## Why

The issue here is that the current fast path still ends up doing extra wrapper
work even when the source and destination already have matching Wasm typed
array representations.

This keeps the existing `setRange` behavior, but removes that redundant work
from the Wasm fast path.

After rebuilding `dart2wasm_benchmark`, a small local benchmark with repeated
same-type view-to-view copies showed clear improvement for
`Uint16`/`Uint32`/`Float32`/`Float64`.

## Tests

- `python3 tools/test.py -m release -c dart2wasm -r d8 -j4 -p compact tests/web/wasm/typed_data_setrange_test`
- `python3 tools/test.py -m release -c dart2wasm -r d8 -j4 -p compact tests/lib/typed_data/setRange_`
- `python3 tools/test.py -m release -c dart2wasm -r d8 -j4 -p compact tests/lib/typed_data`

I also ran `tests/web/wasm` more broadly. The unrelated failures there
reproduced the same way with and without this patch in the local environment.
