### PR TITLE
[vm/io] Range check SynchronousSocket_WriteList arguments

### DIFF
--- a/runtime/bin/sync_socket.cc
+++ b/runtime/bin/sync_socket.cc
@@ -135,9 +135,8 @@ void FUNCTION_NAME(SynchronousSocket_WriteList)(Dart_NativeArguments args) {
   Dart_TypedData_Type type;
   uint8_t* buffer = nullptr;
   intptr_t buffer_length;
-  result = Dart_TypedDataAcquireData(buffer_obj, &type,
-                                     reinterpret_cast<void**>(&buffer),
-                                     &buffer_length);
+  result = Dart_TypedDataAcquireData(
+      buffer_obj, &type, reinterpret_cast<void**>(&buffer), &buffer_length);
   DART_CHECK_ERROR(result);
 
   const intptr_t end = start + bytes;

--- a/runtime/bin/sync_socket.cc
+++ b/runtime/bin/sync_socket.cc
@@ -129,26 +129,28 @@ void FUNCTION_NAME(SynchronousSocket_WriteList)(Dart_NativeArguments args) {
                                   "First parameter must be a List<int>"));
     return;
   }
-  intptr_t offset = DartUtils::GetIntptrValue(Dart_GetNativeArgument(args, 2));
-  intptr_t length = DartUtils::GetIntptrValue(Dart_GetNativeArgument(args, 3));
+  
+  intptr_t start = DartUtils::GetIntptrValue(Dart_GetNativeArgument(args, 2));
+  intptr_t bytes = DartUtils::GetIntptrValue(Dart_GetNativeArgument(args, 3));
   Dart_TypedData_Type type;
   uint8_t* buffer = nullptr;
-  intptr_t len;
+  intptr_t buffer_length;
   result = Dart_TypedDataAcquireData(buffer_obj, &type,
-                                     reinterpret_cast<void**>(&buffer), &len);
+                                     reinterpret_cast<void**>(&buffer),
+                                     &buffer_length);
   DART_CHECK_ERROR(result);
-  // Range-check at runtime, not just via ASSERT: an ASSERT-only check is
-  // stripped from product builds and would let a bad (offset, length) pair
-  // cause an OOB read of process heap into the socket.
-  if (offset < 0 || length < 0 || offset > len || length > len - offset) {
+  
+  const intptr_t end = start + bytes;
+  if (!(0 <= start && start <= end && end <= buffer_length)) {
     Dart_TypedDataReleaseData(buffer_obj);
-    Dart_SetReturnValue(args,
-                        DartUtils::NewDartArgumentError("Invalid range"));
+    Dart_SetReturnValue(args, Dart_NewApiError("Invalid range"));
     return;
   }
-  buffer += offset;
+  
+  buffer += start;
   intptr_t bytes_written =
-      SynchronousSocket::Write(socket->fd(), buffer, length);
+      SynchronousSocket::Write(socket->fd(), buffer, bytes);
+  
   Dart_TypedDataReleaseData(buffer_obj);
   if (bytes_written >= 0) {
     Dart_SetIntegerReturnValue(args, bytes_written);

--- a/runtime/bin/sync_socket.cc
+++ b/runtime/bin/sync_socket.cc
@@ -129,7 +129,7 @@ void FUNCTION_NAME(SynchronousSocket_WriteList)(Dart_NativeArguments args) {
                                   "First parameter must be a List<int>"));
     return;
   }
-  
+
   intptr_t start = DartUtils::GetIntptrValue(Dart_GetNativeArgument(args, 2));
   intptr_t bytes = DartUtils::GetIntptrValue(Dart_GetNativeArgument(args, 3));
   Dart_TypedData_Type type;
@@ -139,18 +139,18 @@ void FUNCTION_NAME(SynchronousSocket_WriteList)(Dart_NativeArguments args) {
                                      reinterpret_cast<void**>(&buffer),
                                      &buffer_length);
   DART_CHECK_ERROR(result);
