### PR TITLE
analyzer: recognize example doc directive

### DIFF
--- a/pkg/analyzer/lib/dart/ast/doc_comment.dart
+++ b/pkg/analyzer/lib/dart/ast/doc_comment.dart
@@ -233,6 +233,28 @@ enum DocDirectiveType {
   /// are included. This also allows us to parse (erroneous) dangling end tags.
   endTemplate.end('endtemplate', openingTag: 'template'),
 
+  /// A [DocDirective] that inserts the contents of an external file.
+  ///
+  /// This directive has one required argument: the path to the example file.
+  /// Optional named arguments can specify the language and indentation behavior.
+  ///
+  /// ```none
+  /// {@example /examples/my_example.dart lang=dart indent=strip}
+  /// ```
+  ///
+  /// See documentation at
+  /// <https://github.com/dart-lang/dartdoc/blob/main/doc/directives.md#example>.
+  example(
+    'example',
+    positionalParameters: [
+      DocDirectiveParameter('path', DocDirectiveParameterFormat.uri),
+    ],
+    namedParameters: [
+      DocDirectiveParameter('lang', DocDirectiveParameterFormat.any),
+      DocDirectiveParameter('indent', DocDirectiveParameterFormat.any),
+    ],
+  ),
+
   /// A [DocDirective] declaring a block of HTML content which is to be inserted
   /// after all other processing, including Markdown parsing.
   ///

--- a/pkg/analyzer/lib/src/fasta/doc_comment_builder.dart
+++ b/pkg/analyzer/lib/src/fasta/doc_comment_builder.dart
@@ -382,6 +382,9 @@ final class DocCommentBuilder {
       case 'endtemplate':
         _endBlockDocDirectiveTag(parser, DocDirectiveType.endTemplate);
         return true;
+      case 'example':
+        _pushDocDirective(parser.simpleDirective(DocDirectiveType.example));
+        return true;
       case 'inject-html':
         _parseBlockDocDirectiveTag(parser, DocDirectiveType.injectHtml);
         return true;

--- a/pkg/analyzer/test/src/dart/parser/doc_comment_test.dart
+++ b/pkg/analyzer/test/src/dart/parser/doc_comment_test.dart
@@ -1833,6 +1833,31 @@ Comment
 ''');
   }
 
+  test_exampleDirective() {
+    var parseResult = parseTestCodeWithDiagnostics(r'''
+int x = 0;
+
+/// Text.
+/// {@example /example/webcrypto/hmac/import_raw_key.dart}
+class A {}
+''');
+
+    var node = parseResult.findNode.comment('{@example');
+    assertParsedNodeText(node, r'''
+Comment
+  tokens
+    /// Text.
+    /// {@example /example/webcrypto/hmac/import_raw_key.dart}
+  docDirectives
+    SimpleDocDirective
+      tag
+        offset: [26, 81]
+        type: [DocDirectiveType.example]
+        positionalArguments
+          /example/webcrypto/hmac/import_raw_key.dart
+''');
+  }
+
   test_unknownDocDirective() {
     var parseResult = parseTestCodeWithDiagnostics(r'''
 int x = 0;


### PR DESCRIPTION
Fixes dart-lang/sdk#63504.

This PR updates the analyzer doc comment parser to recognize the dartdoc `{@example ...}` directive.

Changes:

* Adds `example` to `DocDirectiveType`
* Parses `{@example ...}` as a known simple doc directive
* Adds parser coverage for an example directive using a package-root-relative path

Validation:

* `dart test test/src/dart/parser/doc_comment_test.dart -p vm --plain-name 'DocCommentParserTest test_exampleDirective'`
* `dart test test/src/dart/parser/doc_comment_test.dart`


