### PR TITLE
bound netlink address copy to destination size in getifaddrs

### DIFF
--- a/runtime/bin/ifaddrs.cc
+++ b/runtime/bin/ifaddrs.cc
@@ -42,32 +42,33 @@ static void SetFlags(struct ifaddrs* ifaddr, int flag) {
   ifaddr->ifa_flags = flag;
 }
 
-static void SetAddresses(struct ifaddrs* ifaddr,
-                         int family,
-                         int index,
-                         void* data,
-                         size_t len) {
+DART_WARN_UNUSED_RESULT static bool SetAddresses(struct ifaddrs* ifaddr,
+                                                 int family,
+                                                 int index,
+                                                 void* data,
+                                                 size_t len) {
   if (family == AF_INET6) {
+    // The attribute length comes from the netlink message and is not guaranteed
+    // to match the address family, so reject anything that doesn't fit.
+    if (len != sizeof(sockaddr_in6::sin6_addr)) {
+      return false;
+    }
     sockaddr_in6* socketaddr = new sockaddr_in6;
     socketaddr->sin6_family = AF_INET6;
     socketaddr->sin6_scope_id = index;
-    // The attribute length comes from the netlink message and is not guaranteed
-    // to match the address family, so cap the copy at the destination size.
-    if (len > sizeof(socketaddr->sin6_addr)) {
-      len = sizeof(socketaddr->sin6_addr);
-    }
     memmove(&socketaddr->sin6_addr, data, len);
     ifaddr->ifa_addr = reinterpret_cast<sockaddr*>(socketaddr);
-    return;
+    return true;
   }
   ASSERT(family == AF_INET);
+  if (len != sizeof(sockaddr_in::sin_addr)) {
+    return false;
+  }
   sockaddr_in* socketaddr = new sockaddr_in;
   socketaddr->sin_family = AF_INET;
-  if (len > sizeof(socketaddr->sin_addr)) {
-    len = sizeof(socketaddr->sin_addr);
-  }
   memmove(&socketaddr->sin_addr, data, len);
   ifaddr->ifa_addr = reinterpret_cast<sockaddr*>(socketaddr);
+  return true;
 }
 
 static void SetNetmask(struct ifaddrs* ifaddr, int family, int prefixlen) {
@@ -98,7 +99,9 @@ static bool SetIfAddrsFromAddrMsg(struct ifaddrs* ifaddr,
                                   void* bytes,
                                   size_t len,
                                   nlmsghdr* header) {
-  SetAddresses(ifaddr, msg->ifa_family, msg->ifa_index, bytes, len);
+  if (!SetAddresses(ifaddr, msg->ifa_family, msg->ifa_index, bytes, len)) {
+    return false;
+  }
   SetNetmask(ifaddr, msg->ifa_family, msg->ifa_prefixlen);
   SetFlags(ifaddr, msg->ifa_flags);
   return SetIfName(ifaddr, msg->ifa_index);
@@ -109,7 +112,9 @@ static bool SetIfAddrsFromInfoMsg(struct ifaddrs* ifaddr,
                                   void* bytes,
                                   size_t len,
                                   nlmsghdr* header) {
-  SetAddresses(ifaddr, ifi->ifi_family, ifi->ifi_index, bytes, len);
+  if (!SetAddresses(ifaddr, ifi->ifi_family, ifi->ifi_index, bytes, len)) {
+    return false;
+  }
   SetNetmask(ifaddr, ifi->ifi_family, 0);
   SetFlags(ifaddr, ifi->ifi_flags);
   return SetIfName(ifaddr, ifi->ifi_index);

--- a/runtime/bin/ifaddrs.cc
+++ b/runtime/bin/ifaddrs.cc
@@ -51,6 +51,11 @@ static void SetAddresses(struct ifaddrs* ifaddr,
     sockaddr_in6* socketaddr = new sockaddr_in6;
     socketaddr->sin6_family = AF_INET6;
     socketaddr->sin6_scope_id = index;
+    // The attribute length comes from the netlink message and is not guaranteed
+    // to match the address family, so cap the copy at the destination size.
+    if (len > sizeof(socketaddr->sin6_addr)) {
+      len = sizeof(socketaddr->sin6_addr);
+    }
     memmove(&socketaddr->sin6_addr, data, len);
     ifaddr->ifa_addr = reinterpret_cast<sockaddr*>(socketaddr);
     return;
@@ -58,6 +63,9 @@ static void SetAddresses(struct ifaddrs* ifaddr,
   ASSERT(family == AF_INET);
   sockaddr_in* socketaddr = new sockaddr_in;
   socketaddr->sin_family = AF_INET;
+  if (len > sizeof(socketaddr->sin_addr)) {
+    len = sizeof(socketaddr->sin_addr);
+  }
   memmove(&socketaddr->sin_addr, data, len);
   ifaddr->ifa_addr = reinterpret_cast<sockaddr*>(socketaddr);
 }


### PR DESCRIPTION
SetAddresses in the Android getifaddrs fallback copies RTA_PAYLOAD bytes from a netlink IFA_ADDRESS attribute straight into the 4-byte sin_addr or 16-byte sin6_addr, and RTA_OK only bounds the attribute against the read buffer, so a malformed RTM_NEWADDR with an oversized address attribute overflows the freshly allocated sockaddr on the heap. Cap the copy at the destination field size in both branches, matching the length check GetSockAddr already does for the same address bytes.