### PR TITLE
Rename AddEnumConstant to CreateEnumConstant

### DIFF
--- a/pkg/analysis_server/lib/src/services/correction/dart/create_enum_constant.dart
+++ b/pkg/analysis_server/lib/src/services/correction/dart/create_enum_constant.dart
@@ -12,7 +12,7 @@ import 'package:analyzer_plugin/utilities/change_builder/change_builder_core.dar
 import 'package:analyzer_plugin/utilities/fixes/fixes.dart';
 import 'package:analyzer_plugin/utilities/range_factory.dart';
 
-class AddEnumConstant extends ResolvedCorrectionProducer {
+class CreateEnumConstant extends ResolvedCorrectionProducer {
   /// The name of the constant to be created.
   String _constantName = '';
 
@@ -27,7 +27,7 @@ class AddEnumConstant extends ResolvedCorrectionProducer {
   List<String> get fixArguments => [_constantName];
 
   @override
-  FixKind get fixKind => DartFixKind.addEnumConstant;
+  FixKind get fixKind => DartFixKind.createEnumConstant;
 
   @override
   Future<void> compute(ChangeBuilder builder) async {

--- a/pkg/analysis_server/lib/src/services/correction/fix.dart
+++ b/pkg/analysis_server/lib/src/services/correction/fix.dart
@@ -117,11 +117,6 @@ abstract final class DartFixKind {
     DartFixKindPriority.inFile,
     'Add debug property references in file',
   );
-  static const addEnumConstant = FixKind(
-    'dart.fix.add.enumConstant',
-    DartFixKindPriority.standard,
-    "Add enum constant '{0}'",
-  );
   static const addEolAtEndOfFile = FixKind(
     'dart.fix.add.eolAtEndOfFile',
     DartFixKindPriority.standard,
@@ -817,6 +812,11 @@ abstract final class DartFixKind {
     'dart.fix.create.constructorSuper',
     DartFixKindPriority.standard,
     'Create constructor to call {0}',
+  );
+  static const createEnumConstant = FixKind(
+    'dart.fix.create.enumConstant',
+    DartFixKindPriority.standard,
+    "Create enum constant '{0}'",
   );
   static const createExtensionGetter = FixKind(
     'dart.fix.create.extension.getter',

--- a/pkg/analysis_server/lib/src/services/correction/fix_internal.dart
+++ b/pkg/analysis_server/lib/src/services/correction/fix_internal.dart
@@ -9,7 +9,6 @@ import 'package:analysis_server/src/services/correction/dart/add_class_modifier.
 import 'package:analysis_server/src/services/correction/dart/add_const.dart';
 import 'package:analysis_server/src/services/correction/dart/add_diagnostic_property_reference.dart';
 import 'package:analysis_server/src/services/correction/dart/add_empty_argument_list.dart';
-import 'package:analysis_server/src/services/correction/dart/add_enum_constant.dart';
 import 'package:analysis_server/src/services/correction/dart/add_eol_at_end_of_file.dart';
 import 'package:analysis_server/src/services/correction/dart/add_explicit_call.dart';
 import 'package:analysis_server/src/services/correction/dart/add_explicit_cast.dart';
@@ -93,6 +92,7 @@ import 'package:analysis_server/src/services/correction/dart/create_class.dart';
 import 'package:analysis_server/src/services/correction/dart/create_constructor.dart';
 import 'package:analysis_server/src/services/correction/dart/create_constructor_for_final_fields.dart';
 import 'package:analysis_server/src/services/correction/dart/create_constructor_super.dart';
+import 'package:analysis_server/src/services/correction/dart/create_enum_constant.dart';
 import 'package:analysis_server/src/services/correction/dart/create_extension_member.dart';
 import 'package:analysis_server/src/services/correction/dart/create_field.dart';
 import 'package:analysis_server/src/services/correction/dart/create_file.dart';
@@ -560,10 +560,10 @@ final _builtInNonLintGenerators = <DiagnosticCode, List<ProducerGenerator>>{
   ],
   diag.deprecatedFactoryMethod: [AddReturnType.new],
   diag.dotShorthandUndefinedGetter: [
-    AddEnumConstant.new,
     ChangeTo.getterOrSetter,
-    CreateGetter.new,
+    CreateEnumConstant.new,
     CreateField.new,
+    CreateGetter.new,
   ],
   diag.dotShorthandUndefinedInvocation: [
     ChangeTo.method,
@@ -818,7 +818,7 @@ final _builtInNonLintGenerators = <DiagnosticCode, List<ProducerGenerator>>{
   diag.undefinedClass: [ChangeTo.classOrMixin],
   diag.undefinedClassBoolean: [ReplaceBooleanWithBool.new],
   diag.undefinedEnumConstant: [
-    AddEnumConstant.new,
+    CreateEnumConstant.new,
     CreateField.new,
     CreateGetter.new,
     ChangeTo.getterOrSetter,

--- a/pkg/analysis_server/test/src/services/correction/fix/create_enum_constant_test.dart
+++ b/pkg/analysis_server/test/src/services/correction/fix/create_enum_constant_test.dart
@@ -11,14 +11,14 @@ import 'fix_processor.dart';
 
 void main() {
   defineReflectiveSuite(() {
-    defineReflectiveTests(AddEnumConstantTest);
+    defineReflectiveTests(CreateEnumConstantTest);
   });
 }
 
 @reflectiveTest
-class AddEnumConstantTest extends FixProcessorTest {
+class CreateEnumConstantTest extends FixProcessorTest {
   @override
-  FixKind get kind => DartFixKind.addEnumConstant;
+  FixKind get kind => DartFixKind.createEnumConstant;
 
   Future<void> test_add() async {
     await resolveTestCode('''
@@ -34,7 +34,7 @@ enum E {ONE, TWO}
 E e() {
   return E.TWO;
 }
-''', matchFixMessage: "Add enum constant 'TWO'");
+''', matchFixMessage: "Create enum constant 'TWO'");
   }
 
   Future<void> test_add_dotShorthand() async {
@@ -51,7 +51,7 @@ enum E { ONE, TWO }
 E e() {
   return .TWO;
 }
-''', matchFixMessage: "Add enum constant 'TWO'");
+''', matchFixMessage: "Create enum constant 'TWO'");
   }
 
   Future<void> test_differentLibrary() async {

--- a/pkg/analysis_server/test/src/services/correction/fix/test_all.dart
+++ b/pkg/analysis_server/test/src/services/correction/fix/test_all.dart
@@ -13,7 +13,6 @@ import 'add_curly_braces_test.dart' as add_curly_braces;
 import 'add_diagnostic_property_reference_test.dart'
     as add_diagnostic_property_reference;
 import 'add_empty_argument_list_test.dart' as add_empty_argument_list;
-import 'add_enum_constant_test.dart' as add_enum_constant_test;
 import 'add_eol_at_end_of_file_test.dart' as add_eol_at_end_of_file;
 import 'add_explicit_call_test.dart' as add_explicit_call;
 import 'add_explicit_cast_test.dart' as add_explicit_cast;
@@ -128,6 +127,7 @@ import 'create_constructor_for_final_fields_test.dart'
     as create_constructor_for_final_field;
 import 'create_constructor_super_test.dart' as create_constructor_super;
 import 'create_constructor_test.dart' as create_constructor;
+import 'create_enum_constant_test.dart' as create_enum_constant;
 import 'create_extension_member_test.dart' as create_extension_member;
 import 'create_field_test.dart' as create_field;
 import 'create_file_test.dart' as create_file;
@@ -352,7 +352,6 @@ void main() {
     add_curly_braces.main();
     add_diagnostic_property_reference.main();
     add_empty_argument_list.main();
-    add_enum_constant_test.main();
     add_eol_at_end_of_file.main();
     add_explicit_call.main();
     add_explicit_cast.main();
@@ -441,6 +440,7 @@ void main() {
     create_constructor_for_final_field.main();
     create_constructor_super.main();
     create_constructor.main();
+    create_enum_constant.main();
     create_extension_member.main();
     create_field.main();
     create_file.main();


### PR DESCRIPTION
Renames the enum constant creation fix to align with the naming convention used by all other `Create <member>` fixes (`CreateField`, `CreateGetter`, `CreateMethod`, etc).

The FixKind's message text changes from `Add enum constant` to `Create enum constant` to match. The internal string ID is also updated to `dart.fix.create.enumConstant`.

This is the first of three PRs addressing #61847:
1. This PR: rename `AddEnumConstant` to `CreateEnumConstant`
2. Follow-up: handle enum constructors with parameters (fill args with parameter names)
3. Follow-up: register the fix on missing diagnostic sites (`undefined_identifier` inside enum methods, `super(.b)` case)

Refs #61847

- [x] I've reviewed the contributor guide and applied the relevant portions to this PR.