### PR TITLE
[vm/io] Range check Socket_SendMessage arguments

### DIFF
--- a/runtime/bin/socket.cc
+++ b/runtime/bin/socket.cc
@@ -828,7 +828,12 @@ void FUNCTION_NAME(Socket_SendMessage)(Dart_NativeArguments args) {
     Dart_Handle buffer_dart = Dart_GetNativeArgument(args, 1);
     TypedDataScope data(buffer_dart);
 
-    ASSERT((offset + length) <= data.size_in_bytes());
+    const intptr_t end = offset + length;
+    if (!(0 <= offset && offset <= end && end <= data.size_in_bytes())) {
+      delete os_error;
+      Dart_SetReturnValue(args, Dart_NewApiError("Invalid range"));
+      return;
+    }
     uint8_t* buffer_at_offset =
         reinterpret_cast<uint8_t*>(data.data()) + offset;
     bytes_written = SocketBase::SendMessage(

--- a/sdk/lib/_internal/vm/bin/socket_patch.dart
+++ b/sdk/lib/_internal/vm/bin/socket_patch.dart
@@ -1524,7 +1524,7 @@ base class _NativeSocket extends _NativeSocketNativeWrapper
       _BufferAndStart bufferAndStart = _ensureFastAndSerializableByteData(
         buffer,
         offset,
-        bytes,
+        offset + bytes,
       );
       if (!const bool.fromEnvironment("dart.vm.product")) {
         _SocketProfile.collectStatistic(
@@ -1568,7 +1568,7 @@ base class _NativeSocket extends _NativeSocketNativeWrapper
       _BufferAndStart bufferAndStart = _ensureFastAndSerializableByteData(
         buffer,
         offset,
-        bytes,
+        offset + bytes,
       );
       if (!const bool.fromEnvironment("dart.vm.product")) {
         _SocketProfile.collectStatistic(

--- a/tests/standalone/io/regress_sendmessage_overread_test.dart
+++ b/tests/standalone/io/regress_sendmessage_overread_test.dart
@@ -1,0 +1,41 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:expect/expect.dart';
+
+Future<void> main() async {
+  // sendMessage with control messages is POSIX-only.
+  if (!(Platform.isLinux || Platform.isMacOS)) {
+    return;
+  }
+
+  final server = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+  final got = Completer<List<int>>();
+
+  server.listen((sock) {
+    sock.close();
+    got.complete(sock.expand((v) => v).toList());
+  });
+
+  final client = await RawSocket.connect(
+    InternetAddress.loopbackIPv4,
+    server.port,
+  );
+
+  // `data` is a plain `List<int>` (not a `Uint8List`), forcing the helper
+  // to take its copy path.
+  final data = List<int>.generate(16, (i) => i);
+
+  client.sendMessage(const <SocketControlMessage>[], data, 5, 10);
+  client.close();
+
+  final received = await got.future.timeout(const Duration(seconds: 5));
+  await server.close();
+
+  Expect.equals(10, received.length);
+  Expect.listEquals(<int>[5, 6, 7, 8, 9, 10, 11, 12, 13, 14], received);
+}


### PR DESCRIPTION
Follow-up to #63358, same fix pattern applied to `Socket_SendMessage`.

`_NativeSocket.send` and `_NativeSocket.sendMessage` (`sdk/lib/_internal/vm/bin/socket_patch.dart`) pass `bytes` (the byte count) as the third argument to `_ensureFastAndSerializableByteData(_, _, end)`, whose third parameter is the exclusive `end` index. In the helper's copy path (when `buffer` is not a full-size `Uint8List`) this means it allocates `Uint8List(bytes - offset)` instead of `Uint8List(bytes)`; the native is then told to send `bytes` bytes from the shorter buffer, reading `offset` bytes of adjacent Dart heap memory and forwarding them to the peer via `sendmsg(2)`.

Changes:
- Pass `offset + bytes` (i.e. `end`) to the helper in both `_NativeSocket.send` and `_NativeSocket.sendMessage`.
- Replace the release-no-op `ASSERT((offset + length) <= data.size_in_bytes())` in `Socket_SendMessage` (`runtime/bin/socket.cc`) with a runtime range check, mirroring the post-fix style in #63358.
- Add `tests/standalone/io/regress_sendmessage_overread_test.dart` covering the publicly-reachable `sendMessage` codepath.

The `_NativeSocket.send` callsite is not directly reachable from the public API (`RawDatagramSocket.send` always passes `offset=0`), but it shares the same off-by-one and is corrected for defense-in-depth.