### PR TITLE
clarify ProcessStartMode.normal behavior

### DIFF
--- a/sdk/lib/io/process.dart
+++ b/sdk/lib/io/process.dart
@@ -131,6 +131,12 @@ abstract final class ProcessInfo {
 /// Modes for running a new process.
 final class ProcessStartMode {
   /// Normal child process.
+  ///
+  /// Default for the `mode` parameter of [Process.start]. The child process
+  /// has stdin, stdout, and stderr connected to the parent process using pipes
+  /// and accessible through the [Process] object returned by that method.
+  /// See [Process.start] for how the parent and child interact while the child
+  /// is running.
   static const normal = const ProcessStartMode._internal(0);
 
   /// Stdio handles are inherited by the child process.


### PR DESCRIPTION
This PR updates the dartdoc for ProcessStartMode.normal to clarify that it’s the default for Process.start, connects the child’s stdin, stdout, and stderr to the parent via pipes, and refers to Process.start for interaction details.

issue #61304

---

- [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
