### PR TITLE
[vm/kernel] Range-check kernel Reader offsets at runtime

### DIFF
--- a/runtime/vm/kernel_binary.h
+++ b/runtime/vm/kernel_binary.h
@@ -392,9 +392,21 @@ class Reader : public ValueObject {
 
   intptr_t ReadListLength() { return ReadUInt(); }
 
-  uint8_t ReadByte() { return raw_buffer_[offset_++]; }
+  uint8_t ReadByte() {
+    if (offset_ < 0 || offset_ >= size_) {
+      FATAL("kernel::Reader::ReadByte out of range: "
+            "offset=%" Pd " size=%" Pd, offset_, size_);
+    }
+    return raw_buffer_[offset_++];
+  }
 
-  uint8_t PeekByte() { return raw_buffer_[offset_]; }
+  uint8_t PeekByte() {
+    if (offset_ < 0 || offset_ >= size_) {
+      FATAL("kernel::Reader::PeekByte out of range: "
+            "offset=%" Pd " size=%" Pd, offset_, size_);
+    }
+    return raw_buffer_[offset_];
+  }
 
   void ReadBytes(uint8_t* buffer, uint8_t size) {
     for (int i = 0; i < size; i++) {
@@ -483,7 +495,15 @@ class Reader : public ValueObject {
 
   intptr_t offset() const { return offset_; }
   void set_offset(intptr_t offset) {
-    ASSERT(offset < size_);
+    // Offsets in the kernel binary are read straight from attacker-controlled
+    // bytes (e.g. `library_offset` table entries, `string_table_offset`).
+    // An ASSERT-only check is stripped from product builds and would let
+    // bad offsets reach `ReadByte`/`ReadUInt32`, producing OOB reads of
+    // memory outside the typed-data buffer. Validate at runtime.
+    if (offset < 0 || offset > size_) {
+      FATAL("kernel::Reader::set_offset out of range: "
+            "%" Pd " (size=%" Pd ")", offset, size_);
+    }
     offset_ = offset;
   }
   intptr_t size() const { return size_; }
@@ -493,7 +513,11 @@ class Reader : public ValueObject {
   }
 
   const uint8_t* BufferAt(intptr_t offset) {
-    ASSERT((offset >= 0) && (offset < size_));
+    // Same caveat as set_offset: callers may pass attacker-controlled values.
+    if (offset < 0 || offset >= size_) {
+      FATAL("kernel::Reader::BufferAt out of range: "
+            "%" Pd " (size=%" Pd ")", offset, size_);
+    }
     return &raw_buffer_[offset];
   }
 

--- a/runtime/vm/kernel_loader.h
+++ b/runtime/vm/kernel_loader.h
@@ -270,9 +270,19 @@ class KernelLoader : public ValueObject {
 
   intptr_t library_offset(intptr_t index) {
     kernel::Reader reader(program_->binary());
-    return reader.ReadFromIndexNoReset(reader.size(),
-                                       KernelFixedFieldsAfterLibraries,
-                                       program_->library_count() + 1, index);
+    intptr_t offset = reader.ReadFromIndexNoReset(
+        reader.size(), KernelFixedFieldsAfterLibraries,
+        program_->library_count() + 1, index);
+    // The offset comes straight from the kernel file's library-offset
+    // table and is then handed to `Reader::set_offset` by every caller.
+    // Validate it here so the entire library-loading path can rely on
+    // the invariant `0 <= offset <= reader.size()`.
+    if (offset < 0 || offset > reader.size()) {
+      FATAL("library_offset[%" Pd "] out of range: "
+            "%" Pd " (binary size=%" Pd ")",
+            index, offset, reader.size());
+    }
+    return offset;
   }
 
   NameIndex library_canonical_name(intptr_t index) {


### PR DESCRIPTION
`kernel::Reader::set_offset`, `BufferAt`, `ReadByte`, and `PeekByte` performed only debug-only `ASSERT` bounds checks. The offsets they consume are read directly from the kernel file -- in particular, `KernelLoader::library_offset(i)` returns a `uint32_t` from the library-offset table at the end of the `.dill` and feeds it to `Reader::set_offset(...)` (e.g. `library_canonical_name`, `KernelLoader::LoadLibrary`). With ASSERT compiled out in product builds a corrupted offset in a malformed kernel file leads `Reader` to read arbitrary process memory.

Reproducer (Dart 3.11.6 stable, linux_x64):

  dart compile kernel hello.dart -o hello.dill
  SIZE=$(stat -c '%s' hello.dill)
  printf '\xff\xff\xff\xff' | \
    dd of=hello.dill bs=1 seek=$((SIZE-16)) count=4 conv=notrunc
  dart hello.dill
  # ===> SEGV in dart::kernel::LibraryHelper::ReadUntilExcluding+0x4c
  #      <- KernelLoader::LoadLibrary <- LoadProgram <- LoadEntireProgram
  #      <- Dart_LoadScriptFromKernel

Add runtime range checks at the four lowest-level entry points in `Reader`, plus a defense-in-depth check in `KernelLoader::library_offset` so the invariant `0 <= offset <= reader.size()` holds for every caller. The `FATAL` matches the policy used by `Reader::EnsureEnd` and the `[vm/io] Range check Filter_Process arguments` change (commit d2903a568cc).

The same bug class affects `string_table_offset`,
`metadata_payloads_offset`, `metadata_mappings_offset`, `name_table_offset`, `constant_table_offset`, and
`component_index_offset` -- they are all `uint32_t` values from the file's component index that flow into `set_offset`. The new runtime check in `set_offset` covers them.

TEST=Manual: see reproducer above; the SEGV is replaced with a FATAL indicating the out-of-range offset.

- Thanks for your contribution! Please replace this text with a description of what this PR is changing or adding and why, list any relevant issues, and review the contribution guidelines below.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
