### PR TITLE
[vm/kernel] Range check library_count in Program::ReadFrom

### DIFF
--- a/runtime/tests/vm/dart/regress_kernel_library_count_test.dart
+++ b/runtime/tests/vm/dart/regress_kernel_library_count_test.dart
@@ -1,0 +1,72 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+//
+// Regression test for an out-of-bounds read in dart::kernel::Program::ReadFrom
+// when loading a .dill whose `library_count` field has been set to a value
+// large enough that the subsequent ReadSingleFieldFromIndexNoReset call
+// computes a negative offset.
+//
+// `library_count` is the uint32 at byte offset `size - 8` in the trailing
+// index. Setting it to e.g. 2^28 causes
+//     offset_ = size - (library_count + 12) * 4
+// to underflow into a large negative intptr_t. Before the fix, the
+// release-build Reader::ReadUInt32At only asserted (no-op under NDEBUG) and
+// then dereferenced raw_buffer_ + offset_, segfaulting at
+// `Program::ReadFrom+0x20f`.
+
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:expect/expect.dart';
+import 'package:path/path.dart' as p;
+
+Future<void> main() async {
+  final tmp = await Directory.systemTemp.createTemp('regress_kernel_libcount');
+  try {
+    final source = File(p.join(tmp.path, 'hello.dart'));
+    await source.writeAsString("void main() { print('hello'); }\n");
+
+    final dillPath = p.join(tmp.path, 'hello.dill');
+    final compile = await Process.run(Platform.executable, [
+      'compile',
+      'kernel',
+      source.path,
+      '-o',
+      dillPath,
+    ]);
+    if (compile.exitCode != 0) {
+      throw 'dart compile kernel failed:\n${compile.stdout}\n${compile.stderr}';
+    }
+
+    // Patch the uint32 library_count at file offset size-8 to a value
+    // that makes (library_count + 12) * 4 exceed the file size.
+    final evilPath = p.join(tmp.path, 'evil.dill');
+    final bytes = Uint8List.fromList(File(dillPath).readAsBytesSync());
+    const newLibraryCount = 1 << 28;
+    bytes[bytes.length - 8] = (newLibraryCount >> 24) & 0xFF;
+    bytes[bytes.length - 7] = (newLibraryCount >> 16) & 0xFF;
+    bytes[bytes.length - 6] = (newLibraryCount >> 8) & 0xFF;
+    bytes[bytes.length - 5] = newLibraryCount & 0xFF;
+    File(evilPath).writeAsBytesSync(bytes);
+
+    final run = await Process.run(Platform.executable, [evilPath]);
+
+    // The patched .dill must not run cleanly.
+    Expect.notEquals(0, run.exitCode);
+
+    // The VM must reject the file gracefully — no SEGV / crash dump.
+    final combinedStderr = run.stderr.toString();
+    Expect.isFalse(
+      combinedStderr.contains('===== CRASH ====='),
+      'Expected graceful rejection but VM crashed:\n$combinedStderr',
+    );
+    Expect.isFalse(
+      combinedStderr.contains('Program::ReadFrom'),
+      'Expected graceful rejection but stack trace shows Program::ReadFrom:\n'
+      '$combinedStderr',
+    );
+  } finally {
+    await tmp.delete(recursive: true);
+  }
+}

--- a/runtime/vm/kernel_binary.cc
+++ b/runtime/vm/kernel_binary.cc
@@ -72,6 +72,8 @@ const char* kKernelInvalidBinaryFormatVersion =
     ")";
 const char* kKernelInvalidSizeIndicated =
     "Invalid kernel binary: Indicated size is invalid";
+const char* kKernelInvalidLibraryCount =
+    "Invalid kernel binary: library_count is out of range";
 const char* kKernelInvalidSdkHash = "Invalid SDK hash";
 
 const int kSdkHashSizeInBytes = 10;
