### PR TITLE
Quick fixes that create constructors use new-style syntax when primary_constructors is enabled

### DIFF
--- a/pkg/analysis_server/lib/src/services/correction/dart/create_constructor_for_final_fields.dart
+++ b/pkg/analysis_server/lib/src/services/correction/dart/create_constructor_for_final_fields.dart
@@ -177,7 +177,11 @@ class CreateConstructorForFinalFields extends ResolvedCorrectionProducer {
         // TODO(srawlins): Replace this block with `writeConstructorDeclaration`
         // and `parameterWriter`.
         builder.write('const ');
-        builder.write(fixContext.containerName);
+        if (isEnabled(Feature.primary_constructors)) {
+          builder.write('new');
+        } else {
+          builder.write(fixContext.containerName);
+        }
         builder.write('({');
         if (!requiredNamedParametersFirst) {
           builder.writeType(
@@ -227,7 +231,11 @@ class CreateConstructorForFinalFields extends ResolvedCorrectionProducer {
         // TODO(srawlins): Replace this block with `writeConstructorDeclaration`
         // and `parameterWriter`.
         builder.write('const ');
-        builder.write(fixContext.containerName);
+        if (isEnabled(Feature.primary_constructors)) {
+          builder.write('new');
+        } else {
+          builder.write(fixContext.containerName);
+        }
         builder.write('({');
         if (!requiredNamedParametersFirst) {
           builder.write('super.key');
@@ -276,7 +284,11 @@ class CreateConstructorForFinalFields extends ResolvedCorrectionProducer {
         if (isConst) {
           builder.write('const ');
         }
-        builder.write(fixContext.containerName);
+        if (isEnabled(Feature.primary_constructors)) {
+          builder.write('new');
+        } else {
+          builder.write(fixContext.containerName);
+        }
         builder.write('({');
         var parameters = <_FieldRecord>[];
         var buffer = StringBuffer();
@@ -336,7 +348,11 @@ class CreateConstructorForFinalFields extends ResolvedCorrectionProducer {
         if (isConst) {
           builder.write('const ');
         }
-        builder.write(fixContext.containerName);
+        if (isEnabled(Feature.primary_constructors)) {
+          builder.write('new');
+        } else {
+          builder.write(fixContext.containerName);
+        }
         builder.write('(');
         var hasWritten = false;
         for (var field in fields) {

--- a/pkg/analysis_server/lib/src/services/correction/dart/create_constructor_super.dart
+++ b/pkg/analysis_server/lib/src/services/correction/dart/create_constructor_super.dart
@@ -156,14 +156,18 @@ class _CreateConstructor extends ResolvedCorrectionProducer {
           }
         }
 
-        if (isEnabled(Feature.primary_constructors) && constructorName == null) {
+        if (isEnabled(Feature.primary_constructors)) {
           builder.write('new');
+          if (constructorName != null) {
+            builder.write(' ');
+            builder.addSimpleLinkedEdit('NAME', constructorName);
+          }
         } else {
           builder.write(_targetClass.namePart.typeName.lexeme);
-        }
-        if (constructorName != null && constructorName != 'new') {
-          builder.write('.');
-          builder.addSimpleLinkedEdit('NAME', constructorName);
+          if (constructorName != null) {
+            builder.write('.');
+            builder.addSimpleLinkedEdit('NAME', constructorName);
+          }
         }
         builder.write('(');
         writeParameters(true);
@@ -206,14 +210,18 @@ class _CreateConstructor extends ResolvedCorrectionProducer {
           builder.write(parameterName);
         }
 
-        if (isEnabled(Feature.primary_constructors) && constructorName == null) {
+        if (isEnabled(Feature.primary_constructors)) {
           builder.write('new');
+          if (constructorName != null) {
+            builder.write(' ');
+            builder.addSimpleLinkedEdit('NAME', constructorName);
+          }
         } else {
           builder.write(_targetClass.namePart.typeName.lexeme);
-        }
-        if (constructorName != null && constructorName != 'new') {
-          builder.write('.');
-          builder.addSimpleLinkedEdit('NAME', constructorName);
+          if (constructorName != null) {
+            builder.write('.');
+            builder.addSimpleLinkedEdit('NAME', constructorName);
+          }
         }
         builder.write('(');
 

--- a/pkg/analysis_server/lib/src/services/correction/dart/create_constructor_super.dart
+++ b/pkg/analysis_server/lib/src/services/correction/dart/create_constructor_super.dart
@@ -158,13 +158,13 @@ class _CreateConstructor extends ResolvedCorrectionProducer {
 
         if (isEnabled(Feature.primary_constructors)) {
           builder.write('new');
-          if (constructorName != null) {
+          if (constructorName != null && constructorName != 'new') {
             builder.write(' ');
             builder.addSimpleLinkedEdit('NAME', constructorName);
           }
         } else {
           builder.write(_targetClass.namePart.typeName.lexeme);
-          if (constructorName != null) {
+          if (constructorName != null && constructorName != 'new') {
             builder.write('.');
             builder.addSimpleLinkedEdit('NAME', constructorName);
           }
@@ -212,13 +212,13 @@ class _CreateConstructor extends ResolvedCorrectionProducer {
 
         if (isEnabled(Feature.primary_constructors)) {
           builder.write('new');
-          if (constructorName != null) {
+          if (constructorName != null && constructorName != 'new') {
             builder.write(' ');
             builder.addSimpleLinkedEdit('NAME', constructorName);
           }
         } else {
           builder.write(_targetClass.namePart.typeName.lexeme);
-          if (constructorName != null) {
+          if (constructorName != null && constructorName != 'new') {
             builder.write('.');
             builder.addSimpleLinkedEdit('NAME', constructorName);
           }

--- a/pkg/analysis_server/lib/src/services/correction/dart/create_constructor_super.dart
+++ b/pkg/analysis_server/lib/src/services/correction/dart/create_constructor_super.dart
@@ -156,7 +156,11 @@ class _CreateConstructor extends ResolvedCorrectionProducer {
           }
         }
 
-        builder.write(_targetClass.namePart.typeName.lexeme);
+        if (isEnabled(Feature.primary_constructors) && constructorName == null) {
+          builder.write('new');
+        } else {
+          builder.write(_targetClass.namePart.typeName.lexeme);
+        }
         if (constructorName != null && constructorName != 'new') {
           builder.write('.');
           builder.addSimpleLinkedEdit('NAME', constructorName);
@@ -202,7 +206,11 @@ class _CreateConstructor extends ResolvedCorrectionProducer {
           builder.write(parameterName);
         }
 
-        builder.write(_targetClass.namePart.typeName.lexeme);
+        if (isEnabled(Feature.primary_constructors) && constructorName == null) {
+          builder.write('new');
+        } else {
+          builder.write(_targetClass.namePart.typeName.lexeme);
+        }
         if (constructorName != null && constructorName != 'new') {
           builder.write('.');
           builder.addSimpleLinkedEdit('NAME', constructorName);

--- a/pkg/analysis_server/test/edit/refactoring_test.dart
+++ b/pkg/analysis_server/test/edit/refactoring_test.dart
@@ -2269,7 +2269,7 @@ enum E {
 enum E {
   v1.newName(), v2.newName();
 
-  const E.newName();
+  const new newName();
 }
 ''',
       feedbackValidator: (feedback) {

--- a/pkg/analysis_server/test/lsp/completion_dart_test.dart
+++ b/pkg/analysis_server/test/lsp/completion_dart_test.dart
@@ -5497,7 +5497,7 @@ import 'package:flutter/widgets.dart';
 class A {}
 
 class \${1:MyWidget} extends StatefulWidget {
-  const \${1:MyWidget}$expectedWidgetConstructorParams;
+  const new$expectedWidgetConstructorParams;
 
   @override
   State<\${1:MyWidget}> createState() => _\${1:MyWidget}State();
@@ -5540,7 +5540,7 @@ import 'package:flutter/widgets.dart';
 class A {}
 
 class \${1:MyWidget} extends StatefulWidget {
-  const \${1:MyWidget}$expectedWidgetConstructorParams;
+  const new$expectedWidgetConstructorParams;
 
   @override
   State<\${1:MyWidget}> createState() => _\${1:MyWidget}State();
@@ -5598,7 +5598,7 @@ import 'package:flutter/widgets.dart';
 class A {}
 
 class \${1:MyWidget} extends StatelessWidget {
-  const \${1:MyWidget}$expectedWidgetConstructorParams;
+  const new$expectedWidgetConstructorParams;
 
   @override
   Widget build(BuildContext context) {
@@ -5634,7 +5634,7 @@ $expectedImports
 class A {}
 
 class \${1:MyWidget} extends StatelessWidget {
-  const \${1:MyWidget}$expectedWidgetConstructorParams;
+  const new$expectedWidgetConstructorParams;
 
   @override
   Widget build(BuildContext context) {
@@ -5664,7 +5664,7 @@ stless^
 $expectedImports
 
 class \${1:MyWidget} extends StatelessWidget {
-  const \${1:MyWidget}$expectedWidgetConstructorParams;
+  const new$expectedWidgetConstructorParams;
 
   @override
   Widget build(BuildContext context) {
@@ -5692,7 +5692,7 @@ class \${1:MyWidget} extends StatelessWidget {
 $expectedImports
 
 class \${1:MyWidget} extends StatelessWidget {
-  const \${1:MyWidget}$expectedWidgetConstructorParams;
+  const new$expectedWidgetConstructorParams;
 
   @override
   Widget build(BuildContext context) {

--- a/pkg/analysis_server/test/lsp/completion_dart_test.dart
+++ b/pkg/analysis_server/test/lsp/completion_dart_test.dart
@@ -5497,7 +5497,7 @@ import 'package:flutter/widgets.dart';
 class A {}
 
 class \${1:MyWidget} extends StatefulWidget {
-  const new$expectedWidgetConstructorParams;
+  const \${1:MyWidget}$expectedWidgetConstructorParams;
 
   @override
   State<\${1:MyWidget}> createState() => _\${1:MyWidget}State();
@@ -5540,7 +5540,7 @@ import 'package:flutter/widgets.dart';
 class A {}
 
 class \${1:MyWidget} extends StatefulWidget {
-  const new$expectedWidgetConstructorParams;
+  const \${1:MyWidget}$expectedWidgetConstructorParams;
 
   @override
   State<\${1:MyWidget}> createState() => _\${1:MyWidget}State();
@@ -5598,7 +5598,7 @@ import 'package:flutter/widgets.dart';
 class A {}
 
 class \${1:MyWidget} extends StatelessWidget {
-  const new$expectedWidgetConstructorParams;
+  const \${1:MyWidget}$expectedWidgetConstructorParams;
 
   @override
   Widget build(BuildContext context) {
@@ -5634,7 +5634,7 @@ $expectedImports
 class A {}
 
 class \${1:MyWidget} extends StatelessWidget {
-  const new$expectedWidgetConstructorParams;
+  const \${1:MyWidget}$expectedWidgetConstructorParams;
 
   @override
   Widget build(BuildContext context) {
@@ -5664,7 +5664,7 @@ stless^
 $expectedImports
 
 class \${1:MyWidget} extends StatelessWidget {
-  const new$expectedWidgetConstructorParams;
+  const \${1:MyWidget}$expectedWidgetConstructorParams;
 
   @override
   Widget build(BuildContext context) {
@@ -5692,7 +5692,7 @@ class \${1:MyWidget} extends StatelessWidget {
 $expectedImports
 
 class \${1:MyWidget} extends StatelessWidget {
-  const new$expectedWidgetConstructorParams;
+  const \${1:MyWidget}$expectedWidgetConstructorParams;
 
   @override
   Widget build(BuildContext context) {

--- a/pkg/analysis_server/test/services/refactoring/legacy/extract_widget_test.dart
+++ b/pkg/analysis_server/test/services/refactoring/legacy/extract_widget_test.dart
@@ -127,7 +127,7 @@ class MyWidget extends StatelessWidget {
 }
 
 class Test extends StatelessWidget {
-  const Test({
+  const new({
     super.key,
   });
 
@@ -178,7 +178,7 @@ Widget f() {
 }
 
 class Test extends StatelessWidget {
-  const Test({
+  const new({
     super.key,
   });
 
@@ -214,7 +214,7 @@ class MyWidget extends StatelessWidget {
 }
 
 class Test extends StatelessWidget {
-  const Test({
+  const new({
     super.key,
   });
 
@@ -247,7 +247,7 @@ Widget f() {
 }
 
 class Test extends StatelessWidget {
-  const Test({
+  const new({
     super.key,
   });
 
@@ -300,7 +300,7 @@ Widget f() {
 }
 
 class Test extends StatelessWidget {
-  const Test({
+  const new({
     super.key,
   });
 
@@ -403,7 +403,7 @@ class MyWidget extends StatelessWidget {
 }
 
 class Test extends StatelessWidget {
-  const Test({
+  const new({
     super.key,
     required this.c,
   });
@@ -455,7 +455,7 @@ class MyWidget extends StatelessWidget {
 }
 
 class Test extends StatelessWidget {
-  const Test({
+  const new({
     super.key,
   });
 
@@ -519,7 +519,7 @@ class MyWidget extends StatelessWidget {
 }
 
 class Test extends StatelessWidget {
-  const Test({
+  const new({
     super.key,
     required this.foo,
     required this.p1,
@@ -574,7 +574,7 @@ class MyWidget extends StatelessWidget {
 }
 
 class Test extends StatelessWidget {
-  const Test({
+  const new({
     super.key,
     required this.n,
     this.i,
@@ -623,7 +623,7 @@ class MyWidget extends StatelessWidget {
 }
 
 class Test extends StatelessWidget {
-  const Test({
+  const new({
     super.key,
     this.value,
   });
@@ -688,7 +688,7 @@ class MyWidget extends StatelessWidget {
 }
 
 class Test extends StatelessWidget {
-  const Test({
+  const new({
     super.key,
     required this.foo,
     required this.p1,
@@ -747,7 +747,7 @@ class MyWidget extends StatelessWidget {
 }
 
 class Test extends StatelessWidget {
-  const Test({
+  const new({
     super.key,
     required this.c,
   });
@@ -790,7 +790,7 @@ class MyWidget extends StatelessWidget {
 }
 
 class Test extends StatelessWidget {
-  const Test({
+  const new({
     super.key,
   });
 
@@ -898,7 +898,7 @@ class MyWidget extends StatelessWidget {
 }
 
 class Test extends StatelessWidget {
-  const Test({
+  const new({
     super.key,
     required this.c,
   });
@@ -962,7 +962,7 @@ class MyWidget extends StatelessWidget {
 }
 
 class Test extends StatelessWidget {
-  const Test({
+  const new({
     super.key,
     required this.local,
   });
@@ -1032,7 +1032,7 @@ class MyWidget extends StatelessWidget {
 }
 
 class Test extends StatelessWidget {
-  const Test({
+  const new({
     super.key,
     required this._field,
   });
@@ -1081,7 +1081,7 @@ class MyWidget extends StatelessWidget {
 }
 
 class Test extends StatelessWidget {
-  const Test({
+  const new({
     super.key,
     required this.field,
     required String field2,
@@ -1186,7 +1186,7 @@ class MyWidget extends StatelessWidget {
 }
 
 class Test extends StatelessWidget {
-  const Test({
+  const new({
     super.key,
     required this.field,
     required this.local,
@@ -1251,7 +1251,7 @@ Widget f() {
 }
 
 class Test extends StatelessWidget {
-  const Test({
+  const new({
     super.key,
     required this.index,
     required this.a,
@@ -1416,7 +1416,7 @@ class _MyWidgetState extends State<MyWidget> {
 }
 
 class Test extends StatelessWidget {
-  const Test({
+  const new({
     super.key,
     required this.widget,
   });

--- a/pkg/analysis_server/test/services/refactoring/legacy/extract_widget_test.dart
+++ b/pkg/analysis_server/test/services/refactoring/legacy/extract_widget_test.dart
@@ -127,7 +127,7 @@ class MyWidget extends StatelessWidget {
 }
 
 class Test extends StatelessWidget {
-  const Test({
+  const new({
     super.key,
   });
 
@@ -178,7 +178,7 @@ Widget f() {
 }
 
 class Test extends StatelessWidget {
-  const Test({
+  const new({
     super.key,
   });
 
@@ -214,7 +214,7 @@ class MyWidget extends StatelessWidget {
 }
 
 class Test extends StatelessWidget {
-  const Test({
+  const new({
     super.key,
   });
 
@@ -247,7 +247,7 @@ Widget f() {
 }
 
 class Test extends StatelessWidget {
-  const Test({
+  const new({
     super.key,
   });
 
@@ -300,7 +300,7 @@ Widget f() {
 }
 
 class Test extends StatelessWidget {
-  const Test({
+  const new({
     super.key,
   });
 
@@ -403,7 +403,7 @@ class MyWidget extends StatelessWidget {
 }
 
 class Test extends StatelessWidget {
-  const Test({
+  const new({
     super.key,
     required this.c,
   });
@@ -455,7 +455,7 @@ class MyWidget extends StatelessWidget {
 }
 
 class Test extends StatelessWidget {
-  const Test({
+  const new({
     super.key,
   });
 
@@ -519,7 +519,7 @@ class MyWidget extends StatelessWidget {
 }
 
 class Test extends StatelessWidget {
-  const Test({
+  const new({
     super.key,
     required this.foo,
     required this.p1,
@@ -574,7 +574,7 @@ class MyWidget extends StatelessWidget {
 }
 
 class Test extends StatelessWidget {
-  const Test({
+  const new({
     super.key,
     required this.n,
     this.i,
@@ -623,7 +623,7 @@ class MyWidget extends StatelessWidget {
 }
 
 class Test extends StatelessWidget {
-  const Test({
+  const new({
     super.key,
     this.value,
   });
@@ -688,7 +688,7 @@ class MyWidget extends StatelessWidget {
 }
 
 class Test extends StatelessWidget {
-  const Test({
+  const new({
     super.key,
     required this.foo,
     required this.p1,
@@ -747,7 +747,7 @@ class MyWidget extends StatelessWidget {
 }
 
 class Test extends StatelessWidget {
-  const Test({
+  const new({
     super.key,
     required this.c,
   });
@@ -790,7 +790,7 @@ class MyWidget extends StatelessWidget {
 }
 
 class Test extends StatelessWidget {
-  const Test({
+  const new({
     super.key,
   });
 
@@ -898,7 +898,7 @@ class MyWidget extends StatelessWidget {
 }
 
 class Test extends StatelessWidget {
-  const Test({
+  const new({
     super.key,
     required this.c,
   });
@@ -962,7 +962,7 @@ class MyWidget extends StatelessWidget {
 }
 
 class Test extends StatelessWidget {
-  const Test({
+  const new({
     super.key,
     required this.local,
   });
@@ -1032,7 +1032,7 @@ class MyWidget extends StatelessWidget {
 }
 
 class Test extends StatelessWidget {
-  const Test({
+  const new({
     super.key,
     required this._field,
   });
@@ -1081,7 +1081,7 @@ class MyWidget extends StatelessWidget {
 }
 
 class Test extends StatelessWidget {
-  const Test({
+  const new({
     super.key,
     required this.field,
     required String field2,
@@ -1186,7 +1186,7 @@ class MyWidget extends StatelessWidget {
 }
 
 class Test extends StatelessWidget {
-  const Test({
+  const new({
     super.key,
     required this.field,
     required this.local,
@@ -1251,7 +1251,7 @@ Widget f() {
 }
 
 class Test extends StatelessWidget {
-  const Test({
+  const new({
     super.key,
     required this.index,
     required this.a,
@@ -1351,7 +1351,7 @@ class MyWidget extends StatelessWidget {
 }
 
 class Test extends StatelessWidget {
-  const Test({
+  const new({
     Key? key,
   }) : super(key: key);
 
@@ -1416,7 +1416,7 @@ class _MyWidgetState extends State<MyWidget> {
 }
 
 class Test extends StatelessWidget {
-  const Test({
+  const new({
     super.key,
     required this.widget,
   });

--- a/pkg/analysis_server/test/services/refactoring/legacy/extract_widget_test.dart
+++ b/pkg/analysis_server/test/services/refactoring/legacy/extract_widget_test.dart
@@ -1351,7 +1351,7 @@ class MyWidget extends StatelessWidget {
 }
 
 class Test extends StatelessWidget {
-  const new({
+  const Test({
     Key? key,
   }) : super(key: key);
 

--- a/pkg/analysis_server/test/services/refactoring/legacy/extract_widget_test.dart
+++ b/pkg/analysis_server/test/services/refactoring/legacy/extract_widget_test.dart
@@ -127,7 +127,7 @@ class MyWidget extends StatelessWidget {
 }
 
 class Test extends StatelessWidget {
-  const new({
+  const Test({
     super.key,
   });
 
@@ -178,7 +178,7 @@ Widget f() {
 }
 
 class Test extends StatelessWidget {
-  const new({
+  const Test({
     super.key,
   });
 
@@ -214,7 +214,7 @@ class MyWidget extends StatelessWidget {
 }
 
 class Test extends StatelessWidget {
-  const new({
+  const Test({
     super.key,
   });
 
@@ -247,7 +247,7 @@ Widget f() {
 }
 
 class Test extends StatelessWidget {
-  const new({
+  const Test({
     super.key,
   });
 
@@ -300,7 +300,7 @@ Widget f() {
 }
 
 class Test extends StatelessWidget {
-  const new({
+  const Test({
     super.key,
   });
 
@@ -403,7 +403,7 @@ class MyWidget extends StatelessWidget {
 }
 
 class Test extends StatelessWidget {
-  const new({
+  const Test({
     super.key,
     required this.c,
   });
@@ -455,7 +455,7 @@ class MyWidget extends StatelessWidget {
 }
 
 class Test extends StatelessWidget {
-  const new({
+  const Test({
     super.key,
   });
 
@@ -519,7 +519,7 @@ class MyWidget extends StatelessWidget {
 }
 
 class Test extends StatelessWidget {
-  const new({
+  const Test({
     super.key,
     required this.foo,
     required this.p1,
@@ -574,7 +574,7 @@ class MyWidget extends StatelessWidget {
 }
 
 class Test extends StatelessWidget {
-  const new({
+  const Test({
     super.key,
     required this.n,
     this.i,
@@ -623,7 +623,7 @@ class MyWidget extends StatelessWidget {
 }
 
 class Test extends StatelessWidget {
-  const new({
+  const Test({
     super.key,
     this.value,
   });
@@ -688,7 +688,7 @@ class MyWidget extends StatelessWidget {
 }
 
 class Test extends StatelessWidget {
-  const new({
+  const Test({
     super.key,
     required this.foo,
     required this.p1,
@@ -747,7 +747,7 @@ class MyWidget extends StatelessWidget {
 }
 
 class Test extends StatelessWidget {
-  const new({
+  const Test({
     super.key,
     required this.c,
   });
@@ -790,7 +790,7 @@ class MyWidget extends StatelessWidget {
 }
 
 class Test extends StatelessWidget {
-  const new({
+  const Test({
     super.key,
   });
 
@@ -898,7 +898,7 @@ class MyWidget extends StatelessWidget {
 }
 
 class Test extends StatelessWidget {
-  const new({
+  const Test({
     super.key,
     required this.c,
   });
@@ -962,7 +962,7 @@ class MyWidget extends StatelessWidget {
 }
 
 class Test extends StatelessWidget {
-  const new({
+  const Test({
     super.key,
     required this.local,
   });
@@ -1032,7 +1032,7 @@ class MyWidget extends StatelessWidget {
 }
 
 class Test extends StatelessWidget {
-  const new({
+  const Test({
     super.key,
     required this._field,
   });
@@ -1081,7 +1081,7 @@ class MyWidget extends StatelessWidget {
 }
 
 class Test extends StatelessWidget {
-  const new({
+  const Test({
     super.key,
     required this.field,
     required String field2,
@@ -1186,7 +1186,7 @@ class MyWidget extends StatelessWidget {
 }
 
 class Test extends StatelessWidget {
-  const new({
+  const Test({
     super.key,
     required this.field,
     required this.local,
@@ -1251,7 +1251,7 @@ Widget f() {
 }
 
 class Test extends StatelessWidget {
-  const new({
+  const Test({
     super.key,
     required this.index,
     required this.a,
@@ -1416,7 +1416,7 @@ class _MyWidgetState extends State<MyWidget> {
 }
 
 class Test extends StatelessWidget {
-  const new({
+  const Test({
     super.key,
     required this.widget,
   });

--- a/pkg/analysis_server/test/services/refactoring/legacy/rename_constructor_test.dart
+++ b/pkg/analysis_server/test/services/refactoring/legacy/rename_constructor_test.dart
@@ -170,7 +170,7 @@ void f() {
 class A {
   int field = 0;
 
-  A.newName();
+  new newName();
 }
 class B extends A {
   B() : super.newName() {}
@@ -468,7 +468,7 @@ void f() {
     refactoring.newName = 'newName';
     return assertSuccessfulRefactoring('''
 class A {
-  A.newName();
+  new newName();
 
   int field = 0;
 }
@@ -752,7 +752,7 @@ enum E {
 
   factory E.other() => throw 0;
 
-  const E.newName();
+  const new newName();
 }
 ''');
   }
@@ -780,7 +780,7 @@ enum E {
 
   final int foo = 0;
 
-  const E.newName();
+  const new newName();
 }
 ''');
   }
@@ -806,7 +806,7 @@ enum E {
 enum E {
   v1.newName(), v2.newName(), v3.newName();
 
-  const E.newName();
+  const new newName();
 
   void foo() {}
 }
@@ -832,7 +832,7 @@ enum E {
 enum E {
   v1.newName(), v2.newName(), v3.newName();
 
-  const E.newName();
+  const new newName();
 }
 ''');
   }
@@ -856,7 +856,7 @@ enum E {
 enum E {
   v1.newName(), v2.newName(), v3.newName();
 
-  const E.newName();
+  const new newName();
 }
 ''');
   }

--- a/pkg/analysis_server/test/services/snippets/dart/flutter_stateful_widget_test.dart
+++ b/pkg/analysis_server/test/services/snippets/dart/flutter_stateful_widget_test.dart
@@ -61,13 +61,13 @@ class _/*4*/MyWidgetState extends State</*5*/MyWidget> {
 import 'package:flutter/widgets.dart';
 
 class /*0*/MyWidget extends StatefulWidget {
-  const /*1*/MyWidget({super.key});
+  const new({super.key});
 
   @override
-  State</*2*/MyWidget> createState() => _/*3*/MyWidgetState();
+  State</*1*/MyWidget> createState() => _/*2*/MyWidgetState();
 }
 
-class _/*4*/MyWidgetState extends State</*5*/MyWidget> {
+class _/*3*/MyWidgetState extends State</*4*/MyWidget> {
   @override
   Widget build(BuildContext context) {
     return /*[0*/const Placeholder()/*0]*/;

--- a/pkg/analysis_server/test/services/snippets/dart/flutter_stateful_widget_test.dart
+++ b/pkg/analysis_server/test/services/snippets/dart/flutter_stateful_widget_test.dart
@@ -61,13 +61,13 @@ class _/*4*/MyWidgetState extends State</*5*/MyWidget> {
 import 'package:flutter/widgets.dart';
 
 class /*0*/MyWidget extends StatefulWidget {
-  const new({super.key});
+  const /*1*/MyWidget({super.key});
 
   @override
-  State</*1*/MyWidget> createState() => _/*2*/MyWidgetState();
+  State</*2*/MyWidget> createState() => _/*3*/MyWidgetState();
 }
 
-class _/*3*/MyWidgetState extends State</*4*/MyWidget> {
+class _/*4*/MyWidgetState extends State</*5*/MyWidget> {
   @override
   Widget build(BuildContext context) {
     return /*[0*/const Placeholder()/*0]*/;

--- a/pkg/analysis_server/test/services/snippets/dart/flutter_stateful_widget_with_animation_controller_test.dart
+++ b/pkg/analysis_server/test/services/snippets/dart/flutter_stateful_widget_with_animation_controller_test.dart
@@ -77,13 +77,13 @@ class _/*4*/MyWidgetState extends State</*5*/MyWidget>
 import 'package:flutter/widgets.dart';
 
 class /*0*/MyWidget extends StatefulWidget {
-  const /*1*/MyWidget({super.key});
+  const new({super.key});
 
   @override
-  State</*2*/MyWidget> createState() => _/*3*/MyWidgetState();
+  State</*1*/MyWidget> createState() => _/*2*/MyWidgetState();
 }
 
-class _/*4*/MyWidgetState extends State</*5*/MyWidget>
+class _/*3*/MyWidgetState extends State</*4*/MyWidget>
     with SingleTickerProviderStateMixin {
   late AnimationController _controller;
 

--- a/pkg/analysis_server/test/services/snippets/dart/flutter_stateful_widget_with_animation_controller_test.dart
+++ b/pkg/analysis_server/test/services/snippets/dart/flutter_stateful_widget_with_animation_controller_test.dart
@@ -77,13 +77,13 @@ class _/*4*/MyWidgetState extends State</*5*/MyWidget>
 import 'package:flutter/widgets.dart';
 
 class /*0*/MyWidget extends StatefulWidget {
-  const new({super.key});
+  const /*1*/MyWidget({super.key});
 
   @override
-  State</*1*/MyWidget> createState() => _/*2*/MyWidgetState();
+  State</*2*/MyWidget> createState() => _/*3*/MyWidgetState();
 }
 
-class _/*3*/MyWidgetState extends State</*4*/MyWidget>
+class _/*4*/MyWidgetState extends State</*5*/MyWidget>
     with SingleTickerProviderStateMixin {
   late AnimationController _controller;
 

--- a/pkg/analysis_server/test/services/snippets/dart/flutter_stateless_widget_test.dart
+++ b/pkg/analysis_server/test/services/snippets/dart/flutter_stateless_widget_test.dart
@@ -56,7 +56,7 @@ class /*0*/MyWidget extends StatelessWidget {
 import 'package:flutter/widgets.dart';
 
 class /*0*/MyWidget extends StatelessWidget {
-  const /*1*/MyWidget({super.key});
+  const new({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/pkg/analysis_server/test/services/snippets/dart/flutter_stateless_widget_test.dart
+++ b/pkg/analysis_server/test/services/snippets/dart/flutter_stateless_widget_test.dart
@@ -56,7 +56,7 @@ class /*0*/MyWidget extends StatelessWidget {
 import 'package:flutter/widgets.dart';
 
 class /*0*/MyWidget extends StatelessWidget {
-  const new({super.key});
+  const /*1*/MyWidget({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/pkg/analysis_server/test/shared/shared_code_actions_refactor_tests.dart
+++ b/pkg/analysis_server/test/shared/shared_code_actions_refactor_tests.dart
@@ -673,7 +673,7 @@ mixin SharedExtractWidgetRefactorCodeActionsTests
   final extractWidgetTitle = 'Extract Widget';
 
   String get expectedNewWidgetConstructorDeclaration => '''
-const NewWidget({
+const new({
     super.key,
   });
 ''';

--- a/pkg/analysis_server/test/src/cider/rename_test.dart
+++ b/pkg/analysis_server/test/src/cider/rename_test.dart
@@ -446,7 +446,7 @@ void f() {
 class A {
   int field = 0;
 
-  A.newName();
+  new newName();
 }
 class B extends A {
   B() : super.newName() {}
@@ -740,7 +740,7 @@ enum E {
 
   factory E.other() => throw 0;
 
-  const E.newName();
+  const new newName();
 }
 ''', result!.replaceMatches.first.matches);
   }
@@ -763,7 +763,7 @@ enum E {
 
   final int foo = 0;
 
-  const E.newName();
+  const new newName();
 }
 ''', result!.replaceMatches.first.matches);
   }
@@ -784,7 +784,7 @@ enum E {
 enum E {
   v1.newName(), v2.newName(), v3.newName();
 
-  const E.newName();
+  const new newName();
 
   void foo() {}
 }

--- a/pkg/analysis_server/test/src/services/correction/fix/create_class_test.dart
+++ b/pkg/analysis_server/test/src/services/correction/fix/create_class_test.dart
@@ -292,14 +292,10 @@ void f() {}
 void f() {}
 
 class Test {
-  const Test(String s);
+  const new(String s);
 }
 ''');
-    assertLinkedGroup(change.linkedEditGroups[0], [
-      "Test('",
-      'Test {',
-      'Test(S',
-    ]);
+    assertLinkedGroup(change.linkedEditGroups[0], ["Test('", 'Test {']);
   }
 
   Future<void> test_class_instanceMember() async {
@@ -437,7 +433,7 @@ void f() {
 }
 
 class Test {
-  const Test();
+  const new();
 }
 ''');
   }
@@ -468,7 +464,7 @@ const v = Test();
 const v = Test();
 
 class Test {
-  const Test();
+  const new();
 }
 ''',
       filter: (e) {

--- a/pkg/analysis_server/test/src/services/correction/fix/create_class_test.dart
+++ b/pkg/analysis_server/test/src/services/correction/fix/create_class_test.dart
@@ -292,10 +292,14 @@ void f() {}
 void f() {}
 
 class Test {
-  const new(String s);
+  const Test(String s);
 }
 ''');
-    assertLinkedGroup(change.linkedEditGroups[0], ["Test('", 'Test {']);
+    assertLinkedGroup(change.linkedEditGroups[0], [
+      "Test('",
+      'Test {',
+      'Test(S',
+    ]);
   }
 
   Future<void> test_class_instanceMember() async {
@@ -433,7 +437,7 @@ void f() {
 }
 
 class Test {
-  const new();
+  const Test();
 }
 ''');
   }
@@ -464,7 +468,7 @@ const v = Test();
 const v = Test();
 
 class Test {
-  const new();
+  const Test();
 }
 ''',
       filter: (e) {

--- a/pkg/analysis_server/test/src/services/correction/fix/create_constructor_for_final_fields_test.dart
+++ b/pkg/analysis_server/test/src/services/correction/fix/create_constructor_for_final_fields_test.dart
@@ -360,32 +360,6 @@ class Test {
     );
   }
 
-  Future<void> test_enum() async {
-    await resolveTestCode('''
-enum E {
-  v(a: 0, c: 2);
-  final int a;
-  final int b = 1;
-  final int c;
-}
-''');
-    await assertHasFix(
-      '''
-enum E {
-  v(a: 0, c: 2);
-  final int a;
-  final int b = 1;
-  final int c;
-
-  const new({required this.a, required this.c});
-}
-''',
-      filter: (error) {
-        return error.message.contains("'a' must be initialized");
-      },
-    );
-  }
-
   Future<void> test_class_noSuperClass_withoutPrimaryConstructors() async {
     await resolveTestCode('''
 // @dart=3.10
@@ -408,6 +382,32 @@ class Test {
 ''',
       filter: (error) {
         return error.message.contains("'a'");
+      },
+    );
+  }
+
+  Future<void> test_enum() async {
+    await resolveTestCode('''
+enum E {
+  v(a: 0, c: 2);
+  final int a;
+  final int b = 1;
+  final int c;
+}
+''');
+    await assertHasFix(
+      '''
+enum E {
+  v(a: 0, c: 2);
+  final int a;
+  final int b = 1;
+  final int c;
+
+  const new({required this.a, required this.c});
+}
+''',
+      filter: (error) {
+        return error.message.contains("'a' must be initialized");
       },
     );
   }
@@ -606,32 +606,6 @@ class Test {
     );
   }
 
-  Future<void> test_enum_simple() async {
-    await resolveTestCode('''
-enum E {
-  v(0, 2);
-  final int a;
-  final int b = 1;
-  final int c;
-}
-''');
-    await assertHasFix(
-      '''
-enum E {
-  v(0, 2);
-  final int a;
-  final int b = 1;
-  final int c;
-
-  const new(this.a, this.c);
-}
-''',
-      filter: (error) {
-        return error.message.contains("'a'");
-      },
-    );
-  }
-
   Future<void> test_class_simple_withoutPrimaryConstructors() async {
     await resolveTestCode('''
 // @dart=3.10
@@ -650,6 +624,32 @@ class Test {
   final int c;
 
   Test(this.a, this.c);
+}
+''',
+      filter: (error) {
+        return error.message.contains("'a'");
+      },
+    );
+  }
+
+  Future<void> test_enum_simple() async {
+    await resolveTestCode('''
+enum E {
+  v(0, 2);
+  final int a;
+  final int b = 1;
+  final int c;
+}
+''');
+    await assertHasFix(
+      '''
+enum E {
+  v(0, 2);
+  final int a;
+  final int b = 1;
+  final int c;
+
+  const new(this.a, this.c);
 }
 ''',
       filter: (error) {

--- a/pkg/analysis_server/test/src/services/correction/fix/create_constructor_for_final_fields_test.dart
+++ b/pkg/analysis_server/test/src/services/correction/fix/create_constructor_for_final_fields_test.dart
@@ -39,7 +39,7 @@ class Test {
   final int a;
   late final int b;
 
-  Test({required this.a});
+  new({required this.a});
 }
 ''');
   }
@@ -60,7 +60,7 @@ import 'package:flutter/widgets.dart';
 class Test extends StatelessWidget {
   final int _a;
 
-  const Test({super.key, required this._a});
+  const new({super.key, required this._a});
 }
 ''',
       filter: (error) {
@@ -88,7 +88,7 @@ import 'package:flutter/widgets.dart';
 class Test extends StatelessWidget {
   final int _a;
 
-  const Test({required this._a, super.key});
+  const new({required this._a, super.key});
 }
 ''',
       filter: (error) {
@@ -127,7 +127,7 @@ class Base extends StatelessWidget {
 class Test extends Base {
   final int other;
 
-  Test({required this.other, super.key, super.a});
+  new({required this.other, super.key, super.a});
 }
 ''');
   }
@@ -159,7 +159,7 @@ class B extends A {
   final int f21;
   final int f22;
 
-  B({super.f11, super.f12, required this.f21, required this.f22});
+  new({super.f11, super.f12, required this.f21, required this.f22});
 }
 ''',
       filter: (error) {
@@ -195,7 +195,7 @@ class B extends A {
   final int f21;
   final int f22;
 
-  B({required super.f11, required super.f12, required this.f21, required this.f22});
+  new({required super.f11, required super.f12, required this.f21, required this.f22});
 }
 ''',
       filter: (error) {
@@ -234,7 +234,7 @@ class B extends A {
   final int? f21;
   int? f22;
 
-  B({required super.f12, required this.f21, super.f11});
+  new({required super.f12, required this.f21, super.f11});
 }
 ''',
       filter: (error) {
@@ -255,7 +255,7 @@ class Test {
     await assertHasFix(
       '''
 class Test {
-  Test({required this.a, required this.c});
+  new({required this.a, required this.c});
 
   final int a;
   final int b = 2;
@@ -283,7 +283,7 @@ class Test {
   final int b = 2;
   final int c;
 
-  Test({required this.a, required this.c});
+  new({required this.a, required this.c});
 }
 ''',
       filter: (error) {
@@ -307,7 +307,7 @@ class Test {
   final int _b;
   final int c;
 
-  Test({required this._a, required this._b, required this.c});
+  new({required this._a, required this._b, required this.c});
 }
 ''',
       filter: (error) {
@@ -377,11 +377,37 @@ enum E {
   final int b = 1;
   final int c;
 
-  const E({required this.a, required this.c});
+  const new({required this.a, required this.c});
 }
 ''',
       filter: (error) {
         return error.message.contains("'a' must be initialized");
+      },
+    );
+  }
+
+  Future<void> test_class_noSuperClass_withoutPrimaryConstructors() async {
+    await resolveTestCode('''
+// @dart=3.10
+class Test {
+  final int a;
+  final int b = 2;
+  final int c;
+}
+''');
+    await assertHasFix(
+      '''
+// @dart=3.10
+class Test {
+  final int a;
+  final int b = 2;
+  final int c;
+
+  Test({required this.a, required this.c});
+}
+''',
+      filter: (error) {
+        return error.message.contains("'a'");
       },
     );
   }
@@ -405,7 +431,7 @@ class Test {
   final int a;
   late final int b;
 
-  Test(this.a);
+  new(this.a);
 }
 ''');
   }
@@ -430,7 +456,7 @@ class MyWidget extends StatelessWidget {
   final int b = 2;
   final int? c;
 
-  const MyWidget({super.key, required this.a, this.c});
+  const new({super.key, required this.a, this.c});
 }
 ''',
       filter: (error) {
@@ -459,7 +485,7 @@ class MyWidget extends StatelessWidget {
   final Widget child;
   final int? b;
 
-  const MyWidget({super.key, required this.a, this.b, required this.child});
+  const new({super.key, required this.a, this.b, required this.child});
 }
 ''',
       filter: (error) {
@@ -488,7 +514,7 @@ class MyWidget extends StatelessWidget {
   final List<Widget> children;
   final int? b;
 
-  const MyWidget({super.key, required this.a, this.b, required this.children});
+  const new({super.key, required this.a, this.b, required this.children});
 }
 ''',
       filter: (error) {
@@ -512,7 +538,7 @@ class Test {
   final int _b;
   final int c;
 
-  Test(this.a, this._b, this.c);
+  new(this.a, this._b, this.c);
 }
 ''',
       filter: (error) {
@@ -543,7 +569,7 @@ class Test {
     await assertHasFix(
       '''
 class Test {
-  Test(this.a, this.c);
+  new(this.a, this.c);
 
   final int a;
   final int b = 2;
@@ -571,7 +597,7 @@ class Test {
   final int b = 2;
   final int c;
 
-  Test(this.a, this.c);
+  new(this.a, this.c);
 }
 ''',
       filter: (error) {
@@ -597,7 +623,33 @@ enum E {
   final int b = 1;
   final int c;
 
-  const E(this.a, this.c);
+  const new(this.a, this.c);
+}
+''',
+      filter: (error) {
+        return error.message.contains("'a'");
+      },
+    );
+  }
+
+  Future<void> test_class_simple_withoutPrimaryConstructors() async {
+    await resolveTestCode('''
+// @dart=3.10
+class Test {
+  final int a;
+  final int b = 2;
+  final int c;
+}
+''');
+    await assertHasFix(
+      '''
+// @dart=3.10
+class Test {
+  final int a;
+  final int b = 2;
+  final int c;
+
+  Test(this.a, this.c);
 }
 ''',
       filter: (error) {

--- a/pkg/analysis_server/test/src/services/correction/fix/create_constructor_super_test.dart
+++ b/pkg/analysis_server/test/src/services/correction/fix/create_constructor_super_test.dart
@@ -214,18 +214,6 @@ class B extends A {
 ''', matchFixMessage: 'Create constructor to call super.named()');
   }
 
-  Future<void>
-  test_namedConstructor_withPrimaryConstructors_alreadyExists() async {
-    await resolveTestCode('''
-class A(final int field) {}
-
-class B extends A {
-  new(super.field);
-}
-''');
-    await assertNoFix();
-  }
-
   Future<void> test_namedOptionalParams() async {
     await resolveTestCode('''
 class A {

--- a/pkg/analysis_server/test/src/services/correction/fix/create_constructor_super_test.dart
+++ b/pkg/analysis_server/test/src/services/correction/fix/create_constructor_super_test.dart
@@ -30,7 +30,7 @@ class B extends A {}
 class A(final int field) {}
 
 class B extends A {
-  B(super.field);
+  new(super.field);
 }
 ''', matchFixMessage: 'Create constructor to call super.');
   }
@@ -45,7 +45,7 @@ class B extends A;
 class A(final int field);
 
 class B extends A {
-  B(super.field);
+  new(super.field);
 }
 ''', matchFixMessage: 'Create constructor to call super.');
   }
@@ -72,7 +72,7 @@ class A {
 class B extends A {
   int existingField = 0;
 
-  B(super.field);
+  new(super.field);
 
   void existingMethod() {}
 }
@@ -100,7 +100,7 @@ class C extends B {
 import 'package:test/b.dart';
 
 class C extends B {
-  C(super.a);
+  new(super.a);
 }
 ''');
   }
@@ -125,7 +125,7 @@ class A {
   int field;
 }
 class B extends A {
-  B(super.field);
+  new(super.field);
 
   int existingField = 0;
   void existingMethod() {}
@@ -176,7 +176,7 @@ class A {
 class B extends A {
   int existingField = 0;
 
-  B(super.p1, super.p2, super.p3);
+  new(super.p1, super.p2, super.p3);
 
   void existingMethod() {}
 }
@@ -201,7 +201,7 @@ class A {
 class B extends A {
   int existingField = 0;
 
-  B(super.p1, super.p2, super.p3, {required super.p4, required super.p5});
+  new(super.p1, super.p2, super.p3, {required super.p4, required super.p5});
 
   void existingMethod() {}
 }
@@ -226,7 +226,7 @@ class A {
 class B extends A {
   int existingField = 0;
 
-  B(super.p1, super.p2, super.p3);
+  new(super.p1, super.p2, super.p3);
 
   void existingMethod() {}
 }
@@ -259,7 +259,7 @@ class C<T> {
   C(this.x);
 }
 class D extends C<int> {
-  D(super.x);
+  new(super.x);
 }
 ''');
   }
@@ -286,11 +286,42 @@ class A {
 class B extends A {
   int existingField = 0;
 
-  B(super._);
+  new(super._);
 
   void existingMethod() {}
 }
 ''');
+  }
+
+  Future<void> test_fieldInitializer_withoutPrimaryConstructors() async {
+    await resolveTestCode('''
+// @dart=3.10
+class A {
+  int _field;
+  A(this._field);
+  int get field => _field;
+}
+class B extends A {
+  int existingField = 0;
+
+  void existingMethod() {}
+}
+''');
+    await assertHasFix('''
+// @dart=3.10
+class A {
+  int _field;
+  A(this._field);
+  int get field => _field;
+}
+class B extends A {
+  int existingField = 0;
+
+  B(super.field);
+
+  void existingMethod() {}
+}
+''', matchFixMessage: 'Create constructor to call super.');
   }
 }
 

--- a/pkg/analysis_server/test/src/services/correction/fix/create_constructor_super_test.dart
+++ b/pkg/analysis_server/test/src/services/correction/fix/create_constructor_super_test.dart
@@ -318,7 +318,8 @@ class B extends A {
 ''', matchFixMessage: 'Create constructor to call super.named()');
   }
 
-  Future<void> test_namedConstructor_withPrimaryConstructors_alreadyExists() async {
+  Future<void>
+  test_namedConstructor_withPrimaryConstructors_alreadyExists() async {
     await resolveTestCode('''
 class A(final int field) {}
 

--- a/pkg/analysis_server/test/src/services/correction/fix/create_constructor_super_test.dart
+++ b/pkg/analysis_server/test/src/services/correction/fix/create_constructor_super_test.dart
@@ -79,6 +79,37 @@ class B extends A {
 ''', matchFixMessage: 'Create constructor to call super.');
   }
 
+  Future<void> test_fieldInitializer_withoutPrimaryConstructors() async {
+    await resolveTestCode('''
+// @dart=3.10
+class A {
+  int _field;
+  A(this._field);
+  int get field => _field;
+}
+class B extends A {
+  int existingField = 0;
+
+  void existingMethod() {}
+}
+''');
+    await assertHasFix('''
+// @dart=3.10
+class A {
+  int _field;
+  A(this._field);
+  int get field => _field;
+}
+class B extends A {
+  int existingField = 0;
+
+  B(super.field);
+
+  void existingMethod() {}
+}
+''', matchFixMessage: 'Create constructor to call super.');
+  }
+
   Future<void> test_importType() async {
     newFile('$testPackageLibPath/a.dart', '''
 class A {}
@@ -151,11 +182,48 @@ class A {
 class B extends A {
   int existingField = 0;
 
-  B.named(super.p1, super.p2) : super.named();
+  new named(super.p1, super.p2) : super.named();
 
   void existingMethod() {}
 }
 ''', matchFixMessage: 'Create constructor to call super.named()');
+  }
+
+  Future<void> test_namedConstructor_withPrimaryConstructors() async {
+    await resolveTestCode('''
+class A {
+  A.named(int p1);
+}
+class B extends A {
+  int existingField = 0;
+
+  void existingMethod() {}
+}
+''');
+    await assertHasFix('''
+class A {
+  A.named(int p1);
+}
+class B extends A {
+  int existingField = 0;
+
+  new named(super.p1) : super.named();
+
+  void existingMethod() {}
+}
+''', matchFixMessage: 'Create constructor to call super.named()');
+  }
+
+  Future<void>
+  test_namedConstructor_withPrimaryConstructors_alreadyExists() async {
+    await resolveTestCode('''
+class A(final int field) {}
+
+class B extends A {
+  new(super.field);
+}
+''');
+    await assertNoFix();
   }
 
   Future<void> test_namedOptionalParams() async {
@@ -291,74 +359,6 @@ class B extends A {
   void existingMethod() {}
 }
 ''');
-  }
-
-  Future<void> test_namedConstructor_withPrimaryConstructors() async {
-    await resolveTestCode('''
-class A {
-  A.named(int p1);
-}
-class B extends A {
-  int existingField = 0;
-
-  void existingMethod() {}
-}
-''');
-    await assertHasFix('''
-class A {
-  A.named(int p1);
-}
-class B extends A {
-  int existingField = 0;
-
-  new named(super.p1) : super.named();
-
-  void existingMethod() {}
-}
-''', matchFixMessage: 'Create constructor to call super.named()');
-  }
-
-  Future<void>
-  test_namedConstructor_withPrimaryConstructors_alreadyExists() async {
-    await resolveTestCode('''
-class A(final int field) {}
-
-class B extends A {
-  new(super.field);
-}
-''');
-    await assertNoFix();
-  }
-
-  Future<void> test_fieldInitializer_withoutPrimaryConstructors() async {
-    await resolveTestCode('''
-// @dart=3.10
-class A {
-  int _field;
-  A(this._field);
-  int get field => _field;
-}
-class B extends A {
-  int existingField = 0;
-
-  void existingMethod() {}
-}
-''');
-    await assertHasFix('''
-// @dart=3.10
-class A {
-  int _field;
-  A(this._field);
-  int get field => _field;
-}
-class B extends A {
-  int existingField = 0;
-
-  B(super.field);
-
-  void existingMethod() {}
-}
-''', matchFixMessage: 'Create constructor to call super.');
   }
 }
 

--- a/pkg/analysis_server/test/src/services/correction/fix/create_constructor_super_test.dart
+++ b/pkg/analysis_server/test/src/services/correction/fix/create_constructor_super_test.dart
@@ -295,21 +295,38 @@ class B extends A {
 
   Future<void> test_namedConstructor_withPrimaryConstructors() async {
     await resolveTestCode('''
-class A(final int field) {}
-
+class A {
+  A.named(int p1);
+}
 class B extends A {
-  B.named();
+  int existingField = 0;
+
+  void existingMethod() {}
 }
 ''');
     await assertHasFix('''
+class A {
+  A.named(int p1);
+}
+class B extends A {
+  int existingField = 0;
+
+  new named(super.p1) : super.named();
+
+  void existingMethod() {}
+}
+''', matchFixMessage: 'Create constructor to call super.named()');
+  }
+
+  Future<void> test_namedConstructor_withPrimaryConstructors_alreadyExists() async {
+    await resolveTestCode('''
 class A(final int field) {}
 
 class B extends A {
-  B.named();
-
-  new named(super.field);
+  new(super.field);
 }
-''', matchFixMessage: 'Create constructor to call super.');
+''');
+    await assertNoFix();
   }
 
   Future<void> test_fieldInitializer_withoutPrimaryConstructors() async {

--- a/pkg/analysis_server/test/src/services/correction/fix/create_constructor_super_test.dart
+++ b/pkg/analysis_server/test/src/services/correction/fix/create_constructor_super_test.dart
@@ -293,6 +293,25 @@ class B extends A {
 ''');
   }
 
+  Future<void> test_namedConstructor_withPrimaryConstructors() async {
+    await resolveTestCode('''
+class A(final int field) {}
+
+class B extends A {
+  B.named();
+}
+''');
+    await assertHasFix('''
+class A(final int field) {}
+
+class B extends A {
+  B.named();
+
+  new named(super.field);
+}
+''', matchFixMessage: 'Create constructor to call super.');
+  }
+
   Future<void> test_fieldInitializer_withoutPrimaryConstructors() async {
     await resolveTestCode('''
 // @dart=3.10

--- a/pkg/analysis_server/test/src/services/correction/fix/create_constructor_test.dart
+++ b/pkg/analysis_server/test/src/services/correction/fix/create_constructor_test.dart
@@ -54,7 +54,7 @@ void f() {
     await assertHasFix('''
 /// $_text200
 class A {
-  A(int i, double d);
+  new(int i, double d);
 }
 ''', target: a);
   }
@@ -74,7 +74,7 @@ A f() {
     await assertHasFix('''
 /// $_text200
 class A {
-  A(int i, double d);
+  new(int i, double d);
 }
 ''', target: a);
   }
@@ -94,7 +94,7 @@ void f() {
     await assertHasFix('''
 /// $_text200
 class A {
-  A.named(int i, double d);
+  new named(int i, double d);
 }
 ''', target: a);
   }
@@ -114,7 +114,7 @@ A f() {
     await assertHasFix('''
 /// $_text200
 class A {
-  A.named(int i, double d);
+  new named(int i, double d);
 }
 ''', target: a);
   }
@@ -147,7 +147,7 @@ void f() {
 class A {
   int field = 0;
 
-  A(int i, double d);
+  new(int i, double d);
 
   method() {}
 }
@@ -172,7 +172,7 @@ A f() {
 class A {
   int field = 0;
 
-  A(int i, double d);
+  new(int i, double d);
 
   method() {}
 }
@@ -204,7 +204,7 @@ void f() {
 ''');
     await assertHasFix('''
 class A {
-  A.named(int i, double d);
+  new named(int i, double d);
 
   method() {}
 }
@@ -226,7 +226,7 @@ A f() {
 ''');
     await assertHasFix('''
 class A {
-  A.named(int i, double d);
+  new named(int i, double d);
 
   method() {}
 }
@@ -246,7 +246,7 @@ void f() {
 ''');
     await assertHasFix('''
 class A {
-  A.named(int i);
+  new named(int i);
 }
 void f() {
   new A.named(1);
@@ -264,7 +264,7 @@ A f() {
 ''');
     await assertHasFix('''
 class A {
-  A.named(int i);
+  new named(int i);
 }
 A f() {
   return .named(1);
@@ -285,7 +285,7 @@ enum E {
   c.x();
   const E.y();
 
-  const E.x();
+  const new x();
 }
 ''', matchFixMessage: "Create constructor 'E.x'");
   }
@@ -302,7 +302,7 @@ enum E {
   c;
   const E.x();
 
-  const E();
+  const new();
 }
 ''', matchFixMessage: "Create constructor 'E'");
   }
@@ -319,7 +319,7 @@ enum E {
   c(1);
   const E.x();
 
-  const E(int i);
+  const new(int i);
 }
 ''');
   }
@@ -335,7 +335,7 @@ A f() {
 ''');
     await assertHasFix('''
 class A {
-  A(int i);
+  new(int i);
 
   method() {}
 }

--- a/pkg/analyzer_plugin/lib/src/utilities/change_builder/change_builder_dart.dart
+++ b/pkg/analyzer_plugin/lib/src/utilities/change_builder/change_builder_dart.dart
@@ -186,7 +186,11 @@ class DartEditBuilderImpl extends EditBuilderImpl implements DartEditBuilder {
       addSimpleLinkedEdit(classNameGroupName, className);
     }
     if (constructorName != null) {
-      write('.');
+      if (_featureSet.isEnabled(Feature.primary_constructors)) {
+        write(' ');
+      } else {
+        write('.');
+      }
       if (constructorNameGroupName == null) {
         write(constructorName);
       } else {

--- a/pkg/analyzer_plugin/lib/src/utilities/change_builder/change_builder_dart.dart
+++ b/pkg/analyzer_plugin/lib/src/utilities/change_builder/change_builder_dart.dart
@@ -178,8 +178,7 @@ class DartEditBuilderImpl extends EditBuilderImpl implements DartEditBuilder {
       write(Keyword.CONST.lexeme);
       write(' ');
     }
-    if (_featureSet.isEnabled(Feature.primary_constructors) &&
-        constructorName == null) {
+    if (_featureSet.isEnabled(Feature.primary_constructors)) {
       write('new');
     } else if (classNameGroupName == null) {
       write(className);

--- a/pkg/analyzer_plugin/lib/src/utilities/change_builder/change_builder_dart.dart
+++ b/pkg/analyzer_plugin/lib/src/utilities/change_builder/change_builder_dart.dart
@@ -178,7 +178,10 @@ class DartEditBuilderImpl extends EditBuilderImpl implements DartEditBuilder {
       write(Keyword.CONST.lexeme);
       write(' ');
     }
-    if (classNameGroupName == null) {
+    if (_featureSet.isEnabled(Feature.primary_constructors) &&
+        constructorName == null) {
+      write('new');
+    } else if (classNameGroupName == null) {
       write(className);
     } else {
       addSimpleLinkedEdit(classNameGroupName, className);

--- a/pkg/analyzer_plugin/test/src/utilities/change_builder/change_builder_dart_test.dart
+++ b/pkg/analyzer_plugin/test/src/utilities/change_builder/change_builder_dart_test.dart
@@ -548,7 +548,7 @@ class DartEditBuilderImplTest extends AbstractContextTest
       });
     });
     var edit = getEdit(builder);
-    expect(edit.replacement, equalsIgnoringWhitespace('A() { print(42); }'));
+    expect(edit.replacement, equalsIgnoringWhitespace('new() { print(42); }'));
   }
 
   Future<void> test_writeConstructorDeclaration_fieldNames() async {
@@ -567,7 +567,7 @@ class C {
       });
     });
     var edit = getEdit(builder);
-    expect(edit.replacement, equalsIgnoringWhitespace('A(this.a, this.bb);'));
+    expect(edit.replacement, equalsIgnoringWhitespace('new(this.a, this.bb);'));
   }
 
   Future<void> test_writeConstructorDeclaration_initializerWriter() async {
@@ -586,7 +586,7 @@ class C {
       });
     });
     var edit = getEdit(builder);
-    expect(edit.replacement, equalsIgnoringWhitespace('A() : super();'));
+    expect(edit.replacement, equalsIgnoringWhitespace('new() : super();'));
   }
 
   Future<void> test_writeConstructorDeclaration_parameterWriter() async {
@@ -605,7 +605,7 @@ class C {
       });
     });
     var edit = getEdit(builder);
-    expect(edit.replacement, equalsIgnoringWhitespace('A(int a, {this.b});'));
+    expect(edit.replacement, equalsIgnoringWhitespace('new(int a, {this.b});'));
   }
 
   Future<void> test_writeFieldDeclaration_initializerWriter() async {


### PR DESCRIPTION
Fixes https://github.com/dart-lang/sdk/issues/63519

When the `primary_constructors` language feature is enabled, quick fixes that create constructors now generate new-style `new(...)` syntax instead of old-style `ClassName(...)`.

Changes:
- `writeConstructorDeclaration` in `change_builder_dart.dart`: writes `new` when `primary_constructors` is enabled and `constructorName == null`
- `CreateConstructorForFinalFields`: same check at all 4 inline constructor-name write sites
- `_CreateConstructor` in `create_constructor_super.dart`: same check in both `_computeWithoutSuperParameters` and `_computeWithSuperParameters`, guarded by `constructorName == null` so named constructors are unaffected

Tests:
- Updated existing unnamed-constructor test expectations to `new(...)`
- Added regression tests with `// @dart=3.10` confirming old-style output is preserved when the feature is disabled

- [x] I've reviewed the contributor guide and applied the relevant portions to this PR.