### PR TITLE
bounds-check section string table index in elf loader

### DIFF
--- a/runtime/bin/elf_loader.cc
+++ b/runtime/bin/elf_loader.cc
@@ -236,6 +236,9 @@ bool LoadedElf::ReadSectionTable() {
 }
 
 bool LoadedElf::ReadSectionStringTable() {
+  CHECK_ERROR(
+      header_.shstrtab_section_index < header_.num_section_headers,
+      "Section header string table index is out of bounds.");
   const dart::elf::SectionHeader header =
       section_table_[header_.shstrtab_section_index];
   section_string_table_mapping_.reset(


### PR DESCRIPTION
the elf loader validates several header fields when it reads a snapshot, but it never checks the section-header string-table index. that index is a 16-bit value taken straight from the file header, and ReadSectionStringTable uses it to index the mapped section table without confirming it falls within the number of section headers actually present. on a malformed or crafted object the lookup reads a section header from past the end of the table mapping, and the bogus file offset and size it hands back then drive a further file mapping, so the effect is not limited to one stray read. i noticed it while reading through the header validation sitting next to the existing size checks, which made the missing one stand out. checking the index against num_section_headers before the lookup closes it, in the same style as the other checks in this file.