### PR TITLE
[analyzer] Restrict analyzer plugin sources to the default pub registry

### DIFF
--- a/pkg/analyzer/lib/src/dart/analysis/analysis_options.dart
+++ b/pkg/analyzer/lib/src/dart/analysis/analysis_options.dart
@@ -328,26 +328,22 @@ final class AnalysisOptionsBuilder {
       YamlScalar(value: String version),
       YamlScalar(value: String hostedUrl),
     )) {
+      // Only the default pub registry is accepted as a plugin source from
+      // project configuration. A plugin hosted on an arbitrary, non-default
+      // host is skipped.
+      if (!_isDefaultPluginHost(hostedUrl)) {
+        return null;
+      }
       return VersionedPluginSource(constraint: version, hostedUrl: hostedUrl);
     } else if (versionSource case YamlScalar(value: String version)) {
       return VersionedPluginSource(constraint: version);
     }
 
-    var gitSource = pluginNode.valueAt(AnalysisOptionsFileKeys.git);
-    if (gitSource case YamlScalar(:String value)) {
-      return GitPluginSource(url: value);
-    } else if (gitSource is YamlMap) {
-      var urlSource = gitSource.valueAt(AnalysisOptionsFileKeys.url);
-      if (urlSource case YamlScalar(:String value)) {
-        return GitPluginSource(
-          url: value,
-          path: gitSource.valueAt(AnalysisOptionsFileKeys.path).stringValue,
-          ref: gitSource.valueAt(AnalysisOptionsFileKeys.ref).stringValue,
-          tagPattern: gitSource
-              .valueAt(AnalysisOptionsFileKeys.tagPattern)
-              .stringValue,
-        );
-      }
+    // A 'git' source points a plugin at an arbitrary URL, which is not a
+    // supported way to specify an analyzer plugin in project configuration; it
+    // is skipped.
+    if (pluginNode.valueAt(AnalysisOptionsFileKeys.git) != null) {
+      return null;
     }
 
     var pathSource = pluginNode.valueAt(AnalysisOptionsFileKeys.path);
@@ -372,6 +368,12 @@ final class AnalysisOptionsBuilder {
       return PathPluginSource(path: pathValue);
     }
     return null;
+  }
+
+  /// Whether [hostedUrl] refers to the default pub package registry.
+  static bool _isDefaultPluginHost(String hostedUrl) {
+    var host = Uri.tryParse(hostedUrl)?.host;
+    return host == 'pub.dev' || host == 'pub.dartlang.org';
   }
 }
 

