### PR TITLE
[analysis_server] Use null activeParameter when supported

### DIFF
--- a/pkg/analysis_server/lib/src/cider/signature_help.dart
+++ b/pkg/analysis_server/lib/src/cider/signature_help.dart
@@ -31,6 +31,7 @@ class CiderSignatureHelpComputer {
       resolvedUnit.unit,
       offset,
       formats,
+      noActiveParameterSupport: false,
     );
     if (typeArgsComputer.offsetIsValid) {
       var typeSignature = typeArgsComputer.compute();

--- a/pkg/analysis_server/lib/src/computer/computer_type_arguments_signature.dart
+++ b/pkg/analysis_server/lib/src/computer/computer_type_arguments_signature.dart
@@ -17,6 +17,7 @@ import 'package:analyzer/src/dartdoc/dartdoc_directive_info.dart';
 class DartTypeArgumentsSignatureComputer {
   final AstNode? _node;
   final Set<lsp.MarkupKind>? preferredFormats;
+  final bool noActiveParameterSupport;
   late TypeArgumentList _argumentList;
   final DocumentationPreference documentationPreference;
   final DartDocumentationComputer _documentationComputer;
@@ -26,6 +27,7 @@ class DartTypeArgumentsSignatureComputer {
     CompilationUnit unit,
     int offset,
     this.preferredFormats, {
+    required this.noActiveParameterSupport,
     this.documentationPreference = DocumentationPreference.full,
   }) : _documentationComputer = DartDocumentationComputer(dartdocInfo),
        _node = unit.nodeCovering(offset: offset);
@@ -100,14 +102,16 @@ class DartTypeArgumentsSignatureComputer {
       parameters: parameters,
     );
 
-    return lsp.SignatureHelp(
+    return signatureHelpWithNullableActiveParameter(
       signatures: [signature],
       activeSignature: 0,
-      // This must be a unsigned integer but can be out of range. Since we don't
-      // currently support this, just provide the first out-of-bounds value and
-      // allow the client to decide what to do (the LSP spec says it can be
-      // treated as 0, but VS Code will not highlight any, which is preferred).
-      activeParameter: signature.parameters?.length ?? 0,
+      // When supported by the client, use `null` to indicate that no parameter
+      // is active. Otherwise, use the first out-of-bounds index so older
+      // clients do not highlight any parameter.
+      activeParameter: noActiveParameterSupport
+          ? null
+          : signature.parameters?.length ?? 0,
+      includeActiveParameter: noActiveParameterSupport,
     );
   }
 }

--- a/pkg/analysis_server/lib/src/lsp/client_capabilities.dart
+++ b/pkg/analysis_server/lib/src/lsp/client_capabilities.dart
@@ -95,6 +95,7 @@ class LspClientCapabilities {
   final Set<DiagnosticTag> diagnosticTags;
   final Set<MarkupKind>? completionDocumentationFormats;
   final Set<MarkupKind>? signatureHelpDocumentationFormats;
+  final bool signatureHelpNoActiveParameterSupport;
   final Set<MarkupKind>? hoverContentFormats;
   final Set<SymbolKind> documentSymbolKinds;
   final Set<SymbolKind> workspaceSymbolKinds;
@@ -182,6 +183,8 @@ class LspClientCapabilities {
     var signatureHelpDocumentationFormats = _listToNullableSet(
       signatureInformation?.documentationFormat,
     );
+    var signatureHelpNoActiveParameterSupport =
+        signatureInformation?.noActiveParameterSupport ?? false;
     var workDoneProgress = raw.window?.workDoneProgress ?? false;
     var workspaceSymbolKinds = _listToSet(
       workspaceSymbol?.symbolKind?.valueSet,
@@ -214,6 +217,8 @@ class LspClientCapabilities {
       diagnosticTags: diagnosticTags,
       completionDocumentationFormats: completionDocumentationFormats,
       signatureHelpDocumentationFormats: signatureHelpDocumentationFormats,
+      signatureHelpNoActiveParameterSupport:
+          signatureHelpNoActiveParameterSupport,
       hoverContentFormats: hoverContentFormats,
       documentSymbolKinds: documentSymbolKinds,
       workspaceSymbolKinds: workspaceSymbolKinds,
@@ -255,6 +260,7 @@ class LspClientCapabilities {
     required this.diagnosticTags,
     required this.completionDocumentationFormats,
     required this.signatureHelpDocumentationFormats,
+    required this.signatureHelpNoActiveParameterSupport,
     required this.hoverContentFormats,
     required this.documentSymbolKinds,
     required this.workspaceSymbolKinds,

--- a/pkg/analysis_server/lib/src/lsp/handlers/handler_signature_help.dart
+++ b/pkg/analysis_server/lib/src/lsp/handlers/handler_signature_help.dart
@@ -63,6 +63,8 @@ class SignatureHelpHandler
 
     return (unit, offset).mapResultsSync((unit, offset) {
       var formats = clientCapabilities.signatureHelpDocumentationFormats;
+      var noActiveParameterSupport =
+          clientCapabilities.signatureHelpNoActiveParameterSupport;
       var dartDocInfo = server.getDartdocDirectiveInfoFor(unit);
 
       // First check if we're in a type args list and if so build some
@@ -73,6 +75,7 @@ class SignatureHelpHandler
         offset,
         autoTriggered,
         formats,
+        noActiveParameterSupport,
       );
       if (typeArgsSignature != null) {
         return success(typeArgsSignature);
@@ -95,7 +98,13 @@ class SignatureHelpHandler
         return success(null);
       }
 
-      return success(toSignatureHelp(formats, signature));
+      return success(
+        toSignatureHelp(
+          formats,
+          signature,
+          noActiveParameterSupport: noActiveParameterSupport,
+        ),
+      );
     });
   }
 
@@ -110,12 +119,14 @@ class SignatureHelpHandler
     int offset,
     bool autoTriggered,
     Set<MarkupKind>? formats,
+    bool noActiveParameterSupport,
   ) {
     var typeArgsComputer = DartTypeArgumentsSignatureComputer(
       dartDocInfo,
       unit,
       offset,
       formats,
+      noActiveParameterSupport: noActiveParameterSupport,
     );
     if (!typeArgsComputer.offsetIsValid) {
       return null;

--- a/pkg/analysis_server/lib/src/lsp/mapping.dart
+++ b/pkg/analysis_server/lib/src/lsp/mapping.dart
@@ -1526,8 +1526,9 @@ lsp.Range toRange(server.LineInfo lineInfo, int offset, int length) {
 
 lsp.SignatureHelp toSignatureHelp(
   Set<lsp.MarkupKind>? preferredFormats,
-  server.SignatureInformation signature,
-) {
+  server.SignatureInformation signature, {
+  bool noActiveParameterSupport = false,
+}) {
   // For now, we only support returning one (though we may wish to use named
   // args. etc. to provide one for each possible "next" option when the cursor
   // is at the end ready to provide another argument).
@@ -1573,8 +1574,11 @@ lsp.SignatureHelp toSignatureHelp(
   }
 
   var cleanedDoc = cleanDartdoc(signature.dartdoc);
+  var activeParameter =
+      signature.activeParameterIndex ??
+      (noActiveParameterSupport ? null : signature.parameters.length);
 
-  return lsp.SignatureHelp(
+  return signatureHelpWithNullableActiveParameter(
     signatures: [
       lsp.SignatureInformation(
         label: getSignatureLabel(signature),
@@ -1585,16 +1589,46 @@ lsp.SignatureHelp toSignatureHelp(
       ),
     ],
     activeSignature: 0, // activeSignature
-    // We must provide a unsigned integer here but it's possible there isn't
-    // a valid value (because the user might be in the 10th argument of an
-    // invocation that only takes 1). The LSP spec allows us to send an
-    // out-of-bounds value so send the first out-of-bound value (`.length`). The
-    // spec says this may be treated as 0, however VS Code will not highlight
-    // any parameter in this case (which is preferred and hopefully other
-    // clients may copy).
-    activeParameter:
-        signature.activeParameterIndex ?? signature.parameters.length,
+    // If supported by the client, use `null` to indicate there is no active
+    // parameter. Otherwise, send the first out-of-bounds value (`.length`) so
+    // older clients do not highlight any parameter.
+    activeParameter: activeParameter,
+    includeActiveParameter: noActiveParameterSupport,
   );
+}
+
+lsp.SignatureHelp signatureHelpWithNullableActiveParameter({
+  required List<lsp.SignatureInformation> signatures,
+  int? activeSignature,
+  int? activeParameter,
+  required bool includeActiveParameter,
+}) {
+  return _SignatureHelpWithNullableActiveParameter(
+    signatures: signatures,
+    activeSignature: activeSignature,
+    activeParameter: activeParameter,
+    includeActiveParameter: includeActiveParameter,
+  );
+}
+
+class _SignatureHelpWithNullableActiveParameter extends lsp.SignatureHelp {
+  final bool includeActiveParameter;
+
+  _SignatureHelpWithNullableActiveParameter({
+    required super.signatures,
+    super.activeSignature,
+    super.activeParameter,
+    required this.includeActiveParameter,
+  });
+
+  @override
+  Map<String, Object?> toJson() {
+    var json = super.toJson();
+    if (includeActiveParameter && activeParameter == null) {
+      json['activeParameter'] = null;
+    }
+    return json;
+  }
 }
 
 List<lsp.SnippetableTextEdit> toSnippetTextEdits(

--- a/pkg/analysis_server/test/lsp/server_abstract.dart
+++ b/pkg/analysis_server/test/lsp/server_abstract.dart
@@ -743,6 +743,17 @@ mixin ClientCapabilitiesHelperMixin {
     );
   }
 
+  void setSignatureHelpNoActiveParameterSupport([bool supported = true]) {
+    textDocumentCapabilities = extendTextDocumentCapabilities(
+      textDocumentCapabilities,
+      {
+        'signatureHelp': {
+          'signatureInformation': {'noActiveParameterSupport': supported},
+        },
+      },
+    );
+  }
+
   void setSnippetTextEditSupport([bool supported = true]) {
     experimentalCapabilities['snippetTextEdit'] = supported;
   }

--- a/pkg/analysis_server/test/lsp/signature_help_test.dart
+++ b/pkg/analysis_server/test/lsp/signature_help_test.dart
@@ -338,6 +338,20 @@ void f(int a, int b) {
     );
   }
 
+  Future<void>
+  test_activeParameter_invalid_clientSupportsNoActiveParameter() async {
+    setSignatureHelpNoActiveParameterSupport();
+
+    var result = await _getSignatureHelpJson('''
+void f(int a) {
+  f(1, ^);
+}
+''');
+
+    expect(result.containsKey('activeParameter'), isTrue);
+    expect(result['activeParameter'], isNull);
+  }
+
   Future<void> test_augmentation_method() async {
     var content = '''
 part 'a.dart';
@@ -964,6 +978,30 @@ class Bar extends Foo<^> {}
     );
   }
 
+  Future<void>
+  test_typeParams_activeParameter_clientSupportsNoActiveParameter() async {
+    setSignatureHelpNoActiveParameterSupport();
+
+    var result = await _getSignatureHelpJson('''
+class Foo<T1, T2 extends String> {}
+
+class Bar extends Foo<^> {}
+''');
+
+    expect(result.containsKey('activeParameter'), isTrue);
+    expect(result['activeParameter'], isNull);
+  }
+
+  Future<void> test_typeParams_activeParameter_clientWithoutSupport() async {
+    var result = await _getSignatureHelpJson('''
+class Foo<T1, T2 extends String> {}
+
+class Bar extends Foo<^> {}
+''');
+
+    expect(result['activeParameter'], 2);
+  }
+
   Future<void> test_typeParams_function() async {
     var content = '''
 /// My Foo.
@@ -1027,6 +1065,25 @@ var a = A<^>();
       expectedLabel,
       expectedParams: expectedParams,
     );
+  }
+
+  Future<Map<String, Object?>> _getSignatureHelpJson(String content) async {
+    var code = TestCode.parse(content);
+    await initialize();
+    await openFile(mainFileUri, code.code);
+    await initialAnalysis;
+
+    var request = makeRequest(
+      Method.textDocument_signatureHelp,
+      SignatureHelpParams(
+        textDocument: TextDocumentIdentifier(uri: mainFileUri),
+        position: code.position.position,
+      ),
+    );
+    var response = await sendRequestToServer(request);
+
+    expect(response.error, isNull);
+    return response.result as Map<String, Object?>;
   }
 
   Future<void> test_unopenFile() async {


### PR DESCRIPTION
Fixes #63651.

This updates LSP signature help so that when a client advertises `textDocument.signatureHelp.signatureInformation.noActiveParameterSupport`, the server can return an explicit `activeParameter: null` instead of using an out-of-bounds parameter index.

Changes included:

* Reads `noActiveParameterSupport` from client capabilities.
* Applies the behavior to both regular signature help and type-argument signature help.
* Preserves the existing out-of-bounds fallback for clients that do not support null active parameters.
* Adds LSP tests that assert the raw JSON response includes `activeParameter: null`.

Testing:

* `git diff --check`
* `python3 tools/test.py -n analyzer-unittest-asserts-release-mac pkg/analysis_server/test/lsp/signature_help_test`

  * Could not run locally because `xcodebuild/ReleaseARM64/dart-sdk/bin/dart` is missing in this checkout.
