### PR TITLE
integer truncation in Socket_ReceiveMessage buffer allocation

### DIFF
--- a/runtime/bin/io_buffer.cc
+++ b/runtime/bin/io_buffer.cc
@@ -27,6 +27,13 @@ Dart_Handle IOBuffer::Allocate(intptr_t size, uint8_t** buffer) {
   return result;
 }
 
+Dart_Handle IOBuffer::Allocate(int64_t size, uint8_t** buffer) {
+  if (size < 0 || size > kIntptrMax) {
+    return Dart_Null();
+  }
+  return Allocate(static_cast<intptr_t>(size), buffer);
+}
+
 uint8_t* IOBuffer::Allocate(intptr_t size) {
   return static_cast<uint8_t*>(calloc(size, sizeof(uint8_t)));
 }

--- a/runtime/bin/io_buffer.h
+++ b/runtime/bin/io_buffer.h
@@ -16,6 +16,7 @@ class IOBuffer {
   // Allocate an IO buffer dart object (of type Uint8List) backed by
   // an external byte array.
   static Dart_Handle Allocate(intptr_t size, uint8_t** buffer);
+  static Dart_Handle Allocate(int64_t size, uint8_t** buffer);
 
   // Allocate IO buffer storage.
   static uint8_t* Allocate(intptr_t size);

--- a/runtime/bin/socket.cc
+++ b/runtime/bin/socket.cc
@@ -673,9 +673,13 @@ void FUNCTION_NAME(Socket_ReceiveMessage)(Dart_NativeArguments args) {
   int64_t buffer_num_bytes = 0;
   DartUtils::GetInt64Value(ThrowIfError(Dart_GetNativeArgument(args, 1)),
                            &buffer_num_bytes);
-  int64_t buffer_num_bytes_allocated = buffer_num_bytes;
+  if (buffer_num_bytes < 0 || buffer_num_bytes > kIntptrMax) {
+    Dart_ThrowException(
+        DartUtils::NewDartArgumentError("Invalid buffer length."));
+  }
+  const intptr_t alloc_size = static_cast<intptr_t>(buffer_num_bytes);
   uint8_t* buffer = nullptr;
-  Dart_Handle data = IOBuffer::Allocate(buffer_num_bytes, &buffer);
+  Dart_Handle data = IOBuffer::Allocate(alloc_size, &buffer);
   if (Dart_IsNull(data)) {
     Dart_ThrowException(DartUtils::NewDartOSError());
   }
@@ -694,10 +698,16 @@ void FUNCTION_NAME(Socket_ReceiveMessage)(Dart_NativeArguments args) {
     Dart_ThrowException(error);
   }
   delete os_error;
-  if (buffer_num_bytes > 0 && buffer_num_bytes != buffer_num_bytes_allocated) {
+  if (buffer_num_bytes < 0 || buffer_num_bytes > alloc_size) {
+    Dart_ThrowException(
+        DartUtils::NewDartArgumentError("Invalid buffer length."));
+  }
+  if (buffer_num_bytes > 0 && buffer_num_bytes != alloc_size) {
     // If received fewer than allocated buffer size, truncate buffer.
     uint8_t* new_buffer = nullptr;
-    Dart_Handle new_data = IOBuffer::Allocate(buffer_num_bytes, &new_buffer);
+    Dart_Handle new_data =
+        IOBuffer::Allocate(static_cast<intptr_t>(buffer_num_bytes),
+                           &new_buffer);
     if (Dart_IsNull(new_data)) {
       Dart_ThrowException(DartUtils::NewDartOSError());
     }

--- a/runtime/bin/socket.cc
+++ b/runtime/bin/socket.cc
@@ -533,7 +533,7 @@ void FUNCTION_NAME(Socket_Read)(Dart_NativeArguments args) {
       Socket::GetSocketIdNativeField(Dart_GetNativeArgument(args, 0));
   int64_t length = 0;
   if (DartUtils::GetInt64Value(Dart_GetNativeArgument(args, 1), &length) &&
-      (length >= 0)) {
+      (length >= 0) && (length <= kIntptrMax)) {
     if (Socket::short_socket_read()) {
       length = (length + 1) / 2;
     }
@@ -679,7 +679,7 @@ void FUNCTION_NAME(Socket_ReceiveMessage)(Dart_NativeArguments args) {
   }
   const intptr_t alloc_size = static_cast<intptr_t>(buffer_num_bytes);
   uint8_t* buffer = nullptr;
-  Dart_Handle data = IOBuffer::Allocate(alloc_size, &buffer);
+  Dart_Handle data = IOBuffer::Allocate(buffer_num_bytes, &buffer);
   if (Dart_IsNull(data)) {
     Dart_ThrowException(DartUtils::NewDartOSError());
   }
@@ -698,16 +698,11 @@ void FUNCTION_NAME(Socket_ReceiveMessage)(Dart_NativeArguments args) {
     Dart_ThrowException(error);
   }
   delete os_error;
-  if (buffer_num_bytes < 0 || buffer_num_bytes > alloc_size) {
-    Dart_ThrowException(
-        DartUtils::NewDartArgumentError("Invalid buffer length."));
-  }
   if (buffer_num_bytes > 0 && buffer_num_bytes != alloc_size) {
     // If received fewer than allocated buffer size, truncate buffer.
     uint8_t* new_buffer = nullptr;
     Dart_Handle new_data =
-        IOBuffer::Allocate(static_cast<intptr_t>(buffer_num_bytes),
-                           &new_buffer);
+        IOBuffer::Allocate(buffer_num_bytes, &new_buffer);
     if (Dart_IsNull(new_data)) {
       Dart_ThrowException(DartUtils::NewDartOSError());
     }

--- a/runtime/bin/sync_socket.cc
+++ b/runtime/bin/sync_socket.cc
@@ -214,7 +214,7 @@ void FUNCTION_NAME(SynchronousSocket_Read)(Dart_NativeArguments args) {
 
   int64_t length = 0;
   if (!DartUtils::GetInt64Value(Dart_GetNativeArgument(args, 1), &length) ||
-      (length < 0)) {
+      (length < 0) || (length > kIntptrMax)) {
     Dart_SetReturnValue(args, DartUtils::NewDartArgumentError(
                                   "First parameter must be an integer."));
     return;


### PR DESCRIPTION
Issue:
Socket_ReceiveMessage reads the buffer size as int64_t and uses it for allocation without ensuring it fits in intptr_t. On 32-bit systems, large values can truncate during allocation while recvmsg still uses the original size, leading to writes beyond the allocated buffer.

Fix:
Validate the input size against kIntptrMax, use an intptr_t allocation size, and validate the returned size after recvmsg before using it.