### PR TITLE
[dart:io] set close-on-exec on all received socket message fds

### DIFF
--- a/runtime/bin/socket_base_posix.cc
+++ b/runtime/bin/socket_base_posix.cc
@@ -163,14 +163,17 @@ intptr_t SocketBase::ReceiveMessage(intptr_t fd,
     new (control_message) SocketControlMessage(
         cmsg->cmsg_level, cmsg->cmsg_type, copied_data, data_length);
 
-    int fd;
-    memmove(&fd, CMSG_DATA(cmsg), sizeof(int));
-
 #ifndef MSG_CMSG_CLOEXEC
-    // MSG_CMSG_CLOEXEC is not supported on macOS.
-    if (!FDUtils::SetCloseOnExec(fd)) {
-      FDUtils::SaveErrorAndClose(fd);
-      return -1;
+    // MSG_CMSG_CLOEXEC is not supported on macOS, so set close-on-exec on each
+    // received descriptor. A single SCM_RIGHTS message can carry more than one.
+    const intptr_t num_fds = data_length / sizeof(int);
+    for (intptr_t i = 0; i < num_fds; i++) {
+      int fd;
+      memmove(&fd, static_cast<uint8_t*>(data) + i * sizeof(int), sizeof(int));
+      if (!FDUtils::SetCloseOnExec(fd)) {
+        FDUtils::SaveErrorAndClose(fd);
+        return -1;
+      }
     }
 #endif
   }

--- a/runtime/bin/socket_base_posix.cc
+++ b/runtime/bin/socket_base_posix.cc
@@ -167,9 +167,9 @@ intptr_t SocketBase::ReceiveMessage(intptr_t fd,
     // MSG_CMSG_CLOEXEC is not supported on macOS, so set close-on-exec on each
     // received descriptor. A single SCM_RIGHTS message can carry more than one.
     const intptr_t num_fds = data_length / sizeof(int);
+    const int* fds = reinterpret_cast<int*>(copied_data);
     for (intptr_t i = 0; i < num_fds; i++) {
-      int fd;
-      memmove(&fd, static_cast<uint8_t*>(data) + i * sizeof(int), sizeof(int));
+      const int fd = fds[i];
       if (!FDUtils::SetCloseOnExec(fd)) {
         FDUtils::SaveErrorAndClose(fd);
         return -1;


### PR DESCRIPTION
1. a SCM_RIGHTS control message can carry several descriptors (`SocketControlMessage.fromHandles` takes a list), but the receive loop in `SocketBase::ReceiveMessage` only reads the first one and sets close-on-exec on it.
2. on platforms without `MSG_CMSG_CLOEXEC` (macOS/BSD) the remaining descriptors keep their default state, so they leak into child processes started after the message is received.

Loop over every descriptor in the message and set close-on-exec on each, which is what `MSG_CMSG_CLOEXEC` already does for us on Linux.