### PR TITLE
missing MSG_CMSG_CLOEXEC flag in ReceiveMessage

### DIFF
--- a/runtime/bin/socket_base_posix.cc
+++ b/runtime/bin/socket_base_posix.cc
@@ -127,7 +127,7 @@ intptr_t SocketBase::ReceiveMessage(intptr_t fd,
   int flags = 0;
 #ifdef MSG_CMSG_CLOEXEC
   // MSG_CMSG_CLOEXEC is not supported on macOS.
-  flags &= MSG_CMSG_CLOEXEC;
+  flags |= MSG_CMSG_CLOEXEC;
 #endif
   ssize_t read_bytes = TEMP_FAILURE_RETRY(recvmsg(fd, &msg, flags));
   if ((sync == kAsync) && (read_bytes == -1) && (errno == EWOULDBLOCK)) {


### PR DESCRIPTION
Issue:
ReceiveMessage initializes flags to 0 and uses `flags &= MSG_CMSG_CLOEXEC`, which never enables the flag. As a result, file descriptors received via recvmsg are not marked close-on-exec and can leak into child processes after exec.

Fix:
Use `flags |= MSG_CMSG_CLOEXEC` so the flag is correctly set when supported, ensuring received file descriptors are marked close-on-exec.