### PR TITLE
bounds-check section string table index in elf loader

### DIFF
--- a/runtime/bin/elf_loader.cc
+++ b/runtime/bin/elf_loader.cc
@@ -236,6 +236,8 @@ bool LoadedElf::ReadSectionTable() {
 }
 
 bool LoadedElf::ReadSectionStringTable() {
+  CHECK_ERROR(header_.shstrtab_section_index < header_.num_section_headers,
+              "Section header string table index out of bounds.");
   const dart::elf::SectionHeader header =
       section_table_[header_.shstrtab_section_index];
   section_string_table_mapping_.reset(


### PR DESCRIPTION
readsectionstringtable in runtime/bin/elf_loader.cc indexes section_table_ with header_.shstrtab_section_index taken verbatim from the elf header, but the section table is only mapped for header_.num_section_headers entries and the index is never checked against it. a crafted snapshot fed to Dart_LoadELF or Dart_LoadELF_Memory (shstrtab_section_index well past num_section_headers) reads a SectionHeader out of bounds, and that stray header's file_offset/file_size then drive the string-table mmap. the fix rejects an out-of-range index up front with the same CHECK_ERROR pattern readheader already uses for the other header fields, so the loader fails cleanly like it does for a bad header size or machine. confirmed the out-of-bounds read with an asan model of the exact indexing (heap-buffer-overflow, read of one 64-byte SectionHeader past the table).