### PR TITLE
[vm] Remove unused assert.h, add direct stdint.h includes in runtime/include/

### DIFF
--- a/runtime/include/dart_api.h
+++ b/runtime/include/dart_api.h
@@ -21,7 +21,6 @@
 #define __STDC_FORMAT_MACROS
 #endif
 
-#include <assert.h>
 #include <inttypes.h>
 #include <stdbool.h>
 

--- a/runtime/include/dart_api_dl.h
+++ b/runtime/include/dart_api_dl.h
@@ -7,6 +7,8 @@
 #ifndef RUNTIME_INCLUDE_DART_API_DL_H_
 #define RUNTIME_INCLUDE_DART_API_DL_H_
 
+#include <stdint.h>
+
 #include "dart_api.h"        /* NOLINT */
 #include "dart_native_api.h" /* NOLINT */
 

--- a/runtime/include/dart_native_api.h
+++ b/runtime/include/dart_native_api.h
@@ -7,6 +7,8 @@
 #ifndef RUNTIME_INCLUDE_DART_NATIVE_API_H_
 #define RUNTIME_INCLUDE_DART_NATIVE_API_H_
 
+#include <stdint.h>
+
 #include "dart_api.h" /* NOLINT */
 
 /*

--- a/runtime/include/dart_tools_api.h
+++ b/runtime/include/dart_tools_api.h
@@ -5,6 +5,8 @@
 #ifndef RUNTIME_INCLUDE_DART_TOOLS_API_H_
 #define RUNTIME_INCLUDE_DART_TOOLS_API_H_
 
+#include <stdint.h>
+
 #include "dart_api.h" /* NOLINT */
 
 /** \mainpage Dart Tools Embedding API Reference


### PR DESCRIPTION
G'day @liamappelbe! Tiny include hygiene nit as discussed in #63095.

- Removes unused `#include <assert.h>` from `dart_api.h`
- Adds explicit `#include <stdint.h>` to `dart_native_api.h`, `dart_tools_api.h`, and `dart_api_dl.h`

Bug: https://github.com/dart-lang/sdk/issues/63095

---

- [x] I've reviewed the contributor guide and applied the relevant portions to this PR.