### PR TITLE
Extend SortUnnamedConstructorFirst fix to handle enums

### DIFF
--- a/pkg/analysis_server/lib/src/services/correction/dart/sort_unnamed_constructor_first.dart
+++ b/pkg/analysis_server/lib/src/services/correction/dart/sort_unnamed_constructor_first.dart
@@ -32,17 +32,23 @@ class SortUnnamedConstructorFirst extends ResolvedCorrectionProducer {
         ? coveringNode
         : coveringNode?.parent;
 
-    var clazz = constructorDeclaration?.parent?.parent;
-    if (clazz is! ClassDeclaration) {
-      return;
+    var declaration = constructorDeclaration?.parent?.parent;
+    NodeList<ClassMember> members;
+    int topOfBodyOffset;
+    switch (declaration) {
+      case ClassDeclaration(body: BlockClassBody body):
+        members = body.members;
+        topOfBodyOffset = body.leftBracket.end;
+      case EnumDeclaration(body: BlockEnumBody body):
+        members = body.members;
+        topOfBodyOffset =
+            body.semicolon?.end ??
+            body.constants.lastOrNull?.end ??
+            body.leftBracket.end;
+      default:
+        return;
     }
 
-    var body = clazz.body;
-    if (body is! BlockClassBody) {
-      return;
-    }
-
-    var members = body.members;
     var constructors = members.whereType<ConstructorDeclaration>().toList();
 
     var firstConstructor = constructors.firstOrNull;
@@ -70,11 +76,11 @@ class SortUnnamedConstructorFirst extends ResolvedCorrectionProducer {
       builder.addDeletion(moveRange);
 
       var firstIndex = members.indexOf(firstConstructor);
-      var tokenBeforeFirst = firstIndex != 0
-          ? members[firstIndex - 1].endToken
-          : body.leftBracket;
+      var insertionOffset = firstIndex != 0
+          ? members[firstIndex - 1].endToken.end
+          : topOfBodyOffset;
       builder.addSimpleInsertion(
-        tokenBeforeFirst.end,
+        insertionOffset,
         utils.getRangeText(moveRange),
       );
     });

--- a/pkg/analysis_server/test/src/services/correction/fix/sort_unnamed_constructor_first_test.dart
+++ b/pkg/analysis_server/test/src/services/correction/fix/sort_unnamed_constructor_first_test.dart
@@ -44,6 +44,43 @@ class B {
 }
 ''');
   }
+
+  Future<void> test_one_fix_enum() async {
+    await resolveTestCode('''
+enum A {
+  v,
+  w.a();
+
+  A.a();
+  A();
+}
+
+enum B {
+  x,
+  y.b();
+
+  B.b();
+  B();
+}
+''');
+    await assertHasFix('''
+enum A {
+  v,
+  w.a();
+  A();
+
+  A.a();
+}
+
+enum B {
+  x,
+  y.b();
+  B();
+
+  B.b();
+}
+''');
+  }
 }
 
 @reflectiveTest
@@ -53,6 +90,66 @@ class SortUnnamedConstructorFirstTest extends FixProcessorLintTest {
 
   @override
   String get lintCode => LintNames.sort_unnamed_constructors_first;
+
+  Future<void> test_enum_newHead() async {
+    await resolveTestCode('''
+enum A {
+  v,
+  w.a();
+
+  A.a();
+  new();
+}
+''');
+    await assertHasFix('''
+enum A {
+  v,
+  w.a();
+  new();
+
+  A.a();
+}
+''');
+  }
+
+  Future<void> test_enum_noConstants() async {
+    verifyNoTestUnitErrors = false;
+    await resolveTestCode('''
+enum A {
+  ;
+  A.a();
+  A();
+}
+''');
+    await assertHasFix('''
+enum A {
+  ;
+  A();
+  A.a();
+}
+''', filter: lintNameFilter(lintCode));
+  }
+
+  Future<void> test_enum_simple() async {
+    await resolveTestCode('''
+enum A {
+  v,
+  w.a();
+
+  A.a();
+  A();
+}
+''');
+    await assertHasFix('''
+enum A {
+  v,
+  w.a();
+  A();
+
+  A.a();
+}
+''');
+  }
 
   Future<void> test_keyword_factory() async {
     await resolveTestCode('''


### PR DESCRIPTION
The `SortUnnamedConstructorFirst` lint fix previously only fired for classes since it gated on `ClassDeclaration` and `BlockClassBody`. This extends it to also accept `EnumDeclaration` with `BlockEnumBody` so the fix works on enums when `sort_unnamed_constructors_first` is enabled.

For enums, the top-of-body insertion offset (used when there are no existing constructors before the unnamed one) is computed as:

`semicolon?.end ?? constants.lastOrNull?.end ?? leftBracket.end`

This mirrors the pattern used by `SortConstructorFirst`, which was extended to handle enums in #61788.

Added 4 tests for the single-fix case (simple, named-then-unnamed, `new()` head syntax, no-constants mid-edit) plus 1 bulk-fix test for multiple enums.

Fixes #63703

- [x] I've reviewed the contributor guide and applied the relevant portions to this PR.