--- a/pkg/analyzer/test/src/options/analysis_options_test.dart
+++ b/pkg/analyzer/test/src/options/analysis_options_test.dart
@@ -330,6 +330,8 @@ code-style:
   }
 
   test_plugins_dependency_overrides_git() {
+    // A 'git' source is not an accepted plugin source from project
+    // configuration, so the dependency override is skipped.
     var analysisOptions = parseOptions('''
 plugins:
   plugin_one: ^1.2.3
@@ -342,25 +344,7 @@ plugins:
 
     var dependencyOverrides =
         analysisOptions.pluginsOptions.dependencyOverrides;
-    expect(dependencyOverrides, isNotNull);
-    expect(dependencyOverrides, hasLength(1));
-
-    var packageOverride = dependencyOverrides!.entries.singleOrNull;
-    expect(packageOverride, isNotNull);
-    expect(packageOverride!.key, 'some_package');
-    expect(
-      packageOverride.value,
-      isA<GitPluginSource>().having(
-        (e) => e.toYaml(name: 'some_package'),
-        'toYaml',
-        '''
-  some_package:
-    git:
-      url: https://github.com/dart-lang/some_package.git
-      ref: main
-''',
-      ),
-    );
+    expect(dependencyOverrides, anyOf(isNull, isEmpty));
   }
 
   test_plugins_dependency_overrides_relative() {
@@ -414,6 +398,8 @@ plugins:
   }
 
   test_plugins_dependency_overrides_versionConstraintHosted() {
+    // A 'hosted' source with a non-default host is not an accepted plugin
+    // source from project configuration, so the dependency override is skipped.
     var analysisOptions = parseOptions('''
 plugins:
   plugin_one: ^1.2.3
@@ -421,6 +407,22 @@ plugins:
     some_package1:
       version: ^3.2.1
       hosted: https://example.com/packages/
+''');
+
+    var dependencyOverrides =
+        analysisOptions.pluginsOptions.dependencyOverrides;
+    expect(dependencyOverrides, anyOf(isNull, isEmpty));
+  }
+
+  test_plugins_dependency_overrides_versionConstraintHosted_default() {
+    // A 'hosted' source pointing at the default pub registry is accepted.
+    var analysisOptions = parseOptions('''
+plugins:
+  plugin_one: ^1.2.3
+  dependency_overrides:
+    some_package1:
+      version: ^3.2.1
+      hosted: https://pub.dev
 ''');
 
     var dependencyOverrides =
@@ -439,37 +441,27 @@ plugins:
         '''
   some_package1:
     version: ^3.2.1
-    hosted: https://example.com/packages/
+    hosted: https://pub.dev
 ''',
       ),
     );
   }
 
   test_plugins_gitConstraint() {
+    // A 'git' source is not an accepted plugin source from project
+    // configuration, so the plugin is skipped.
     var analysisOptions = parseOptions('''
 plugins:
   plugin_one:
     git: https://github.com/dart-lang/plugin_one.git
 ''');
 
-    var configuration = analysisOptions.pluginConfigurations.single;
-    expect(configuration.isEnabled, isTrue);
-    expect(configuration.name, 'plugin_one');
-    expect(
-      configuration.source,
-      isA<GitPluginSource>().having(
-        (e) => e.toYaml(name: 'plugin_one'),
-        'toYaml',
-        '''
-  plugin_one:
-    git:
-      url: https://github.com/dart-lang/plugin_one.git
-''',
-      ),
-    );
+    expect(analysisOptions.pluginConfigurations, isEmpty);
   }
 
   test_plugins_gitConstraint_full() {
+    // A 'git' source is not an accepted plugin source from project
+    // configuration, so the plugin is skipped.
     var analysisOptions = parseOptions('''
 plugins:
   plugin_one:
@@ -480,48 +472,19 @@ plugins:
       tag_pattern: 'v*'
 ''');
 
-    var configuration = analysisOptions.pluginConfigurations.single;
-    expect(configuration.isEnabled, isTrue);
-    expect(configuration.name, 'plugin_one');
-    expect(
-      configuration.source,
-      isA<GitPluginSource>().having(
-        (e) => e.toYaml(name: 'plugin_one'),
-        'toYaml',
-        '''
-  plugin_one:
-    git:
-      url: https://github.com/dart-lang/sdk.git
-      ref: main
-      path: pkg/plugin_one
-      tag_pattern: v*
-''',
-      ),
-    );
+    expect(analysisOptions.pluginConfigurations, isEmpty);
   }
 
   test_plugins_gitConstraint_scalar() {
+    // A 'git' source is not an accepted plugin source from project
+    // configuration, so the plugin is skipped.
     var analysisOptions = parseOptions('''
 plugins:
   plugin_one:
     git: https://github.com/dart-lang/plugin_one.git
 ''');
 
-    var configuration = analysisOptions.pluginConfigurations.single;
-    expect(configuration.isEnabled, isTrue);
-    expect(configuration.name, 'plugin_one');
-    expect(
-      configuration.source,
-      isA<GitPluginSource>().having(
-        (e) => e.toYaml(name: 'plugin_one'),
-        'toYaml',
-        '''
-  plugin_one:
-    git:
-      url: https://github.com/dart-lang/plugin_one.git
-''',
-      ),
-    );
+    expect(analysisOptions.pluginConfigurations, isEmpty);
   }
 
   test_plugins_pathConstraint() {
@@ -637,7 +600,7 @@ plugins:
 plugins:
   plugin_one:
     version: ^1.2.3
-    hosted: https://example.com/packages/
+    hosted: https://pub.dev
 ''');
 
     var configuration = analysisOptions.pluginConfigurations.single;
@@ -651,10 +614,23 @@ plugins:
         '''
   plugin_one:
     version: ^1.2.3
-    hosted: https://example.com/packages/
+    hosted: https://pub.dev
 ''',
       ),
     );
+  }
+
+  test_plugins_versionConstraintHosted_nonDefaultHost() {
+    // A 'hosted' source with a non-default host is not an accepted plugin
+    // source from project configuration, so the plugin is skipped.
+    var analysisOptions = parseOptions('''
+plugins:
+  plugin_one:
+    version: ^1.2.3
+    hosted: https://example.com/packages/
+''');
+
+    expect(analysisOptions.pluginConfigurations, isEmpty);
   }
 
   test_signature_differs_for_hosted_plugin() {
@@ -662,7 +638,7 @@ plugins:
 plugins:
   plugin_one:
     version: ^1.2.3
-    hosted: https://example.com/packages/
+    hosted: https://pub.dev
 ''');
     var sig1 = options.signature;
 


### PR DESCRIPTION
The top-level `plugins:` section of `analysis_options.yaml` accepts a plugin source as a version constraint (optionally with a `hosted:` host), a `git:` URL, or a `path:`. The `git:` source and the `hosted:` source with a non-default host let project configuration resolve a plugin from an arbitrary URL/host, which is not a documented or intended way to specify an analyzer plugin.

This validates the plugin source resolved from project configuration in `AnalysisOptionsBuilder._getSource`:

- `git:` sources are no longer accepted (the plugin is skipped).
- `hosted:` sources are only accepted when the host is the default pub registry (`pub.dev` / `pub.dartlang.org`).

`path:`, plain version constraints, and default-pub `hosted:` sources are unchanged.

Tests in `pkg/analyzer/test/src/options/analysis_options_test.dart` are updated to assert the restricted behavior, and new cases cover both the accepted default-host `hosted:` source and the now-skipped non-default-host `hosted:` / `git:` sources.