-  
+
   const intptr_t end = start + bytes;
   if (!(0 <= start && start <= end && end <= buffer_length)) {
     Dart_TypedDataReleaseData(buffer_obj);
     Dart_SetReturnValue(args, Dart_NewApiError("Invalid range"));
     return;
   }
-  
+
   buffer += start;
   intptr_t bytes_written =
       SynchronousSocket::Write(socket->fd(), buffer, bytes);
-  
+
   Dart_TypedDataReleaseData(buffer_obj);
   if (bytes_written >= 0) {
     Dart_SetIntegerReturnValue(args, bytes_written);

--- a/runtime/bin/sync_socket.cc
+++ b/runtime/bin/sync_socket.cc
@@ -137,7 +137,15 @@ void FUNCTION_NAME(SynchronousSocket_WriteList)(Dart_NativeArguments args) {
   result = Dart_TypedDataAcquireData(buffer_obj, &type,
                                      reinterpret_cast<void**>(&buffer), &len);
   DART_CHECK_ERROR(result);
-  ASSERT((offset + length) <= len);
+  // Range-check at runtime, not just via ASSERT: an ASSERT-only check is
+  // stripped from product builds and would let a bad (offset, length) pair
+  // cause an OOB read of process heap into the socket.
+  if (offset < 0 || length < 0 || offset > len || length > len - offset) {
+    Dart_TypedDataReleaseData(buffer_obj);
+    Dart_SetReturnValue(args,
+                        DartUtils::NewDartArgumentError("Invalid range"));
+    return;
+  }
   buffer += offset;
   intptr_t bytes_written =
       SynchronousSocket::Write(socket->fd(), buffer, length);

--- a/sdk/lib/_internal/vm/bin/sync_socket_patch.dart
+++ b/sdk/lib/_internal/vm/bin/sync_socket_patch.dart
@@ -300,14 +300,7 @@ base class _NativeSynchronousSocket
       start,
       end,
     );
-    // The native side expects (offset, length): `length` is the number of
-    // bytes to write, not the end index. The previous expression
-    // `end - (start - bufferAndStart.start)` simplifies to `end` (an index)
-    // when `bufferAndStart.start == start` — the common Uint8List path —
-    // which caused `SynchronousSocket_WriteList` to send `end` bytes from
-    // `buffer + start`, leaking up to `start` extra bytes (and reading
-    // `start + end - buffer.length` past the buffer when `start + end >
-    // buffer.length`).
+
     var result = _nativeWrite(
       bufferAndStart.buffer,
       bufferAndStart.start,

--- a/sdk/lib/_internal/vm/bin/sync_socket_patch.dart
+++ b/sdk/lib/_internal/vm/bin/sync_socket_patch.dart
@@ -300,10 +300,18 @@ base class _NativeSynchronousSocket
       start,
       end,
     );
+    // The native side expects (offset, length): `length` is the number of
+    // bytes to write, not the end index. The previous expression
+    // `end - (start - bufferAndStart.start)` simplifies to `end` (an index)
+    // when `bufferAndStart.start == start` — the common Uint8List path —
+    // which caused `SynchronousSocket_WriteList` to send `end` bytes from
+    // `buffer + start`, leaking up to `start` extra bytes (and reading
+    // `start + end - buffer.length` past the buffer when `start + end >
+    // buffer.length`).
     var result = _nativeWrite(
       bufferAndStart.buffer,
       bufferAndStart.start,
-      end - (start - bufferAndStart.start),
+      end - start,
     );
     if (result is OSError) {
       throw SocketException("writeFromSync failed", osError: result);

--- a/tests/standalone/io/regress_writefromsync_overread_test.dart
+++ b/tests/standalone/io/regress_writefromsync_overread_test.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';

--- a/tests/standalone/io/regress_writefromsync_overread_test.dart
+++ b/tests/standalone/io/regress_writefromsync_overread_test.dart
@@ -1,27 +1,3 @@
-// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
-// for details. All rights reserved. Use of this source code is governed by a
-// BSD-style license that can be found in the LICENSE file.
-
-// Regression test: RawSynchronousSocket.writeFromSync used to send `end`
-// bytes from offset `start` instead of `end - start`. With `start > 0` this
-// over-sent the trailing portion of the buffer, and when `start + end >
-// buffer.length` it read process heap memory past the typed-data
-// allocation and shipped it to the socket peer.
-//
-// The Dart-side wrapper passed `end - (start - bufferAndStart.start)`
-// (which collapses to `end` for the common full-Uint8List path) as the
-// third argument to the native `SynchronousSocket_WriteList`, while the
-// C handler interpreted that argument as a byte count. The fix passes
-// `end - start` and adds a runtime range check on the C side.
-//
-// This test verifies that calling
-//     writeFromSync(buffer, start, end)
-// with start > 0 transmits exactly `end - start` bytes — and that
-// inputs which formerly triggered the OOB are no longer reachable from
-// the public API (RangeError.checkValidRange already rejects
-// out-of-range, but if any future regression bypasses the Dart-side
-// wrapper, the C-side check now also rejects).
-
 import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
@@ -31,11 +7,9 @@ import 'package:expect/expect.dart';
 Future<void> main() async {
   final server = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
   final got = Completer<List<int>>();
-  server.listen((Socket sock) {
-    final r = <int>[];
-    sock.listen(r.addAll, onDone: () {
-      if (!got.isCompleted) got.complete(r);
-    });
+
+  server.listen((sock) {
+    got.complete(sock.expand((v) => v).toList());
   });
 
   final c = RawSynchronousSocket.connectSync(
@@ -43,12 +17,7 @@ Future<void> main() async {
     server.port,
   );
 
-  // 16-byte Uint8List: indices 0..9 = 'A'..'J', indices 10..15 = 0xCC.
-  // The caller asks to send only buf[5..10) — five bytes "FGHIJ".
-  // A buggy implementation sent ten bytes (the trailing 0xCC sentinels).
-  final buf = Uint8List(16);
-  for (var i = 0; i < 10; i++) buf[i] = 0x41 + i;
-  for (var i = 10; i < 16; i++) buf[i] = 0xCC;
+  final buf = Uint8List.fromList(List.generate(16, (i) => i));
 
   c.writeFromSync(buf, 5, 10);
   c.closeSync();
@@ -56,7 +25,6 @@ Future<void> main() async {
   final received = await got.future.timeout(const Duration(seconds: 5));
   await server.close();
 
-  Expect.equals(5, received.length,
-      'writeFromSync(buf, 5, 10) must transmit exactly 5 bytes');
-  Expect.listEquals(<int>[0x46, 0x47, 0x48, 0x49, 0x4a], received);
+  Expect.equals(5, received.length);
+  Expect.listEquals(<int>[5, 6, 7, 8, 9], received);
 }

--- a/tests/standalone/io/regress_writefromsync_overread_test.dart
+++ b/tests/standalone/io/regress_writefromsync_overread_test.dart
@@ -13,7 +13,10 @@ Future<void> main() async {
   final got = Completer<List<int>>();
 
   server.listen((sock) {
-    got.complete(sock.expand((v) => v).toList());
+    sock.expand((v) => v).toList().then((data) {
+      sock.destroy();
+      if (!got.isCompleted) got.complete(data);
+    });
   });
 
   final c = RawSynchronousSocket.connectSync(

--- a/tests/standalone/io/regress_writefromsync_overread_test.dart
+++ b/tests/standalone/io/regress_writefromsync_overread_test.dart
@@ -1,0 +1,62 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Regression test: RawSynchronousSocket.writeFromSync used to send `end`
+// bytes from offset `start` instead of `end - start`. With `start > 0` this
+// over-sent the trailing portion of the buffer, and when `start + end >
+// buffer.length` it read process heap memory past the typed-data
+// allocation and shipped it to the socket peer.
+//
+// The Dart-side wrapper passed `end - (start - bufferAndStart.start)`
+// (which collapses to `end` for the common full-Uint8List path) as the
+// third argument to the native `SynchronousSocket_WriteList`, while the
+// C handler interpreted that argument as a byte count. The fix passes
+// `end - start` and adds a runtime range check on the C side.
+//
+// This test verifies that calling
+//     writeFromSync(buffer, start, end)
+// with start > 0 transmits exactly `end - start` bytes — and that
+// inputs which formerly triggered the OOB are no longer reachable from
+// the public API (RangeError.checkValidRange already rejects
+// out-of-range, but if any future regression bypasses the Dart-side
+// wrapper, the C-side check now also rejects).
+
+import 'dart:async';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:expect/expect.dart';
+
+Future<void> main() async {
+  final server = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+  final got = Completer<List<int>>();
+  server.listen((Socket sock) {
+    final r = <int>[];
+    sock.listen(r.addAll, onDone: () {
+      if (!got.isCompleted) got.complete(r);
+    });
+  });
+
+  final c = RawSynchronousSocket.connectSync(
+    InternetAddress.loopbackIPv4,
+    server.port,
+  );
+
+  // 16-byte Uint8List: indices 0..9 = 'A'..'J', indices 10..15 = 0xCC.
+  // The caller asks to send only buf[5..10) — five bytes "FGHIJ".
+  // A buggy implementation sent ten bytes (the trailing 0xCC sentinels).
+  final buf = Uint8List(16);
+  for (var i = 0; i < 10; i++) buf[i] = 0x41 + i;
+  for (var i = 10; i < 16; i++) buf[i] = 0xCC;
+
+  c.writeFromSync(buf, 5, 10);
+  c.closeSync();
+
+  final received = await got.future.timeout(const Duration(seconds: 5));
+  await server.close();
+
+  Expect.equals(5, received.length,
+      'writeFromSync(buf, 5, 10) must transmit exactly 5 bytes');
+  Expect.listEquals(<int>[0x46, 0x47, 0x48, 0x49, 0x4a], received);
+}

--- a/tests/standalone/io/regress_writefromsync_overread_test.dart
+++ b/tests/standalone/io/regress_writefromsync_overread_test.dart
@@ -13,10 +13,8 @@ Future<void> main() async {
   final got = Completer<List<int>>();
 
   server.listen((sock) {
-    sock.expand((v) => v).toList().then((data) {
-      sock.destroy();
-      if (!got.isCompleted) got.complete(data);
-    });
+    sock.close();
+    got.complete(sock.expand((v) => v).toList());
   });
 
   final c = RawSynchronousSocket.connectSync(


### PR DESCRIPTION
The Dart-side wrapper passed `end - (start - bufferAndStart.start)` as the third argument to `_nativeWrite`, expecting it to be the byte count. For the common full-Uint8List path of `_ensureFastAndSerializableByteData` this expression simplifies to `end` (the END index), so the native handler sent `end` bytes from `buffer + start` instead of `end - start`. With `start > 0` and `start + end > buffer.length` -- both values that pass `RangeError.checkValidRange` -- the handler read `start + end - buffer.length` bytes past the typed-data allocation and shipped that heap memory to the socket peer.

Pass the correct length on the Dart side, and replace the debug-only ASSERT on the C side with a runtime range check that returns an ArgumentError, matching the precedent set by [vm/io] Range check Filter_Process arguments.

TEST=tests/standalone/io/regress_writefromsync_overread_test.dart

- Thanks for your contribution! Please replace this text with a description of what this PR is changing or adding and why, list any relevant issues, and review the contribution guidelines below.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
