### PR TITLE
[vm] Enable misc-include-cleaner in runtime/.clang-tidy

### DIFF
--- a/runtime/.clang-tidy
+++ b/runtime/.clang-tidy
@@ -1,2 +1,2 @@
-Checks: -*,readability-implicit-bool-conversion,bugprone-argument-comment
+Checks: -*,readability-implicit-bool-conversion,bugprone-argument-comment,misc-include-cleaner
 ExcludeHeaderFilterRegex: "third_party.boringssl.src.include.openssl.err\\.h" # breaks readability-implicit-bool-conversion


### PR DESCRIPTION
G'day @liamappelbe! Small follow-up as discussed in #63096.

Adds `misc-include-cleaner` to the runtime `.clang-tidy` checks.

Bug: https://github.com/dart-lang/sdk/issues/63096

---

- [x] I've reviewed the contributor guide and applied the relevant portions to this PR.