### PR TITLE
[dartdev] Add shared runtime for Linux CLI bundles

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -51,6 +51,12 @@ group("runtime") {
       "utils/dtd:dtd_aot",
       "utils/kernel-service:frontend_server_aot_product",
     ]
+    if (is_linux) {
+      deps += [
+        "runtime/bin:dartcliruntime",
+        "runtime/bin:dartcliruntime_product",
+      ]
+    }
   } else {
     deps += [
       "utils/dart_runtime_service_vm",
@@ -111,6 +117,9 @@ group("runtime_precompiled") {
     "runtime/bin:process_test",
     "runtime/vm:kernel_platform_files($host_toolchain)",
   ]
+  if (is_linux) {
+    deps += [ "runtime/bin:dartcliruntime" ]
+  }
   if (is_linux || is_android) {
     deps += [ "runtime/bin:abstract_socket_test" ]
   }

--- a/pkg/dart2native/lib/sdk.dart
+++ b/pkg/dart2native/lib/sdk.dart
@@ -52,6 +52,18 @@ class Sdk {
 
   String get dartAotRuntime => dartAotRuntimeFor();
 
+  String dartCliRuntimeFor({
+    String? sanitizer,
+  }) {
+    final name = sanitizer != null && sanitizer != 'none'
+        ? 'dartcliruntime_$sanitizer'
+        : 'dartcliruntime';
+    return _executablePathFor(
+      name,
+      forceProductInBuildRoot: true,
+    );
+  }
+
   String get genSnapshot => _executablePathFor(
     'gen_snapshot',
     forceProductInBuildRoot: true,

--- a/pkg/dartdev/lib/src/commands/build.dart
+++ b/pkg/dartdev/lib/src/commands/build.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:code_assets/code_assets.dart' hide Sanitizer;
+import 'package:dart2native/dart2native.dart' show markExecutable;
 import 'package:dart2native/generate.dart';
 import 'package:dartdev/src/commands/compile.dart';
 import 'package:dartdev/src/experiments.dart';
@@ -61,6 +62,7 @@ class BuildCliSubcommand extends CompileSubcommandCommand {
   static const String cmdName = 'cli';
 
   static final OS targetOS = OS.current;
+  static final bool busyBoxStyle = targetOS == OS.linux;
   late final List<File> entryPoints;
 
   final bool dataAssetsExperimentEnabled;
@@ -86,7 +88,7 @@ The resulting CLI app bundle is structured in the following manner:
 
 bundle/
   bin/
-    <executable>
+    <executables>
   lib/
     <dynamic libraries>
 ''',
@@ -187,18 +189,18 @@ then that is used instead.''',
   Future<int> run() async {
     final args = argResults!;
     final sanitizer = Sanitizer.fromString(args.option('target-sanitizer'))!;
-    final targetDartAotRuntime = sdk.dartAotRuntimeFor(
-      sanitizer: sanitizer.name,
-    );
+    final targetRuntime = busyBoxStyle
+        ? sdk.dartCliRuntimeFor(sanitizer: sanitizer.name)
+        : sdk.dartAotRuntimeFor(sanitizer: sanitizer.name);
     if (!checkArtifactExists(sdk.genKernelSnapshot) ||
         !checkArtifactExists(sdk.genSnapshot) ||
-        !checkArtifactExists(targetDartAotRuntime) ||
+        !checkArtifactExists(targetRuntime) ||
         !checkArtifactExists(sdk.dart)) {
       return 255;
     }
 
     var genSnapshotBinary = sdk.genSnapshot;
-    var dartAotRuntimeBinary = targetDartAotRuntime;
+    var dartAotRuntimeBinary = targetRuntime;
 
     final crossTarget = crossCompilationTarget(args);
     if (crossTarget != null) {
@@ -372,7 +374,9 @@ then that is used instead.''',
     // next to it.
     final bundleDirectory = Directory.fromUri(outputUri.resolve('bundle/'));
     final binDirectory = Directory.fromUri(bundleDirectory.uri.resolve('bin/'));
+    final libDirectory = Directory.fromUri(bundleDirectory.uri.resolve('lib/'));
     await binDirectory.create(recursive: true);
+    await libDirectory.create(recursive: true);
 
     final packageConfig = await DartNativeAssetsBuilder.loadPackageConfig(
       packageConfigUri,
@@ -456,6 +460,9 @@ then that is used instead.''',
         final outputExeUri = binDirectory.uri.resolve(
           targetOS.executableFileName(e.name),
         );
+        final outputSnapshotUri = busyBoxStyle
+            ? libDirectory.uri.resolve(_linuxAotSnapshotFileName(e.name))
+            : null;
         final generator = KernelGenerator(
           genSnapshot: genSnapshotPath ?? sdk.genSnapshot,
           targetDartAotRuntime:
@@ -463,9 +470,9 @@ then that is used instead.''',
               sdk.dartAotRuntimeFor(
                 sanitizer: sanitizer.name,
               ),
-          kind: Kind.exe,
+          kind: busyBoxStyle ? Kind.aot : Kind.exe,
           sourceFile: e.sourceEntryPoint.toFilePath(),
-          outputFile: outputExeUri.toFilePath(),
+          outputFile: (outputSnapshotUri ?? outputExeUri).toFilePath(),
           verbose: verbose,
           verbosity: verbosity,
           defines: [...sanitizer.defines],
@@ -552,7 +559,18 @@ Use linkMode as dynamic library instead.""",
           ],
         );
 
-        if (targetOS == OS.macOS) {
+        if (busyBoxStyle) {
+          if (first) {
+            await File(
+              sdk.dartCliRuntimeFor(sanitizer: sanitizer.name),
+            ).copy(outputExeUri.toFilePath());
+            await markExecutable(outputExeUri.toFilePath());
+          } else {
+            await Link.fromUri(
+              outputExeUri,
+            ).create(targetOS.executableFileName(executables.first.name));
+          }
+        } else if (targetOS == OS.macOS) {
           // The dylibs are opened with a relative path to the executable.
           // MacOS prevents opening dylibs that are not on the include path.
           await rewriteInstallPath(outputExeUri);
@@ -580,3 +598,6 @@ extension on String {
 ///
 /// Recorded usages and multiple executables are not supported yet.
 typedef DartBuildExecutables = List<({String name, Uri sourceEntryPoint})>;
+
+String _linuxAotSnapshotFileName(String executableName) =>
+    'libdartaot$executableName.so';

--- a/pkg/dartdev/test/native_assets/build_test.dart
+++ b/pkg/dartdev/test/native_assets/build_test.dart
@@ -62,6 +62,17 @@ void main([List<String> args = const []]) async {
             .resolve(OS.current.executableFileName('dart_app'));
         final absoluteExeUri = dartAppUri.resolveUri(relativeExeUri);
         expect(await File.fromUri(absoluteExeUri).exists(), true);
+        if (Platform.isLinux) {
+          final relativeSnapshotUri = relativeBundleUri
+              .resolve('lib/')
+              .resolve(_linuxAotSnapshotFileName('dart_app'));
+          expect(
+            await File.fromUri(
+              dartAppUri.resolveUri(relativeSnapshotUri),
+            ).exists(),
+            true,
+          );
+        }
         await _withTempDir((tempUri) async {
           // The link needs to have the same extension as the executable on
           // Windows to be able to be executable.
@@ -430,7 +441,7 @@ void main(List<String> args) {
         );
         final Directory binDir = File(Platform.resolvedExecutable).parent;
         final sanitizedRuntime =
-            File.fromUri(binDir.uri.resolve('dartaotruntime_$sanitizer'));
+            File.fromUri(binDir.uri.resolve('dartcliruntime_$sanitizer'));
         if (sanitizedRuntime.existsSync()) {
           expect(result.exitCode, 0);
           final relativeExeUri = relativeBundleUri
@@ -438,8 +449,17 @@ void main(List<String> args) {
               .resolve(OS.current.executableFileName('dart_app'));
           final absoluteExeUri = dartAppUri.resolveUri(relativeExeUri);
           expect(await File.fromUri(absoluteExeUri).exists(), true);
+          final relativeSnapshotUri = relativeBundleUri
+              .resolve('lib/')
+              .resolve(_linuxAotSnapshotFileName('dart_app'));
+          expect(
+            await File.fromUri(
+              dartAppUri.resolveUri(relativeSnapshotUri),
+            ).exists(),
+            true,
+          );
         } else {
-          expect(result.stderr, contains('dartaotruntime_$sanitizer'));
+          expect(result.stderr, contains('dartcliruntime_$sanitizer'));
           expect(result.exitCode, 255);
         }
       });
@@ -717,3 +737,6 @@ Uri removeDotExe(Uri withExe) {
   final fileName = exeName.replaceAll('.exe', '');
   return withExe.resolve(fileName);
 }
+
+String _linuxAotSnapshotFileName(String executableName) =>
+    'libdartaot$executableName.so';

--- a/runtime/bin/BUILD.gn
+++ b/runtime/bin/BUILD.gn
@@ -1031,6 +1031,75 @@ dart_executable("dartaotruntime_product") {
   ]
 }
 
+if (is_linux) {
+  dart_executable("dartcliruntime") {
+    extra_configs = [
+      "..:dart_aotruntime_config",
+      "..:add_empty_macho_section_config",
+    ]
+    extra_defines = [ "DART_CLI_RUNTIME" ]
+    extra_deps = [
+      ":icudtl_cc",
+      "..:libdart_aotruntime",
+      "../platform:libdart_platform_aotruntime",
+    ]
+    extra_sources = [
+      "common_options.h",
+      "gzip.cc",
+      "gzip.h",
+      "loader.cc",
+      "loader.h",
+      "main.cc",
+      "main_impl.cc",
+      "main_options.cc",
+      "main_options.h",
+      "snapshot_empty.cc",
+    ]
+
+    if (dart_runtime_mode == "release") {
+      extra_deps += [
+        ":native_assets_api_product",
+        ":shared_object_loaders_product",
+      ]
+    } else {
+      extra_deps += [
+        ":native_assets_api",
+        ":shared_object_loaders",
+      ]
+    }
+  }
+
+  dart_executable("dartcliruntime_product") {
+    use_product_mode = true
+    extra_configs = [
+      "..:dart_aotruntime_config",
+      "..:add_empty_macho_section_config",
+    ]
+    extra_defines = [ "DART_CLI_RUNTIME" ]
+    extra_deps = [
+      "..:libdart_aotruntime_product",
+      "../platform:libdart_platform_aotruntime_product",
+    ]
+    extra_sources = [
+      "common_options.h",
+      "gzip.cc",
+      "gzip.h",
+      "loader.cc",
+      "loader.h",
+      "main.cc",
+      "main_impl.cc",
+      "main_options.cc",
+      "main_options.h",
+      "snapshot_empty.cc",
+    ]
+
+    extra_deps += [
+      ":native_assets_api_product",
+      ":shared_object_loaders_product",
+    ]
+  }
+}
+
 if (dart_target_arch != "ia32" && dart_target_arch != "x86") {
   dart_executable("dart") {
     use_product_mode = true

--- a/runtime/bin/main_impl.cc
+++ b/runtime/bin/main_impl.cc
@@ -28,6 +28,7 @@
 #include "bin/platform.h"
 #include "bin/process.h"
 #include "bin/snapshot_utils.h"
+#include "bin/uri.h"
 #include "bin/utils.h"
 #include "bin/vmservice_impl.h"
 #include "include/bin/dart_io_api.h"
@@ -68,6 +69,40 @@ static const uint8_t* app_snapshot_text = nullptr;
 static bool kernel_isolate_is_running = false;
 
 static Dart_Isolate main_isolate = nullptr;
+
+#if defined(DART_PRECOMPILED_RUNTIME) && defined(DART_CLI_RUNTIME) &&          \
+    defined(DART_HOST_OS_LINUX)
+static CStringUniquePtr BuildCliSnapshotPath(const char* executable_path,
+                                             const char* executable_name) {
+  const char* executable_basename = strrchr(executable_name, '/');
+  executable_basename = executable_basename == nullptr
+                            ? executable_name
+                            : executable_basename + 1;
+  if (executable_basename[0] == '\0') {
+    return CStringUniquePtr();
+  }
+
+  CStringUniquePtr snapshot_path(
+      Utils::SCreate("../lib/libdartaot%s.so", executable_basename));
+  return ResolvePath(snapshot_path.get(), executable_path);
+}
+
+static CStringUniquePtr ResolveCliSnapshotPath(const char* executable_path,
+                                               const char* argv0) {
+  auto candidate = BuildCliSnapshotPath(executable_path, argv0);
+  if (candidate != nullptr && File::Exists(nullptr, candidate.get())) {
+    return candidate;
+  }
+
+  candidate = BuildCliSnapshotPath(executable_path, executable_path);
+  if (candidate != nullptr && File::Exists(nullptr, candidate.get())) {
+    return candidate;
+  }
+
+  return CStringUniquePtr();
+}
+#endif  // defined(DART_PRECOMPILED_RUNTIME) && defined(DART_CLI_RUNTIME) &&
+        // defined(DART_HOST_OS_LINUX)
 
 #define SAVE_ERROR_AND_EXIT(result)                                            \
   *error = Utils::StrDup(Dart_GetError(result));                               \
@@ -1182,6 +1217,7 @@ void main(int argc, char** argv) {
 
   AppSnapshot* app_snapshot = nullptr;
 #if defined(DART_PRECOMPILED_RUNTIME)
+  CStringUniquePtr cli_snapshot_path;
   // If the executable binary contains the runtime together with an appended
   // snapshot, load and run that.
   // Any arguments passed to such an executable are meant for the actual
@@ -1190,10 +1226,7 @@ void main(int argc, char** argv) {
   const size_t kPathBufSize = PATH_MAX + 1;
   char executable_path[kPathBufSize];
   if (Platform::ResolveExecutablePathInto(executable_path, kPathBufSize) > 0) {
-    app_snapshot = Snapshot::TryReadAppendedAppSnapshot(executable_path);
-    if (app_snapshot != nullptr) {
-      script_name = argv[0];
-
+    auto prepare_app_snapshot = [&]() {
       char* error = nullptr;
       asset_resolution_base = ResolveSymlinks(executable_path, &error);
       if (error != nullptr) {
@@ -1203,31 +1236,43 @@ void main(int argc, char** argv) {
         Platform::Exit(kErrorExitCode);
       }
 
-      // Store the executable name.
       Platform::SetExecutableName(argv[0]);
 
-      // Parse out options to be passed to dart main.
       for (int i = 1; i < argc; i++) {
         dart_options.AddArgument(argv[i]);
       }
 
-      // Parse DART_VM_OPTIONS options.
       int env_argc = 0;
       char** env_argv = Options::GetEnvArguments(argv[0], &env_argc);
       if (env_argv != nullptr) {
-        // Any Dart options that are generated based on parsing DART_VM_OPTIONS
-        // are useless, so we'll throw them away rather than passing them along.
+        // Discard Dart options produced while parsing DART_VM_OPTIONS.
         CommandLineOptions tmp_options(env_argc + EXTRA_VM_ARGUMENTS);
         vm_options.EnsureCapacity(env_argc + EXTRA_VM_ARGUMENTS);
         parse_arguments(env_argc, env_argv, &vm_options, &tmp_options,
                         /*parsing_dart_vm_options=*/true);
       }
+    };
+
+    app_snapshot = Snapshot::TryReadAppendedAppSnapshot(executable_path);
+    if (app_snapshot != nullptr) {
+      script_name = argv[0];
+      prepare_app_snapshot();
     }
+
+#if defined(DART_CLI_RUNTIME) && defined(DART_HOST_OS_LINUX)
+    if (app_snapshot == nullptr) {
+      cli_snapshot_path = ResolveCliSnapshotPath(executable_path, argv[0]);
+      script_name = cli_snapshot_path.get();
+      if (script_name != nullptr) {
+        prepare_app_snapshot();
+      }
+    }
+#endif  // defined(DART_CLI_RUNTIME) && defined(DART_HOST_OS_LINUX)
   }
 #endif
 
   // Parse command line arguments.
-  if (app_snapshot == nullptr) {
+  if (app_snapshot == nullptr && script_name == nullptr) {
     parse_arguments(argc, argv, &vm_options, &dart_options,
                     /*parsing_dart_vm_options=*/false);
   }

--- a/sdk/BUILD.gn
+++ b/sdk/BUILD.gn
@@ -30,6 +30,7 @@ declare_args() {
   dartvm_stripped_binary = "dartvm"
   dart_stripped_binary = "dart"
   dart_aotruntime_stripped_binary = "dartaotruntime_product"
+  dart_cliruntime_stripped_binary = "dartcliruntime_product"
   gen_snapshot_stripped_binary = "gen_snapshot_product"
   analyze_snapshot_binary = "analyze_snapshot"
   wasm_opt_stripped_binary = "wasm-opt"
@@ -46,6 +47,7 @@ declare_args() {
 # ......dartvm or dartvm.exe (executable)
 # ......dart.lib (import library for VM native extensions on Windows)
 # ......dartaotruntime or dartaotruntime.exe (executable)
+# ......dartcliruntime (Linux only)
 # ......utils/gen_snapshot or utils/gen_snapshot.exe (if not on ia32)
 # ......snapshots/
 # ........analysis_server.dart.snapshot (JIT snapshot)
@@ -386,6 +388,30 @@ if (_has_dot_sym) {
   }
 }
 
+if (is_linux) {
+  copy("copy_dart_cliruntime") {
+    visibility = [ ":*" ]
+    deps = [ "../runtime/bin:dartcliruntime_product" ]
+    src_dir =
+        get_label_info("../runtime/bin:dartcliruntime_product", "root_out_dir")
+    sources =
+        [ "$src_dir/${dart_cliruntime_stripped_binary}${executable_suffix}" ]
+    outputs = [
+      "$root_out_dir/$dart_sdk_output/bin/dartcliruntime${executable_suffix}",
+    ]
+  }
+  if (_has_dot_sym) {
+    copy("copy_dart_cliruntime_sym") {
+      visibility = [ ":*" ]
+      deps = [ "../runtime/bin:dartcliruntime_product" ]
+      src_dir = get_label_info("../runtime/bin:dartcliruntime_product",
+                               "root_out_dir")
+      sources = [ "$src_dir/dartcliruntime_product${executable_suffix}.sym" ]
+      outputs = [ "$root_out_dir/$dart_sdk_output/bin/dartcliruntime.sym" ]
+    }
+  }
+}
+
 copy_sanitizer_deps = []
 
 # If the default toolchain is already using a sanitizer, the sanitizer variant
@@ -427,7 +453,18 @@ if (!using_sanitizer && current_os == "linux" &&
           [ "$src_dir/${dart_aotruntime_stripped_binary}${executable_suffix}" ]
       outputs = [ "$root_out_dir/$dart_sdk_output/bin/dartaotruntime_${sanitizer}${executable_suffix}" ]
     }
+    copy("copy_dart_cliruntime_$sanitizer") {
+      visibility = [ ":*" ]
+      deps = [ "../runtime/bin:dartcliruntime_product(${current_toolchain}_${sanitizer})" ]
+      src_dir = get_label_info(
+              "../runtime/bin:dartcliruntime_product(${current_toolchain}_${sanitizer})",
+              "root_out_dir")
+      sources =
+          [ "$src_dir/${dart_cliruntime_stripped_binary}${executable_suffix}" ]
+      outputs = [ "$root_out_dir/$dart_sdk_output/bin/dartcliruntime_${sanitizer}${executable_suffix}" ]
+    }
     copy_sanitizer_deps += [ ":copy_dart_aotruntime_$sanitizer" ]
+    copy_sanitizer_deps += [ ":copy_dart_cliruntime_$sanitizer" ]
   }
 }
 
@@ -481,8 +518,14 @@ group("group_dart2native") {
     ":copy_gen_snapshot",
     ":copy_vm_platform_product",
   ]
+  if (is_linux) {
+    deps += [ ":copy_dart_cliruntime" ]
+  }
   if (_has_dot_sym) {
     deps += [ ":copy_dart_aotruntime_sym" ]
+    if (is_linux) {
+      deps += [ ":copy_dart_cliruntime_sym" ]
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #63435

`dart build cli` currently produces a separate executable with an appended AOT snapshot for each entrypoint. On Linux, this keeps the snapshot opaque to native symbolizers and duplicates the runtime in bundles with multiple executables.

This implements the BusyBox-style layout discussed in the issue:

- adds a Linux `dartcliruntime` that resolves `../lib/dartaotsnapshot<executable-name>` from `argv[0]`
- falls back to the resolved executable name so invoking a bundle executable through an external symlink still works
- distributes normal and ASan/MSan/TSan variants of `dartcliruntime` in the SDK
- changes Linux `dart build cli` bundles to contain one runtime, symlink additional entrypoints to it, and keep each AOT snapshot under `bundle/lib/`
- leaves the existing bundle behavior unchanged on other platforms

The native-assets tests cover the new layout, execution through symlinks, custom entrypoints, and sanitizer runtimes.

Tested with:

```text
python3 tools/test.py -n unittest-asserts-release-linux-x64 pkg/dartdev/test/native_assets/build_test.dart
```
