### PR TITLE
[vm/ffi] Split exceptional_return_const multitest

### DIFF
--- a/tests/ffi/exceptional_return_const_slow_path_stacktrace_test.dart
+++ b/tests/ffi/exceptional_return_const_slow_path_stacktrace_test.dart
@@ -1,0 +1,12 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+//
+// Tests exceptionalReturn const expressions with slow paths and stack traces enabled.
+//
+// VMOptions=--use-slow-path --stacktrace-every=100
+// SharedObjects=ffi_test_functions
+
+import 'exceptional_return_const_test.dart' as test;
+
+void main() => test.main();

--- a/tests/ffi/exceptional_return_const_slow_path_test.dart
+++ b/tests/ffi/exceptional_return_const_slow_path_test.dart
@@ -1,0 +1,12 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+//
+// Tests exceptionalReturn const expressions with slow paths enabled.
+//
+// VMOptions=--use-slow-path
+// SharedObjects=ffi_test_functions
+
+import 'exceptional_return_const_test.dart' as test;
+
+void main() => test.main();

--- a/tests/ffi/exceptional_return_const_stacktrace_test.dart
+++ b/tests/ffi/exceptional_return_const_stacktrace_test.dart
@@ -1,0 +1,12 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+//
+// Tests exceptionalReturn const expressions with stack traces enabled.
+//
+// VMOptions=--stacktrace-every=100
+// SharedObjects=ffi_test_functions
+
+import 'exceptional_return_const_test.dart' as test;
+
+void main() => test.main();

--- a/tests/ffi/exceptional_return_const_test.dart
+++ b/tests/ffi/exceptional_return_const_test.dart
@@ -5,9 +5,6 @@
 // Tests passing non-trivial const expressions to exceptionalReturn.
 //
 // VMOptions=
-// VMOptions=--stacktrace-every=100
-// VMOptions=--use-slow-path
-// VMOptions=--use-slow-path --stacktrace-every=100
 // SharedObjects=ffi_test_functions
 
 import 'dart:ffi';

--- a/tests/ffi/ffi.status
+++ b/tests/ffi/ffi.status
@@ -64,7 +64,6 @@ vmspecific_native_finalizer_isolate_groups_test: Skip # SpawnUri not available o
 [ $system == fuchsia ]
 abi_specific_int_incomplete_aot_test: SkipByDesign # Needs gen_kernel and gen_snapshot.
 async_void_function_callbacks_test/*: Skip # Test harness doesn't support multitest with Fuchsia
-exceptional_return_const_test/*: Skip # Test harness doesn't support multitest with Fuchsia
 ffi_induce_a_crash_test/*: Skip # Test harness doesn't support multitest with Fuchsia
 function_callbacks_isolate_ownership_test: SkipByDesign # Needs access to Dart executable
 function_callbacks_leaf_test: SkipByDesign # Needs access to Dart executable


### PR DESCRIPTION
Fixes #60212.

This migrates `exceptional_return_const_test.dart` away from legacy multitest VMOptions expansion by splitting the additional VMOptions variants into separate wrapper test files.

Changes included:

* Keeps `exceptional_return_const_test.dart` as the default VMOptions test.
* Adds separate wrapper tests for:

  * `--stacktrace-every=100`
  * `--use-slow-path`
  * `--use-slow-path --stacktrace-every=100`
* Removes the Fuchsia wildcard skip for `exceptional_return_const_test/*`, since the test no longer relies on multitest expansion.

Testing:

* `dart format tests/ffi/exceptional_return_const_test.dart tests/ffi/exceptional_return_const_stacktrace_test.dart tests/ffi/exceptional_return_const_slow_path_test.dart tests/ffi/exceptional_return_const_slow_path_stacktrace_test.dart`
* `git diff --cached --check`
* `python3 tools/test.py -n vm-mac-release-arm64 'ffi/exceptional_return_const.*_test'`

  * Could not run locally because `xcodebuild/ReleaseARM64/dart` is missing in this checkout.
* `python3 tools/test.py 'ffi/exceptional_return_const.*_test'`

  * Could not run locally because `xcodebuild/DebugARM64/dart` is missing in this checkout.
