### PR TITLE
Extend SortConstructorFirst fix to handle enums

### DIFF
--- a/pkg/analysis_server/lib/src/services/correction/dart/sort_constructor_first.dart
+++ b/pkg/analysis_server/lib/src/services/correction/dart/sort_constructor_first.dart
@@ -29,8 +29,22 @@ class SortConstructorFirst extends ResolvedCorrectionProducer {
     var constructor = coveringNode
         ?.thisOrAncestorOfType<ConstructorDeclaration>();
     if (constructor == null) return;
-    var classBody = constructor.thisOrAncestorOfType<BlockClassBody>();
-    if (classBody == null) return;
+    var body =
+        constructor.thisOrAncestorOfType<BlockClassBody>() ??
+        constructor.thisOrAncestorOfType<BlockEnumBody>();
+    if (body == null) return;
+
+    int insertionOffset;
+    if (body is BlockClassBody) {
+      insertionOffset = body.leftBracket.end;
+    } else if (body is BlockEnumBody) {
+      insertionOffset =
+          body.semicolon?.end ??
+          body.constants.lastOrNull?.end ??
+          body.leftBracket.end;
+    } else {
+      return;
+    }
 
     await builder.addDartFileEdit(file, (builder) {
       var deletionRange = range.endEnd(
@@ -40,7 +54,7 @@ class SortConstructorFirst extends ResolvedCorrectionProducer {
 
       builder.addDeletion(deletionRange);
       builder.addSimpleInsertion(
-        classBody.leftBracket.end,
+        insertionOffset,
         utils.getRangeText(deletionRange),
       );
     });

--- a/pkg/analysis_server/test/src/services/correction/fix/sort_constructor_first_test.dart
+++ b/pkg/analysis_server/test/src/services/correction/fix/sort_constructor_first_test.dart
@@ -45,6 +45,35 @@ class B {
 ''');
   }
 
+  Future<void> test_multiple_enums() async {
+    await resolveTestCode('''
+enum A {
+  a;
+  void m() {}
+  A();
+}
+
+enum B {
+  b;
+  void n() {}
+  B();
+}
+''');
+    await assertHasFix('''
+enum A {
+  a;
+  A();
+  void m() {}
+}
+
+enum B {
+  b;
+  B();
+  void n() {}
+}
+''');
+  }
+
   Future<void> test_single_class() async {
     await resolveTestCode('''
 class A {
@@ -78,6 +107,75 @@ class SortConstructorFirstTest extends FixProcessorLintTest {
 
   @override
   String get lintCode => LintNames.sort_constructors_first;
+
+  Future<void> test_enum_constHead() async {
+    await resolveTestCode('''
+enum E {
+  a;
+  void m() {}
+  new();
+}
+''');
+    await assertHasFix('''
+enum E {
+  a;
+  new();
+  void m() {}
+}
+''');
+  }
+
+  Future<void> test_enum_named() async {
+    await resolveTestCode('''
+enum E {
+  a.named();
+  void m() {}
+  E.named();
+}
+''');
+    await assertHasFix('''
+enum E {
+  a.named();
+  E.named();
+  void m() {}
+}
+''');
+  }
+
+  Future<void> test_enum_noConstants() async {
+    verifyNoTestUnitErrors = false;
+    await resolveTestCode('''
+enum E {
+  ;
+  void m() {}
+  E();
+}
+''');
+    await assertHasFix('''
+enum E {
+  ;
+  E();
+  void m() {}
+}
+''', filter: lintNameFilter(lintCode));
+  }
+
+  Future<void> test_enum_simple() async {
+    await resolveTestCode('''
+enum E {
+  a;
+  void m() {}
+  E();
+}
+''');
+    await assertHasFix('''
+enum E {
+  a;
+  E();
+  void m() {}
+}
+''');
+  }
 
   Future<void> test_hasComment() async {
     await resolveTestCode('''


### PR DESCRIPTION
The `SortConstructorFirst` lint fix previously only fired for classes since it walked to the enclosing `BlockClassBody`. This extends it to also handle `BlockEnumBody` so the fix works on enums when `sort_constructors_first` is enabled.

For enums, the constructor is inserted at:

`semicolon?.end ?? constants.lastOrNull?.end ?? leftBracket.end`

This handles three cases:
- Enum has a separating semicolon after constants, insert after the semicolon
- Enum has constants but no semicolon yet, insert after the last constant
- Enum has neither (mid-edit), insert after the left bracket

The fallback chain was suggested by @FMorschel to handle the mid-edit case.

Added 4 tests for the single-fix case (simple, named, `new()` head syntax, no-constants mid-edit) plus 1 bulk-fix test for multiple enums.

Note: the parallel `sort_unnamed_constructor_first.dart` fix has the same class-only limitation. That can be handled as a separate follow-up if needed.

Fixes #61788

- [x] I've reviewed the contributor guide and applied the relevant portions to this PR.