### PR TITLE
Offer convertToDeclaringParameter on the `this.` prefix of an initializing formal

### DIFF
--- a/pkg/analysis_server/lib/src/services/correction/dart/convert_to_declaring_parameter.dart
+++ b/pkg/analysis_server/lib/src/services/correction/dart/convert_to_declaring_parameter.dart
@@ -50,8 +50,15 @@ class ConvertToDeclaringParameter extends ResolvedCorrectionProducer {
       return;
     }
 
-    if (!parameterName.sourceRange.contains(selectionOffset)) {
-      // The assist only applies if the name of the parameter is selected.
+    var inName = parameterName.sourceRange.contains(selectionOffset);
+    var inThisPrefix =
+        parameter is FieldFormalParameter &&
+        range
+            .startEnd(parameter.thisKeyword, parameter.period)
+            .contains(selectionOffset);
+    if (!inName && !inThisPrefix) {
+      // The assist only applies if the name or the `this.` prefix of the
+      // parameter is selected.
       return;
     }
 

--- a/pkg/analysis_server/test/src/services/correction/assist/convert_to_declaring_parameter_test.dart
+++ b/pkg/analysis_server/test/src/services/correction/assist/convert_to_declaring_parameter_test.dart
@@ -615,6 +615,69 @@ class B {
     await assertNoAssist();
   }
 
+  Future<void> test_selection_default() async {
+    await resolveTestCode('''
+class C([this.x = 0^]) {
+  int x;
+}
+''');
+    await assertNoAssist();
+  }
+
+  Future<void> test_selection_name() async {
+    await resolveTestCode('''
+class C(this.x^) {
+  int x;
+}
+''');
+    await assertHasAssist('''
+class C(var int x) {
+}
+''');
+  }
+
+  Future<void> test_selection_period() async {
+    await resolveTestCode('''
+class C(this^.x) {
+  int x;
+}
+''');
+    await assertHasAssist('''
+class C(var int x) {
+}
+''');
+  }
+
+  Future<void> test_selection_required() async {
+    await resolveTestCode('''
+class C({re^quired this.x}) {
+  int x;
+}
+''');
+    await assertNoAssist();
+  }
+
+  Future<void> test_selection_thisKeyword() async {
+    await resolveTestCode('''
+class C(th^is.x) {
+  int x;
+}
+''');
+    await assertHasAssist('''
+class C(var int x) {
+}
+''');
+  }
+
+  Future<void> test_selection_type() async {
+    await resolveTestCode('''
+class C(in^t this.x) {
+  int x;
+}
+''');
+    await assertNoAssist();
+  }
+
   Future<void> test_type_functionTyped() async {
     await resolveTestCode('''
 class C(int x^(String s)) {


### PR DESCRIPTION
Previously the `convertToDeclaringParameter` assist was only offered when the cursor was inside the parameter's name token. This widens the trigger so it is also offered when the cursor falls anywhere within the `this.` prefix (the `this` keyword or the following period) of a `FieldFormalParameter`.

The applicability range is computed from the node's own `thisKeyword` and `period` tokens, so no offsets or strings are hardcoded. Behavior for super parameters, type annotations, modifiers (`required`, `covariant`, `final`), and default values is unchanged - these were explicitly discussed and excluded from scope.

New tests cover the cursor on `this`, on the `.`, and on the parameter name (regression), and confirm the assist is correctly *not* offered on the type annotation, on a `required` modifier, or in a default value expression.

This follows the scope agreed with @bwilkerson in #63565.

Fixes #63565

- [x] I've reviewed the contributor guide and applied the relevant portions to this PR.