### PR TITLE
Fix Create field/getter producing invalid syntax on multi-line enums with trailing comma

### DIFF
--- a/pkg/analysis_server/test/src/services/correction/fix/create_field_test.dart
+++ b/pkg/analysis_server/test/src/services/correction/fix/create_field_test.dart
@@ -127,6 +127,56 @@ enum E {
 ''');
   }
 
+  Future<void> test_multiLine_noTrailingComma() async {
+    await resolveTestCode('''
+enum E {
+  one,
+  two
+}
+
+int f(E e) {
+  return e.a;
+}
+''');
+    await assertHasFix('''
+enum E {
+  one,
+  two;
+
+  final int a;
+}
+
+int f(E e) {
+  return e.a;
+}
+''');
+  }
+
+  Future<void> test_multiLine_trailingComma() async {
+    await resolveTestCode('''
+enum E {
+  one,
+  two,
+}
+
+int f(E e) {
+  return e.a;
+}
+''');
+    await assertHasFix('''
+enum E {
+  one,
+  two;
+
+  final int a;
+}
+
+int f(E e) {
+  return e.a;
+}
+''');
+  }
+
   Future<void> test_setter_static() async {
     await resolveTestCode('''
 enum E { a }

--- a/pkg/analysis_server/test/src/services/correction/fix/create_getter_test.dart
+++ b/pkg/analysis_server/test/src/services/correction/fix/create_getter_test.dart
@@ -11,9 +11,58 @@ import 'fix_processor.dart';
 
 void main() {
   defineReflectiveSuite(() {
+    defineReflectiveTests(CreateGetterEnumTest);
     defineReflectiveTests(CreateGetterMixinTest);
     defineReflectiveTests(CreateGetterTest);
   });
+}
+
+@reflectiveTest
+class CreateGetterEnumTest extends FixProcessorTest {
+  @override
+  FixKind get kind => DartFixKind.createGetter;
+
+  Future<void> test_multiLine_noTrailingComma() async {
+    await resolveTestCode('''
+enum E {
+  one,
+  two
+}
+
+int f(E e) => e.a;
+''');
+    await assertHasFix('''
+enum E {
+  one,
+  two;
+
+  int get a => null;
+}
+
+int f(E e) => e.a;
+''');
+  }
+
+  Future<void> test_multiLine_trailingComma() async {
+    await resolveTestCode('''
+enum E {
+  one,
+  two,
+}
+
+int f(E e) => e.a;
+''');
+    await assertHasFix('''
+enum E {
+  one,
+  two;
+
+  int get a => null;
+}
+
+int f(E e) => e.a;
+''');
+  }
 }
 
 @reflectiveTest

--- a/pkg/analyzer_plugin/lib/src/utilities/change_builder/change_builder_dart.dart
+++ b/pkg/analyzer_plugin/lib/src/utilities/change_builder/change_builder_dart.dart
@@ -2365,7 +2365,12 @@ class DartFileEditBuilderImpl extends FileEditBuilderImpl
         write,
       );
     } else {
-      addInsertion(offset, insertBeforeExisting: false, write);
+      var trailingComma = preparer._trailingComma;
+      if (trailingComma != null) {
+        addReplacement(range.token(trailingComma), write);
+      } else {
+        addInsertion(offset, insertBeforeExisting: false, write);
+      }
     }
   }
 
@@ -3221,6 +3226,8 @@ class _InsertionPreparer {
 
   late final bool _foundTargetMember;
 
+  Token? _trailingComma;
+
   factory _InsertionPreparer(
     CompilationUnitMember declaration,
     LineInfo lineInfo,
@@ -3284,7 +3291,11 @@ class _InsertionPreparer {
       if (semicolon != null) {
         return semicolon.end;
       } else if (hasConstants) {
-        return lastConstant!.end;
+        var next = lastConstant!.endToken.next;
+        if (next != null && next.type == TokenType.COMMA) {
+          _trailingComma = next;
+        }
+        return lastConstant.end;
       } else if (token != null) {
         return token.offset;
       }

--- a/pkg/analyzer_plugin/test/src/utilities/change_builder/change_builder_dart_test.dart
+++ b/pkg/analyzer_plugin/test/src/utilities/change_builder/change_builder_dart_test.dart
@@ -472,6 +472,54 @@ void f() {
     expect(edits.first.replacement, equalsIgnoringWhitespace('var f;'));
   }
 
+  Future<void> test_insertField_enum_multiLine_noTrailingComma() async {
+    var path = convertPath('/home/test/lib/test.dart');
+    var content = '''
+enum E {
+  ONE
+}''';
+    addSource(path, content);
+
+    var resolvedUnit = await resolveFile(path);
+    var findNode = FindNode(resolvedUnit.content, resolvedUnit.unit);
+    var enumNode = findNode.enumDeclaration('enum E');
+
+    var builder = await newBuilder();
+    await builder.addDartFileEdit(path, (builder) {
+      builder.insertField(enumNode, (builder) {
+        builder.writeFieldDeclaration('f');
+      });
+    });
+    var edits = getEdits(builder);
+    expect(edits, hasLength(1));
+    expect(edits.first.length, 0);
+    expect(edits.first.replacement, equalsIgnoringWhitespace('; var f;'));
+  }
+
+  Future<void> test_insertField_enum_multiLine_trailingComma() async {
+    var path = convertPath('/home/test/lib/test.dart');
+    var content = '''
+enum E {
+  ONE,
+}''';
+    addSource(path, content);
+
+    var resolvedUnit = await resolveFile(path);
+    var findNode = FindNode(resolvedUnit.content, resolvedUnit.unit);
+    var enumNode = findNode.enumDeclaration('enum E');
+
+    var builder = await newBuilder();
+    await builder.addDartFileEdit(path, (builder) {
+      builder.insertField(enumNode, (builder) {
+        builder.writeFieldDeclaration('f');
+      });
+    });
+    var edits = getEdits(builder);
+    expect(edits, hasLength(1));
+    expect(edits.first.length, 1);
+    expect(edits.first.replacement, equalsIgnoringWhitespace('; var f;'));
+  }
+
   Future<void> test_writeClassDeclaration_interfaces() async {
     var path = convertPath('$testPackageRootPath/lib/test.dart');
     addSource(path, 'class A {}');


### PR DESCRIPTION
When adding the first enhanced member to a multi-line enum that has a trailing comma on its last constant and no explicit semicolon, the `Create field` and `Create getter` quick fixes wrote a `;` at the offset immediately after the last constant's identifier. This left the trailing `,` in place, producing invalid syntax like:

    enum E {
      longEnumName,
      anotherLongEnumName,
      yetAnotherLongEnumName,
      thisOneIsLongToo;
    
      final Object? field;,
    }

The fix detects this case in `_InsertionPreparer.insertionLocation`. When a trailing comma follows the last constant of an enum with no semicolon, the comma token is captured. The caller in `insertIntoUnitMember` then uses `addReplacement` over the comma token instead of `addInsertion`, so writing `;` atomically replaces the `,` rather than getting stranded before it.

Added two tests each to `create_field_test.dart` and `create_getter_test.dart` covering both the trailing-comma case (bug fix) and the no-trailing-comma case (regression check), plus two low-level tests in `change_builder_dart_test.dart` verifying the edit shape directly.

Closes #62874

- [x] I've reviewed the contributor guide and applied the relevant portions to this PR.