### PR TITLE
Register CreateGetter fix for undefinedEnumConstant

### DIFF
--- a/pkg/analysis_server/lib/src/services/correction/fix_internal.dart
+++ b/pkg/analysis_server/lib/src/services/correction/fix_internal.dart
@@ -817,6 +817,7 @@ final _builtInNonLintGenerators = <DiagnosticCode, List<ProducerGenerator>>{
   diag.undefinedEnumConstant: [
     AddEnumConstant.new,
     CreateField.new,
+    CreateGetter.new,
     ChangeTo.getterOrSetter,
     CreateMethodOrFunction.new,
   ],

--- a/pkg/analysis_server/test/src/services/correction/fix/create_getter_test.dart
+++ b/pkg/analysis_server/test/src/services/correction/fix/create_getter_test.dart
@@ -63,6 +63,27 @@ enum E {
 int f(E e) => e.a;
 ''');
   }
+
+  Future<void> test_undefinedEnumConstant() async {
+    await resolveTestCode('''
+enum E { a }
+
+void f(E e) {
+  f(E.b);
+}
+''');
+    await assertHasFix('''
+enum E {
+  a;
+
+  static E get b => null;
+}
+
+void f(E e) {
+  f(E.b);
+}
+''');
+  }
 }
 
 @reflectiveTest


### PR DESCRIPTION
The `CreateGetter` producer already handles static enum access correctly (since CL 501040), but was not registered as a fix for the `undefinedEnumConstant` diagnostic. This meant that on code like:

    enum E { a }
    void f(E e) => f(E.b);

only `Change to 'a'`, `Add enum constant`, and `Create field` were offered, `Create getter` was missing even though the producer supports it.

Adding `CreateGetter.new` to the diagnostic's fix list, mirroring the ordering used for `undefinedGetter` and `undefinedIdentifier`.

Closes https://github.com/dart-lang/sdk/issues/61911

- [x] I've reviewed the contributor guide and applied the relevant portions to this PR.