### PR TITLE
Fix private named parameters example in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,8 @@ parameter, you had to write an explicit initializer list:
 class Point {
   final int _x, _y;
   Point({required int x, required int y})
-    : x = _x,
-      y = _y;
+    : _x = x,
+      _y = y;
 }
 ```
 


### PR DESCRIPTION
This PR fixes the Point initializer list in the Private named parameters section of sdk/CHANGELOG.md so the example assigns constructor parameters into the private fields (_x = x, _y = y) instead of the reversed, invalid form.

issue #62719 
---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
