### PR TITLE
fix: prevent path traversal in sourceMapViewer /file endpoint

### DIFF
--- a/tools/dart2js/sourceMapViewer/bin/source_map_viewer.dart
+++ b/tools/dart2js/sourceMapViewer/bin/source_map_viewer.dart
@@ -46,6 +46,15 @@ void handleFile(HttpRequest request) {
     return;
   }
 
+  // Prevent path traversal and absolute path injection.
+  // Source references in source maps are relative to the map file; there is
+  // no legitimate reason for a /file request to escape the map's directory.
+  if (path.contains('..') || path.startsWith('/') || path.startsWith('file:')) {
+    request.response.statusCode = HttpStatus.FORBIDDEN;
+    request.response.close();
+    return;
+  }
+
   Uri uri = sourceMapFile.resolve(path);
   new File.fromUri(uri)
       .openRead()


### PR DESCRIPTION
## Summary

The `/file?path=...` handler in `tools/dart2js/sourceMapViewer/bin/source_map_viewer.dart` (lines 42–57) resolves the query-string `path` parameter against the source map URI without any validation:

```dart
Uri uri = sourceMapFile.resolve(path);
new File.fromUri(uri).openRead().pipe(request.response);
```

An attacker (another process on the machine, or a browser tab making cross-origin requests to the loopback port) can supply:

- **Absolute path** — `/file?path=/etc/passwd` → resolves to `file:///etc/passwd`
- **Traversal sequence** — `/file?path=../../.ssh/id_rsa` → escapes the map directory

Both cases stream arbitrary local files back in the HTTP response.

## Fix

Add a guard before `Uri.resolve()` that rejects:
- paths containing `..`
- paths starting with `/` (absolute)
- paths starting with `file:` (URI injection)

Legitimate source map references are always relative paths within the project directory and never need to escape the source map's parent directory.

## Test

```python
import urllib.parse, os
source_map_uri = "file:///tmp/project/app.js.map/"
# Before fix:
assert urllib.parse.urljoin(source_map_uri, "/etc/passwd") == "file:///etc/passwd"  # PASS → LFI
# After fix: path rejected before resolve()
```