### PR TITLE
[dart2js] Fix inlining moveNext with optional parameters

### DIFF
--- a/pkg/compiler/lib/src/ssa/builder.dart
+++ b/pkg/compiler/lib/src/ssa/builder.dart
@@ -8179,7 +8179,6 @@ class KernelSsaGraphBuilder extends ir.VisitorDefault<void>
     // have been included if necessary, see [makeStaticArgumentList].
     if (!isInstanceMember ||
         currentNode == null || // In erroneous code, currentNode can be null.
-        _providedArgumentsKnownToBeComplete(currentNode) ||
         function is ConstructorBodyEntity ||
         selector!.isGetter) {
       // For these cases, the provided argument list is known to be complete.
@@ -8475,17 +8474,6 @@ class KernelSsaGraphBuilder extends ir.VisitorDefault<void>
     _returnType = state.oldReturnType;
     assert(stack.isEmpty);
     stack = state.oldStack;
-  }
-
-  bool _providedArgumentsKnownToBeComplete(ir.Node currentNode) {
-    /* When inlining the iterator methods generated for a for-in loop, the
-     * [currentNode] is the [ForIn] tree. The compiler-generated iterator
-     * invocations are known to have fully specified argument lists, no default
-     * arguments are used. See invocations of [pushInvokeDynamic] in
-     * [visitForIn].
-     */
-    // TODO(redemption): Is this valid here?
-    return currentNode is ir.ForInStatement;
   }
 
   void _emitReturn(HInstruction? value, SourceInformation? sourceInformation) {

--- a/tests/web/regress/issue/51246_test.dart
+++ b/tests/web/regress/issue/51246_test.dart
@@ -1,0 +1,42 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:expect/expect.dart';
+
+void main() {
+  // Keep `count` in the compiled method, then verify `for-in` uses its default.
+  final direct = Range(3);
+  Expect.isTrue(direct.moveNext(2));
+  Expect.equals(1, direct.current);
+
+  Expect.listEquals([0, 1, 2], consume(Range(3)));
+}
+
+final class Range extends Iterable<int> implements Iterator<int> {
+  Range(this.length);
+
+  final int length;
+  int _current = -1;
+
+  @override
+  int get current => _current;
+
+  @override
+  Range get iterator => Range(length);
+
+  @override
+  bool moveNext([int count = 1]) {
+    _current += count;
+    return _current < length;
+  }
+}
+
+@pragma('dart2js:noInline')
+List<int> consume(Iterable<int> values) {
+  final result = <int>[];
+  for (final value in values) {
+    result.add(value);
+  }
+  return result;
+}


### PR DESCRIPTION
Fixes #51246, dart2js crash when a for-in loop inlines a moveNext implementation with optional parameters. Removes the incorrect argument-completion exemption and uses the compiler’s normal argument handling.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
