### PR TITLE
add 3.12.0 release date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -210,7 +210,7 @@ These changes are [language versioned][] and only affect code at 3.13 or higher:
 
 ## 3.12.0
 
-**Released on:** Unreleased
+**Released on:** 2026-05-18
 
 ### Language
 


### PR DESCRIPTION
This is a quick update of the CHANGELOG to add the release date for the 3.12.0, which still shows "unreleased" in the `main` branch

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
