### PR TITLE
[dart:io] set close-on-exec on File::CreatePipe pipe descriptors

### DIFF
--- a/runtime/bin/file_fuchsia.cc
+++ b/runtime/bin/file_fuchsia.cc
@@ -357,6 +357,8 @@ bool File::CreatePipe(Namespace* namespc, File** readPipe, File** writePipe) {
   if (status != 0) {
     return false;
   }
+  FDUtils::SetCloseOnExec(pipe_fds[0]);
+  FDUtils::SetCloseOnExec(pipe_fds[1]);
   *readPipe = OpenFD(pipe_fds[0]);
   *writePipe = OpenFD(pipe_fds[1]);
   return true;

--- a/runtime/bin/file_linux.cc
+++ b/runtime/bin/file_linux.cc
@@ -350,7 +350,7 @@ bool File::CreateLink(Namespace* namespc,
 
 bool File::CreatePipe(Namespace* namespc, File** readPipe, File** writePipe) {
   int pipe_fds[2];
-  int status = NO_RETRY_EXPECTED(pipe(pipe_fds));
+  int status = NO_RETRY_EXPECTED(pipe2(pipe_fds, O_CLOEXEC));
   if (status != 0) {
     return false;
   }

--- a/runtime/bin/file_macos.cc
+++ b/runtime/bin/file_macos.cc
@@ -391,6 +391,8 @@ bool File::CreatePipe(Namespace* namespc, File** readPipe, File** writePipe) {
   if (status != 0) {
     return false;
   }
+  FDUtils::SetCloseOnExec(pipe_fds[0]);
+  FDUtils::SetCloseOnExec(pipe_fds[1]);
   *readPipe = OpenFD(pipe_fds[0]);
   *writePipe = OpenFD(pipe_fds[1]);
   return true;

--- a/runtime/bin/file_win.cc
+++ b/runtime/bin/file_win.cc
@@ -733,7 +733,7 @@ bool File::CreateLink(Namespace* namespc,
 
 bool File::CreatePipe(Namespace* namespc, File** readPipe, File** writePipe) {
   int pipe_fds[2];
-  int status = _pipe(pipe_fds, 4096, _O_BINARY);
+  int status = _pipe(pipe_fds, 4096, _O_BINARY | _O_NOINHERIT);
   if (status != 0) {
     return false;
   }


### PR DESCRIPTION
File::CreatePipe wraps the pipe() (and _pipe() on Windows) descriptors with OpenFD, which never sets close-on-exec, while File::Open in these same files opens with O_CLOEXEC / _O_NOINHERIT. So the descriptors returned by Pipe.create() stay inheritable and both ends leak across exec into any child started by Process.start in the normal mode, which relies on close-on-exec rather than closing every fd. This sets close-on-exec at pipe creation to match File::Open: pipe2(O_CLOEXEC) on Linux, FDUtils::SetCloseOnExec on macOS and Fuchsia, and _O_NOINHERIT on Windows.

---

- [x] I've reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
