### PR TITLE
Pin third-party dependency scan workflow

### DIFF
--- a/.github/workflows/third-party-deps-scan.yml
+++ b/.github/workflows/third-party-deps-scan.yml
@@ -42,7 +42,7 @@ jobs:
     name: Vulnerability scanning
     needs:
       extract-deps
-    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@main"
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@fa4ff678dd5d0a4fa3d628e57af8162873e93cd6"
     with:
       # Download the artifact uploaded in the extract-deps step.
       download-artifact: osv-lockfile-${{github.sha}}


### PR DESCRIPTION
This pins the reusable OSV scanner workflow used by `.github/workflows/third-party-deps-scan.yml` from `@main` to the current upstream commit `fa4ff678dd5d0a4fa3d628e57af8162873e93cd6`.

The called workflow runs in the vulnerability scan job, which has `security-events: write` so it can upload SARIF results. Pinning the reusable workflow keeps that code-scanning permission tied to an immutable reviewed revision.

Verification:
- `uvx zizmor --min-severity high --min-confidence high --format json .github/workflows/third-party-deps-scan.yml`
- `python3` YAML parse with `yaml.safe_load`
- `/tmp/actionlint-civiform/bin/actionlint .github/workflows/third-party-deps-scan.yml`
- `git diff --check`

Prepared with AI assistance. I reviewed the one-line diff and ran the checks above.