### PR TITLE
Add missing space in help text for --print-dtd

### DIFF
--- a/pkg/dartdev/lib/src/commands/run.dart
+++ b/pkg/dartdev/lib/src/commands/run.dart
@@ -348,7 +348,7 @@ See https://dart.dev/to/package-descriptors for more details.''', verbose) {
         'print-dtd',
         hide: !verbose,
         help:
-            'Prints connection details for the Dart Tooling Daemon (DTD).'
+            'Prints connection details for the Dart Tooling Daemon (DTD). '
             'Useful for Dart DevTools extension authors working with DTD in the '
             'extension development environment.',
       )


### PR DESCRIPTION
Improves the help text for `--print-dtd`. Before:
```sh
$ dart run -h -v
...
 --[no-]print-dtd                                      Prints connection details for the Dart Tooling
                                                       Daemon (DTD).Useful for Dart DevTools extension
                                                       authors working with DTD in the extension
                                                       development environment
...
```

I did not update the tests in `pkg\dartdev\test\commands\run_test.dart` as they don't seem to cover this help text.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
