### PR TITLE
[dart2wasm] Fix bound-check local type

### DIFF
--- a/pkg/dart2wasm/lib/code_generator.dart
+++ b/pkg/dart2wasm/lib/code_generator.dart
@@ -3346,8 +3346,8 @@ abstract class AstCodeGenerator
     DartType bound,
   ) {
     b.local_get(typeLocal);
-    final boundLocal = b.addLocal(translator.runtimeTypeType);
-    types.makeType(this, bound);
+    final boundType = types.makeType(this, bound);
+    final boundLocal = b.addLocal(boundType);
     b.local_tee(boundLocal);
     call(translator.isTypeSubtype.reference);
 

--- a/pkg/dart2wasm/lib/code_generator.dart
+++ b/pkg/dart2wasm/lib/code_generator.dart
@@ -3344,8 +3344,8 @@ abstract class AstCodeGenerator
     DartType bound,
   ) {
     b.local_get(typeLocal);
-    final boundLocal = b.addLocal(translator.runtimeTypeType);
-    types.makeType(this, bound);
+    final boundType = types.makeType(this, bound);
+    final boundLocal = b.addLocal(boundType);
     b.local_tee(boundLocal);
     call(translator.isTypeSubtype.reference);
 

--- a/pkg/dart2wasm/lib/translator.dart
+++ b/pkg/dart2wasm/lib/translator.dart
@@ -289,14 +289,6 @@ class Translator with KernelNodes {
     true,
   );
 
-  // The wasm type used to hold values of `Type`
-  late final w.RefType runtimeTypeType =
-      translateType(coreTypes.typeNonNullableRawType) as w.RefType;
-
-  // The wasm type used to hold values of `Type?`
-  late final w.RefType runtimeTypeTypeNullable = runtimeTypeType
-      .withNullability(true);
-
   // The wasm type used to hold values of `String`
   late final w.RefType stringType =
       translateType(coreTypes.stringNonNullableRawType) as w.RefType;

--- a/pkg/dart2wasm/lib/translator.dart
+++ b/pkg/dart2wasm/lib/translator.dart
@@ -290,14 +290,6 @@ class Translator with KernelNodes {
     true,
   );
 
-  // The wasm type used to hold values of `Type`
-  late final w.RefType runtimeTypeType =
-      translateType(coreTypes.typeNonNullableRawType) as w.RefType;
-
-  // The wasm type used to hold values of `Type?`
-  late final w.RefType runtimeTypeTypeNullable = runtimeTypeType
-      .withNullability(true);
-
   // The wasm type used to hold values of `String`
   late final w.RefType stringType =
       translateType(coreTypes.stringNonNullableRawType) as w.RefType;

--- a/pkg/dart2wasm/lib/types.dart
+++ b/pkg/dart2wasm/lib/types.dart
@@ -383,7 +383,7 @@ class Types {
     ClassInfo info = translator.classInfo[classForType(type)]!;
     if (type is FutureOrType) {
       _makeFutureOrType(codeGen, type);
-      return info.nonNullableType;
+      return nonNullableTypeType;
     }
 
     translator.functions.recordClassAllocation(info.classId);

--- a/tests/web/wasm/issue_63843_test.dart
+++ b/tests/web/wasm/issue_63843_test.dart
@@ -1,0 +1,19 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:collection';
+
+import 'package:expect/expect.dart';
+
+final class CustomType implements Type {
+  const CustomType();
+}
+
+final Type customType = const CustomType();
+
+void main() {
+  Expect.isTrue(identical(customType, const CustomType()));
+  final copy = SplayTreeSet<int>.from([3, 1, 2]).toSet();
+  Expect.listEquals([1, 2, 3], copy.toList());
+}


### PR DESCRIPTION
  Fixes #63843.

dart2wasm stored an internal `_Type` value in a local using the public `Type` representation, which can widen to `Object` when another `Type` implementation is reachable. This produced invalid Wasm during generic bound checks.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
