### PR TITLE
Offer convertToDeclaringParameter on the field declaration

### DIFF
--- a/pkg/analysis_server/lib/src/services/correction/dart/convert_to_declaring_parameter.dart
+++ b/pkg/analysis_server/lib/src/services/correction/dart/convert_to_declaring_parameter.dart
@@ -38,29 +38,33 @@ class ConvertToDeclaringParameter extends ResolvedCorrectionProducer {
 
   @override
   Future<void> compute(ChangeBuilder builder) async {
-    var parameter = node;
-    if (parameter is! FormalParameter) {
-      // The assist only applies to formal parameters.
-      return;
+    FormalParameter parameter;
+    var n = node;
+    if (n is FormalParameter) {
+      var parameterName = n.name;
+      if (parameterName == null) {
+        // The assist only applies to formal parameters with a name.
+        return;
+      }
+
+      var inName = parameterName.sourceRange.contains(selectionOffset);
+      var inThisPrefix =
+          n is FieldFormalParameter &&
+          range.startEnd(n.thisKeyword, n.period).contains(selectionOffset);
+      if (!inName && !inThisPrefix) {
+        // The assist only applies if the name or the `this.` prefix of the
+        // parameter is selected.
+        return;
+      }
+      parameter = n;
+    } else {
+      var resolved = _resolveParameterFromFieldNode(n);
+      if (resolved == null) return;
+      parameter = resolved;
     }
 
     var parameterName = parameter.name;
-    if (parameterName == null) {
-      // The assist only applies to formal parameters with a name.
-      return;
-    }
-
-    var inName = parameterName.sourceRange.contains(selectionOffset);
-    var inThisPrefix =
-        parameter is FieldFormalParameter &&
-        range
-            .startEnd(parameter.thisKeyword, parameter.period)
-            .contains(selectionOffset);
-    if (!inName && !inThisPrefix) {
-      // The assist only applies if the name or the `this.` prefix of the
-      // parameter is selected.
-      return;
-    }
+    if (parameterName == null) return;
 
     var classMembers = _getClassMembers(parameter);
     if (classMembers == null) {
@@ -441,5 +445,56 @@ class ConvertToDeclaringParameter extends ResolvedCorrectionProducer {
   /// Whether the [node] has either a documentation comment or metadata.
   bool _hasCommentOrMetadata(AnnotatedNode node) {
     return node.documentationComment != null || node.metadata.isNotEmpty;
+  }
+
+  /// Returns the primary constructor parameter that initializes the field
+  /// declared by [node], or `null` if no such parameter exists.
+  FormalParameter? _resolveParameterFromFieldNode(AstNode node) {
+    if (node is! VariableDeclaration) return null;
+
+    var variableList = node.parent;
+    if (variableList is! VariableDeclarationList) return null;
+
+    if (variableList.parent is! FieldDeclaration) return null;
+
+    var classOrEnum = node.thisOrAncestorMatching(
+      (n) => n is ClassDeclaration || n is EnumDeclaration,
+    );
+
+    var primaryConstructor = switch (classOrEnum) {
+      ClassDeclaration() => classOrEnum.namePart,
+      EnumDeclaration() => classOrEnum.namePart,
+      _ => null,
+    };
+    if (primaryConstructor is! PrimaryConstructorDeclaration) return null;
+
+    var fieldElement = node.declaredFragment?.element;
+    if (fieldElement is! FieldElement) return null;
+
+    for (var parameter in primaryConstructor.formalParameters.parameters) {
+      if (parameter is FieldFormalParameter) {
+        var element = parameter.declaredFragment?.element;
+        if (element is FieldFormalParameterElement &&
+            element.field == fieldElement) {
+          return parameter;
+        }
+      } else if (parameter is RegularFormalParameter) {
+        var paramElement = parameter.declaredFragment?.element;
+        if (paramElement == null) continue;
+        var body = primaryConstructor.body;
+        if (body == null) continue;
+        for (var init in body.initializers) {
+          if (init is ConstructorFieldInitializer) {
+            var expression = init.expression;
+            if (init.fieldName.element == fieldElement &&
+                expression is SimpleIdentifier &&
+                expression.element == paramElement) {
+              return parameter;
+            }
+          }
+        }
+      }
+    }
+    return null;
   }
 }

--- a/pkg/analysis_server/test/src/services/correction/assist/convert_to_declaring_parameter_test.dart
+++ b/pkg/analysis_server/test/src/services/correction/assist/convert_to_declaring_parameter_test.dart
@@ -180,6 +180,91 @@ class C(var int x) {
 ''');
   }
 
+  Future<void> test_field_alreadyDeclaringParameter() async {
+    await resolveTestCode('''
+class C(var int x) {
+  late int y^;
+}
+''');
+    await assertNoAssist();
+  }
+
+  Future<void> test_field_fieldFormalParameter() async {
+    await resolveTestCode('''
+class C(this.x) {
+  int x^;
+}
+''');
+    await assertHasAssist('''
+class C(var int x) {
+}
+''');
+  }
+
+  Future<void> test_field_initializerList() async {
+    await resolveTestCode('''
+class C(int x) {
+  int x^;
+
+  this : x = x;
+}
+''');
+    await assertHasAssist('''
+class C(var int x) {
+}
+''');
+  }
+
+  Future<void> test_field_noConstructor() async {
+    await resolveTestCode('''
+class C {
+  late int x^;
+}
+''');
+    await assertNoAssist();
+  }
+
+  Future<void> test_field_notInitialized() async {
+    await resolveTestCode('''
+class C(int y) {
+  late int x^;
+}
+''');
+    await assertNoAssist();
+  }
+
+  Future<void> test_field_typeMismatch() async {
+    await resolveTestCode('''
+class C(int x) {
+  num x^;
+
+  this : x = x;
+}
+''');
+    await assertNoAssist();
+  }
+
+  Future<void> test_field_withInitializer() async {
+    await resolveTestCode('''
+class C(int x) {
+  int x^ = DateTime.now().millisecondsSinceEpoch;
+}
+''');
+    await assertNoAssist();
+  }
+
+  Future<void> test_field_withType() async {
+    await resolveTestCode('''
+class C(this.x) {
+  final int x^;
+}
+''');
+    await assertHasAssist('''
+class C(final int x) {
+}
+''');
+  }
+
   Future<void> test_first() async {
     await resolveTestCode('''
 class C(int x^, int y) {


### PR DESCRIPTION
Previously the convertToDeclaringParameter assist was only triggered when the cursor was on a primary constructor parameter. This adds a second trigger: when the cursor is on a field declaration inside a class or enum that has a primary constructor, and one of the existing primary constructor parameters initializes that field (either via a `FieldFormalParameter`
or a direct pass-through assignment in the initializer list), and the field and parameter types match.

The new `_resolveParameterFromFieldNode` method resolves the parameter from the field node and reuses the existing transformation logic unchanged. Eight new tests cover both positive cases (`FieldFormalParameter`, initializer list, typed field) and all the negative guards (no primary constructor, no matching parameter, type mismatch, field with initializer,
already a declaring parameter).

The scope was discussed with @bwilkerson in #63550 , only direct pass-through assignments are supported, not complex expressions, matching the behavior of the existing parameter-triggered path.

Fixes #63550

- [x] I've reviewed the contributor guide and applied the relevant portions to this PR.