@@ -159,6 +161,24 @@ std::unique_ptr<Program> Program::ReadFrom(Reader* reader, const char** error) {
   // Read backwards at the end.
   program->library_count_ = reader->ReadSingleFieldFromIndexNoReset(
       reader->size_, KernelFixedFieldsAfterLibraries);
+  // Validate library_count_ so the next ReadSingleFieldFromIndexNoReset
+  // call does not compute an out-of-bounds offset. That helper sets
+  // offset_ = size_ - KernelNumberOfFixedFields(library_count_) * 4
+  //        = size_ - (library_count_ + 12) * 4
+  // and then dereferences raw_buffer_ + offset_ in ReadUInt32At. For
+  // offset_ >= 0 we need (library_count_ + 12) * 4 <= size_. We
+  // compute in intptr_t here to avoid the int-arithmetic overflow
+  // possible inside KernelNumberOfFixedFields when library_count_ is
+  // close to INT_MAX.
+  const intptr_t kFixedFieldsCount = KernelFixedFieldsBeforeLibraries + 1 +
+                                     KernelFixedFieldsAfterLibraries;
+  if (program->library_count_ < 0 ||
+      program->library_count_ > (reader->size_ / 4) - kFixedFieldsCount) {
+    if (error != nullptr) {
+      *error = kKernelInvalidLibraryCount;
+    }
+    return nullptr;
+  }
   program->source_table_offset_ = reader->ReadSingleFieldFromIndexNoReset(
       reader->size_, KernelNumberOfFixedFields(program->library_count_));
   program->constant_table_offset_ = reader->ReadUInt32();


### PR DESCRIPTION
Same fix pattern as recent #63358 (`7bc22cf` `Range check SynchronousSocket_WriteList arguments`) and `d2903a5` (`Range check Filter_Process arguments`), applied to the kernel-binary parser's first read past `library_count`.

## Bug

`Program::ReadFrom` (`runtime/vm/kernel_binary.cc:160-172`) reads the trailing-index `library_count` field, then immediately calls `ReadSingleFieldFromIndexNoReset` with `KernelNumberOfFixedFields(library_count) = library_count + 12` as the `fields_before` argument:

```cpp
program->library_count_ = reader->ReadSingleFieldFromIndexNoReset(
    reader->size_, KernelFixedFieldsAfterLibraries);
program->source_table_offset_ = reader->ReadSingleFieldFromIndexNoReset(
    reader->size_, KernelNumberOfFixedFields(program->library_count_));
```

`ReadSingleFieldFromIndexNoReset` (`runtime/vm/kernel_binary.h:319-323`) computes:

```cpp
offset_ = end_offset - fields_before * 4;
return ReadUInt32();
```

For `library_count` chosen so that `(library_count + 12) * 4 > size_`, the new `offset_` is a large negative `intptr_t`. `Reader::ReadUInt32At` then dereferences `raw_buffer_ + offset_` with only an `ASSERT` guarding it — `ASSERT((size_ >= 4) && (offset >= 0) && (offset <= size_ - 4))` — which is compiled out under `NDEBUG`. The shipped release VM segfaults.

## Reproducer (on the current release binary SDK 3.11.6)

Take any `dart compile kernel` output, overwrite the 4 bytes at file offset `size - 8` with `0x10000000` (= 2^28), and run any of:

- `dart evil.dill`
- `dart run evil.dill`
- `dart compile jit-snapshot evil.dill -o /tmp/foo.jit`

All three crash with `si_signo=Segmentation fault(11), si_code=SEGV_MAPERR(1)` at PC `dart::kernel::Program::ReadFrom+0x20f`. `dart compile exe` and `dart compile aot-snapshot` take a different load path and catch the malformed input in the Dart-side `BinaryBuilder` (controlled `RangeError`); the bug is specifically in the C++ load path reached on the three entry points above.

## Fix

Validate `library_count` immediately after reading it. The computation is done in `intptr_t` arithmetic to avoid the int overflow possible inside `KernelNumberOfFixedFields` for values close to `INT_MAX`. Constants reused from `kernel_binary.h` so the math stays in sync with `KernelNumberOfFixedFields` itself.

## Regression test

`runtime/tests/vm/dart/regress_kernel_library_count_test.dart` exercises the bug end-to-end:

1. `dart compile kernel hello.dart -o hello.dill`
2. Patch `library_count` (uint32 BE at offset `size - 8`) to `1 << 28`
3. `dart evil.dill`
4. Assert exit code is non-zero **and** that stderr contains neither `===== CRASH =====` nor `Program::ReadFrom` (i.e. the VM rejected the file gracefully rather than crashing).

Pre-fix the subprocess SEGVs and both forbidden strings appear in the crash report; post-fix the subprocess prints the `Invalid kernel binary: library_count is out of range` error and exits non-zero.