### PR TITLE
Clarify overridden_fields lint documentation

### DIFF
--- a/pkg/linter/messages.yaml
+++ b/pkg/linter/messages.yaml
@@ -8815,6 +8815,11 @@ LinterLintCode:
       where a reference to one of the fields can be mistaken for a reference to
       the other.
 
+      The field in the subclass doesn't replace the field in the superclass,
+      nor does it change the initializer for the superclass field. Code that
+      accesses the superclass field, for example through `super`, still reads
+      or writes the original storage location.
+
       #### Example
 
       The following code produces this diagnostic because the field `f` in `B`


### PR DESCRIPTION
Clarifies the published documentation for the `overridden_fields` lint.

The issue discussion notes a common misconception: users may think overriding a field just changes the superclass field's initializer. This adds a short explanation that the subclass field is a separate storage location and does not replace or reinitialize the superclass field.

Fixes #58311.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

Validation:
- Parsed `pkg/linter/messages.yaml` with PyYAML successfully.
- Ran `git diff --check` successfully.

Note: I could not run the Dart linter/doc generation tests in this shallow GitHub clone because this environment does not have a Dart SDK binary or the full `gclient fetch` checkout required by `CONTRIBUTING.md`.