### PR TITLE
Reject invalid RSV1 frames and preserve compression state during fragmentation

### DIFF
--- a/sdk/lib/_http/http_testing.dart
+++ b/sdk/lib/_http/http_testing.dart
@@ -39,6 +39,7 @@ typedef TestingClass$_HttpHeaders = _HttpHeaders;
 typedef TestingClass$_HttpParser = _HttpParser;
 typedef TestingClass$_HttpRequest = _HttpRequest;
 typedef TestingClass$_SHA1 = _SHA1;
+typedef TestingClass$_WebSocketPerMessageDeflate = _WebSocketPerMessageDeflate;
 typedef TestingClass$_WebSocketProtocolTransformer =
     _WebSocketProtocolTransformer;
 typedef TestingClass$_WebSocketImpl = _WebSocketImpl;

--- a/sdk/lib/_http/websocket_impl.dart
+++ b/sdk/lib/_http/websocket_impl.dart
@@ -163,12 +163,16 @@ class _WebSocketProtocolTransformer
 
           _opcode = (byte & OPCODE);
 
-          if (_opcode != _WebSocketOpcode.CONTINUATION) {
-            if ((byte & RSV1) != 0) {
-              _compressed = true;
-            } else {
-              _compressed = false;
-            }
+          bool reserved1 = (byte & RSV1) != 0;
+          if (reserved1 &&
+              (_deflate == null ||
+                  _opcode == _WebSocketOpcode.CONTINUATION ||
+                  _isControlFrame())) {
+            throw WebSocketException("Protocol error");
+          }
+
+          if (_opcode != _WebSocketOpcode.CONTINUATION && !_isControlFrame()) {
+            _compressed = reserved1;
           }
 
           if (_opcode <= _WebSocketOpcode.BINARY) {
@@ -449,8 +453,9 @@ class _WebSocketPong {
   _WebSocketPong([this.payload]);
 }
 
-typedef /*String|Future<String>*/ _ProtocolSelector =
-    Function(List<String> protocols);
+typedef /*String|Future<String>*/ _ProtocolSelector = Function(
+  List<String> protocols,
+);
 
 class _WebSocketTransformerImpl
     extends StreamTransformerBase<HttpRequest, WebSocket>

--- a/sdk/lib/_http/websocket_impl.dart
+++ b/sdk/lib/_http/websocket_impl.dart
@@ -163,8 +163,8 @@ class _WebSocketProtocolTransformer
 
           _opcode = (byte & OPCODE);
 
-          bool reserved1 = (byte & RSV1) != 0;
-          if (reserved1 &&
+          bool isMessageCompressed = (byte & RSV1) != 0;
+          if (isMessageCompressed &&
               (_deflate == null ||
                   _opcode == _WebSocketOpcode.CONTINUATION ||
                   _isControlFrame())) {
@@ -172,7 +172,7 @@ class _WebSocketProtocolTransformer
           }
 
           if (_opcode != _WebSocketOpcode.CONTINUATION && !_isControlFrame()) {
-            _compressed = reserved1;
+            _compressed = isMessageCompressed;
           }
 
           if (_opcode <= _WebSocketOpcode.BINARY) {

--- a/tests/standalone/io/web_socket_protocol_processor_test.dart
+++ b/tests/standalone/io/web_socket_protocol_processor_test.dart
@@ -9,6 +9,7 @@ import "dart:convert";
 // ignore: IMPORT_INTERNAL_LIBRARY
 import "dart:_http"
     show
+        TestingClass$_WebSocketPerMessageDeflate,
         TestingClass$_WebSocketProtocolTransformer,
         Testing$_WebSocketProtocolTransformer;
 import "dart:math";
@@ -19,6 +20,7 @@ import "package:expect/expect.dart";
 
 typedef _WebSocketProtocolTransformer =
     TestingClass$_WebSocketProtocolTransformer;
+typedef _WebSocketPerMessageDeflate = TestingClass$_WebSocketPerMessageDeflate;
 
 class WebSocketFrame {
   WebSocketFrame(int opcode, List<int> data);
@@ -323,6 +325,107 @@ void testMaxPayloadLengthDefaultAcceptsLargeFrame() {
   controller.close();
 }
 
+void testReserved1WithoutNegotiatedExtensionRejected() {
+  asyncStart();
+  var transformer = new _WebSocketProtocolTransformer();
+  var controller = new StreamController<List<int>>(sync: true);
+  controller.stream
+      .transform(transformer)
+      .listen(
+        (_) {
+          Expect.fail("No data should be delivered for a reserved RSV1 bit");
+        },
+        onError: (e) {
+          asyncEnd();
+        },
+      );
+  controller.add(<int>[0xC2, 0]);
+}
+
+void testReserved1OnContinuationFrameRejected() {
+  asyncStart();
+  var transformer = new _WebSocketProtocolTransformer(
+    false,
+    new _WebSocketPerMessageDeflate(),
+  );
+  var controller = new StreamController<List<int>>(sync: true);
+  controller.stream
+      .transform(transformer)
+      .listen(
+        (_) {
+          Expect.fail("No data should be delivered for a reserved RSV1 bit");
+        },
+        onError: (e) {
+          asyncEnd();
+        },
+      );
+  controller.add(<int>[FRAME_OPCODE_BINARY, 0]);
+  controller.add(<int>[0xC0, 0]);
+}
+
+void testReserved1OnControlFrameRejected() {
+  asyncStart();
+  var transformer = new _WebSocketProtocolTransformer(
+    false,
+    new _WebSocketPerMessageDeflate(),
+  );
+  var controller = new StreamController<List<int>>(sync: true);
+  controller.stream
+      .transform(transformer)
+      .listen(
+        (_) {
+          Expect.fail("No data should be delivered for a reserved RSV1 bit");
+        },
+        onError: (e) {
+          asyncEnd();
+        },
+      );
+  controller.add(<int>[0xC9, 0]);
+}
+
+void testControlFramePreservesCompressionState() {
+  asyncStart();
+  var outgoingDeflate = new _WebSocketPerMessageDeflate();
+  var transformer = new _WebSocketProtocolTransformer(
+    false,
+    new _WebSocketPerMessageDeflate(),
+  );
+  var controller = new StreamController<List<int>>(sync: true);
+  var message = <int>[for (int i = 0; i < 100; i++) i];
+  var compressed = outgoingDeflate.processOutgoingMessage(message);
+  Expect.isTrue(compressed.length > 1);
+  var split = compressed.length ~/ 2;
+  int messageCount = 0;
+  controller.stream
+      .transform(transformer)
+      .listen(
+        (buffer) {
+          if (buffer is! List<int>) return;
+          Expect.listEquals(message, buffer);
+          messageCount++;
+        },
+        onDone: () {
+          Expect.equals(1, messageCount);
+          asyncEnd();
+        },
+      );
+  var first = createFrame(
+    false,
+    FRAME_OPCODE_BINARY,
+    null,
+    compressed,
+    0,
+    split,
+  );
+  first[0] |= 0x40;
+  controller.add(first);
+  controller.add(<int>[0x89, 0]);
+  controller.add(
+    createFrame(true, 0, null, compressed, split, compressed.length - split),
+  );
+  controller.close();
+}
+
 void main() {
   asyncStart();
   testFullMessages();
@@ -330,5 +433,9 @@ void main() {
   testUnmaskedMessage();
   testMaxPayloadLengthRejectsOversizedFrame();
   testMaxPayloadLengthDefaultAcceptsLargeFrame();
+  testReserved1WithoutNegotiatedExtensionRejected();
+  testReserved1OnContinuationFrameRejected();
+  testReserved1OnControlFrameRejected();
+  testControlFramePreservesCompressionState();
   asyncEnd();
 }


### PR DESCRIPTION
## Summary

This change fixes two WebSocket protocol handling issues in `_WebSocketProtocolTransformer`:

* Rejects frames that set `RSV1` without negotiated per-message compression.
* Preserves compression state when control frames are interleaved with fragmented compressed messages.

## Changes

* Reject `RSV1` when per-message compression has not been negotiated.
* Reject `RSV1` on continuation frames.
* Reject `RSV1` on control frames.
* Prevent control frames from resetting the active message compression state.