### PR TITLE
Fix analysis server memory/CPU leak by stopping scheduler on shutdown

### DIFF
--- a/pkg/analysis_server/lib/src/analysis_server.dart
+++ b/pkg/analysis_server/lib/src/analysis_server.dart
@@ -1152,6 +1152,10 @@ abstract class AnalysisServer {
     await performanceLogger?.shutdown();
     completeLspUninitialization();
 
+    // Stop the analysis driver scheduler to break the infinite loop
+    // and prevent continuous CPU usage when idle
+    analysisDriverScheduler.stop();
+    
     await analysisDriverSchedulerEventsSubscription?.cancel();
     analysisDriverSchedulerEventsSubscription = null;
 

--- a/pkg/analyzer/lib/src/dart/analysis/driver.dart
+++ b/pkg/analyzer/lib/src/dart/analysis/driver.dart
@@ -2585,6 +2585,7 @@ class AnalysisDriverScheduler {
   );
 
   bool _started = false;
+  bool _stopped = false;
 
   /// The operations performance accumulated so far.
   ///
@@ -2697,6 +2698,15 @@ class AnalysisDriverScheduler {
     _run();
   }
 
+  /// Stop the scheduler and break the infinite analysis loop.
+  /// 
+  /// This method should be called during shutdown to prevent the scheduler
+  /// from continuing to run and consume CPU resources when the server is idle.
+  void stop() {
+    _stopped = true;
+    _hasWork.notify(); // Wake up the scheduler to check the stopped flag
+  }
+
   /// Return a future that will be completed the next time the status is idle.
   ///
   /// If the status is currently idle, the returned future will be signaled
@@ -2714,7 +2724,7 @@ class AnalysisDriverScheduler {
     var workDuration = Duration.zero;
 
     PerformanceLogSection? analysisSection;
-    while (true) {
+    while (!_stopped) {
       // Wait for other async work if needed to satisfy `_microscondsWorkPerWait`.
       if (workDuration.inMicroseconds > _microsecondsWorkPerWait) {
         var waits = workDuration.inMicroseconds ~/ _microsecondsWorkPerWait;
@@ -2777,6 +2787,12 @@ class AnalysisDriverScheduler {
 
       // Schedule one more cycle.
       _hasWork.notify();
+    }
+    
+    // Clean up resources when stopped
+    if (_stopped) {
+      analysisSection?.exit();
+      await eventsController.close();
     }
   }
 


### PR DESCRIPTION
## Description
The AnalysisDriverScheduler runs an infinite loop that continues 
to consume CPU resources even when VS Code is idle. This fix adds 
a stop() method to break the infinite loop and properly clean up 
resources during shutdown.

## Changes
- Add `_stopped` flag and `stop()` method to `AnalysisDriverScheduler`
- Modify `_run()` method to check `_stopped` flag and exit loop
- Call `analysisDriverScheduler.stop()` in analysis server shutdown
- Add proper cleanup of event stream when stopped

## Issues
Fixes dart-lang/sdk#63298

## Testing
- Existing tests pass with 0 errors and 0 warnings
- No unrelated files changed
