### PR TITLE
Handle enum constructors with parameters in CreateEnumConstant

### DIFF
--- a/pkg/analysis_server/lib/src/services/correction/dart/create_enum_constant.dart
+++ b/pkg/analysis_server/lib/src/services/correction/dart/create_enum_constant.dart
@@ -59,14 +59,16 @@ class CreateEnumConstant extends ResolvedCorrectionProducer {
     var constructors = targetElement.constructors
         .where((c) => !c.isFactory)
         .toList();
-    if (constructors.any((c) => c.formalParameters.isNotEmpty)) return;
 
     String? constructorName;
+    ConstructorElement? constructor;
     if (constructors.isNotEmpty) {
       if (constructors.length > 1) return;
-      if (constructors.first.name != 'new') {
-        constructorName = constructors.first.name;
+      var c = constructors.first;
+      if (c.name != 'new') {
+        constructorName = c.name;
       }
+      constructor = c;
     }
 
     EnumConstantDeclaration? lastConstant;
@@ -83,28 +85,56 @@ class CreateEnumConstant extends ResolvedCorrectionProducer {
     var targetFile = targetFragment.libraryFragment.source.fullName;
 
     await builder.addDartFileEdit(targetFile, (builder) {
+      var suffix = _constantSuffix(constructorName, constructor);
       if (lastConstant != null) {
         builder.addInsertion(lastConstant.end, (builder) {
           builder.write(', ');
           builder.write(_constantName);
-          if (constructorName != null) builder.write('.$constructorName()');
+          builder.write(suffix);
         });
       } else if (rightBracket != null) {
         // If has a block body.
         builder.addInsertion(rightBracket.offset, (builder) {
           builder.write(' ');
           builder.write(_constantName);
-          if (constructorName != null) builder.write('.$constructorName()');
+          builder.write(suffix);
           builder.write(' ');
         });
       } else if (semicolon != null) {
         builder.addReplacement(range.token(semicolon), (builder) {
           builder.write(' { ');
           builder.write(_constantName);
-          if (constructorName != null) builder.write('.$constructorName()');
+          builder.write(suffix);
           builder.write(' }');
         });
       }
     });
+  }
+
+  String _buildArgs(ConstructorElement constructor) {
+    var parts = <String>[];
+    for (var param in constructor.formalParameters) {
+      var name = param.name;
+      if (name == null) continue;
+      if (param.isRequiredPositional) {
+        parts.add(name);
+      } else if (param.isRequiredNamed) {
+        parts.add('$name: $name');
+      }
+    }
+    return parts.join(', ');
+  }
+
+  String _constantSuffix(
+    String? constructorName,
+    ConstructorElement? constructor,
+  ) {
+    var args = constructor != null ? _buildArgs(constructor) : '';
+    if (constructorName != null) {
+      return '.$constructorName($args)';
+    } else if (args.isNotEmpty) {
+      return '($args)';
+    }
+    return '';
   }
 }

--- a/pkg/analysis_server/test/src/services/correction/fix/create_enum_constant_test.dart
+++ b/pkg/analysis_server/test/src/services/correction/fix/create_enum_constant_test.dart
@@ -90,6 +90,184 @@ enum E { ONE, TWO }
 ''', target: '$testPackageLibPath/a.dart');
   }
 
+  Future<void> test_dotShorthandFactoryEmpty() async {
+    await resolveTestCode('''
+enum E {
+  ONE;
+
+  const E();
+  factory E.f() => ONE;
+}
+
+E e() {
+  return .TWO;
+}
+''');
+
+    await assertHasFix('''
+enum E {
+  ONE, TWO;
+
+  const E();
+  factory E.f() => ONE;
+}
+
+E e() {
+  return .TWO;
+}
+''');
+  }
+
+  Future<void> test_dotShorthandFactoryEmptyRedirect() async {
+    await resolveTestCode('''
+enum E {
+  ONE;
+
+  const E();
+  factory E.f() => ONE;
+  factory E.g() = E.f;
+}
+
+E e() {
+  return .TWO;
+}
+''');
+
+    await assertHasFix('''
+enum E {
+  ONE, TWO;
+
+  const E();
+  factory E.f() => ONE;
+  factory E.g() = E.f;
+}
+
+E e() {
+  return .TWO;
+}
+''');
+  }
+
+  Future<void> test_dotShorthandFactoryWithRequired() async {
+    await resolveTestCode('''
+enum E {
+  ONE(1);
+
+  final int i;
+  const E(this.i);
+  factory E.f({required int i, required String s}) => ONE;
+}
+
+E e() {
+  return .TWO;
+}
+''');
+
+    await assertHasFix('''
+enum E {
+  ONE(1), TWO(i);
+
+  final int i;
+  const E(this.i);
+  factory E.f({required int i, required String s}) => ONE;
+}
+
+E e() {
+  return .TWO;
+}
+''');
+  }
+
+  Future<void> test_dotShorthandFactoryWithRequiredRedirect() async {
+    await resolveTestCode('''
+enum E {
+  ONE(1);
+
+  final int i;
+  const E(this.i);
+  factory E.f({required int i, required String s}) => ONE;
+  factory E.g({required int i, required String s}) = E.f;
+}
+
+E e() {
+  return .TWO;
+}
+''');
+
+    await assertHasFix('''
+enum E {
+  ONE(1), TWO(i);
+
+  final int i;
+  const E(this.i);
+  factory E.f({required int i, required String s}) => ONE;
+  factory E.g({required int i, required String s}) = E.f;
+}
+
+E e() {
+  return .TWO;
+}
+''');
+  }
+
+  Future<void> test_factory_beforeGenerative() async {
+    await resolveTestCode('''
+enum E {
+  ONE;
+
+  factory E.f() => ONE;
+  const E();
+}
+
+E e() {
+  return E.TWO;
+}
+''');
+
+    await assertHasFix('''
+enum E {
+  ONE, TWO;
+
+  factory E.f() => ONE;
+  const E();
+}
+
+E e() {
+  return E.TWO;
+}
+''');
+  }
+
+  Future<void> test_mixed() async {
+    await resolveTestCode('''
+enum E {
+  ONE(1, s: 'hello');
+
+  final int i;
+  final String s;
+  const E(this.i, {required this.s});
+}
+
+E e() {
+  return E.TWO;
+}
+''');
+
+    await assertHasFix('''
+enum E {
+  ONE(1, s: 'hello'), TWO(i, s: s);
+
+  final int i;
+  final String s;
+  const E(this.i, {required this.s});
+}
+
+E e() {
+  return E.TWO;
+}
+''');
+  }
+
   Future<void> test_named() async {
     await resolveTestCode('''
 enum E {
@@ -246,7 +424,18 @@ E e() {
 }
 ''');
 
-    await assertNoFix();
+    await assertHasFix('''
+enum E {
+  ONE.named(1), TWO.named(i);
+
+  final int i;
+  const E.named(this.i);
+}
+
+E e() {
+  return E.TWO;
+}
+''');
   }
 
   Future<void> test_named_nonZeroParameters_dotShorthand() async {
@@ -263,7 +452,18 @@ E e() {
 }
 ''');
 
-    await assertNoFix();
+    await assertHasFix('''
+enum E {
+  ONE.named(1), TWO.named(i);
+
+  final int i;
+  const E.named(this.i);
+}
+
+E e() {
+  return .TWO;
+}
+''');
   }
 
   Future<void> test_named_unnamed() async {
@@ -281,6 +481,32 @@ E e() {
 ''');
 
     await assertNoFix();
+  }
+
+  Future<void> test_namedConstructor_withRequired() async {
+    await resolveTestCode('''
+enum E {
+  ONE.other(1);
+
+  const E.other(int x);
+}
+
+E e() {
+  return E.TWO;
+}
+''');
+
+    await assertHasFix('''
+enum E {
+  ONE.other(1), TWO.other(x);
+
+  const E.other(int x);
+}
+
+E e() {
+  return E.TWO;
+}
+''');
   }
 
   Future<void> test_namedPrimary() async {
@@ -310,7 +536,121 @@ enum E.named(final int i) {
 E e = E.two;
 ''');
 
-    await assertNoFix();
+    await assertHasFix('''
+enum E.named(final int i) {
+  one.named(1), two.named(i);
+}
+
+E e = E.two;
+''');
+  }
+
+  Future<void> test_optionalNamedWithDefault() async {
+    await resolveTestCode('''
+enum E {
+  ONE(i: 1);
+
+  const E({int i = 0});
+}
+
+E e() {
+  return E.TWO;
+}
+''');
+
+    await assertHasFix('''
+enum E {
+  ONE(i: 1), TWO;
+
+  const E({int i = 0});
+}
+
+E e() {
+  return E.TWO;
+}
+''');
+  }
+
+  Future<void> test_optionalPositionalWithDefault() async {
+    await resolveTestCode('''
+enum E {
+  ONE(1);
+
+  const E([int i = 0]);
+}
+
+E e() {
+  return E.TWO;
+}
+''');
+
+    await assertHasFix('''
+enum E {
+  ONE(1), TWO;
+
+  const E([int i = 0]);
+}
+
+E e() {
+  return E.TWO;
+}
+''');
+  }
+
+  Future<void> test_requiredNamed() async {
+    await resolveTestCode('''
+enum E {
+  ONE(s: 'hello');
+
+  final String s;
+  const E({required this.s});
+}
+
+E e() {
+  return E.TWO;
+}
+''');
+
+    await assertHasFix('''
+enum E {
+  ONE(s: 'hello'), TWO(s: s);
+
+  final String s;
+  const E({required this.s});
+}
+
+E e() {
+  return E.TWO;
+}
+''');
+  }
+
+  Future<void> test_requiredPositional() async {
+    await resolveTestCode('''
+enum E {
+  ONE(1);
+
+  final int value;
+  const E(this.value);
+}
+
+E e() {
+  return E.TWO;
+}
+''');
+
+    await assertHasFix('''
+enum E {
+  ONE(1), TWO(value);
+
+  final int value;
+  const E(this.value);
+}
+
+E e() {
+  return E.TWO;
+}
+''');
   }
 
   Future<void> test_toEmpty_braces() async {
@@ -450,7 +790,18 @@ E e() {
 }
 ''');
 
-    await assertNoFix();
+    await assertHasFix('''
+enum E {
+  ONE(1), TWO(i);
+
+  final int i;
+  const E(this.i);
+}
+
+E e() {
+  return E.TWO;
+}
+''');
   }
 
   Future<void> test_unnamedPrimary() async {
@@ -480,6 +831,12 @@ enum E(final int i) {
 E e = E.two;
 ''');
 
-    await assertNoFix();
+    await assertHasFix('''
+enum E(final int i) {
+  one(1), two(i);
+}
+
+E e = E.two;
+''');
   }
 }


### PR DESCRIPTION
Previously `CreateEnumConstant` bailed out when the enum's non-factory constructor had any parameters. This extends it to fire on such enums and fill required arguments with the parameter names, matching the approach @bwilkerson suggested in the issue thread.

For a constructor like:

    const E(int i, {required String s})

The generated constant becomes:

    b(i, s: s)

Required positional parameters use the bare parameter name, required named parameters use `name: name`, and optional parameters are left out since their defaults suffice.

This is the second of three PRs addressing #61847:
1. Merged: rename `AddEnumConstant` to `CreateEnumConstant` (#63837)
2. This PR: handle enum constructors with parameters
3. Follow-up: register the fix on missing diagnostic sites (`undefined_identifier` inside enum methods, `super(.b)` case)

Refs #61847

- [x] I've reviewed the contributor guide and applied the relevant portions to this PR.