### PR TITLE
[analyzer/ffi] Reject Struct-constrained mixin applications

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -312,6 +312,7 @@ if (is_fuchsia) {
     "tests/ffi/static_checks/regress_60250_test.dart",
     "tests/ffi/static_checks/regress_62693_test.dart",
     "tests/ffi/static_checks/regress_62716_test.dart",
+    "tests/ffi/static_checks/regress_63388_test.dart",
     "tests/ffi/static_checks/regress_flutter_188175_test.dart",
     "tests/ffi/static_checks/vmspecific_function_callbacks_negative_test.dart",
     "tests/ffi/static_checks/vmspecific_regress_38993_test.dart",

--- a/pkg/analyzer/lib/src/generated/ffi_verifier.dart
+++ b/pkg/analyzer/lib/src/generated/ffi_verifier.dart
@@ -2799,7 +2799,7 @@ extension on NamedType {
   /// Return `true` if this represents a subtype of `Struct` or `Union`.
   bool get isCompoundSubtype {
     var element = this.element;
-    if (element is ClassElement) {
+    if (element is InterfaceElement) {
       return element.allSupertypes.any((e) => e.isCompound);
     }
     return false;

--- a/pkg/analyzer/test/src/diagnostics/subtype_of_struct_class_test.dart
+++ b/pkg/analyzer/test/src/diagnostics/subtype_of_struct_class_test.dart
@@ -63,6 +63,25 @@ final class AbiSpecificInteger4 implements AbiSpecificInteger1 {
 ''');
   }
 
+  test_implements_mixin_constrained_to_struct() async {
+    await resolveTestCodeWithDiagnostics(r'''
+import 'dart:ffi';
+
+base mixin HeaderFields on Struct {
+  @Int32()
+  external int fieldA;
+}
+
+final class ExampleStruct implements HeaderFields {
+//                                   ^^^^^^^^^^^^
+// [diag.baseClassImplementedOutsideOfLibrary] The class 'Struct' can't be implemented outside of its library because it's a base class.
+// [diag.subtypeOfStructClassInImplements] The class 'ExampleStruct' can't implement 'HeaderFields' because 'HeaderFields' is a subtype of 'Struct', 'Union', or 'AbiSpecificInteger'.
+  @override
+  int fieldA = 0;
+}
+''');
+  }
+
   test_implements_struct() async {
     await resolveTestCodeWithDiagnostics(r'''
 import 'dart:ffi';
@@ -107,6 +126,26 @@ final class C implements S {}
 
 @reflectiveTest
 class SubtypeOfStructClassInWithTest extends PubPackageResolutionTest {
+  test_with_mixin_constrained_to_struct() async {
+    await resolveTestCodeWithDiagnostics(r'''
+import 'dart:ffi';
+
+base mixin HeaderFields on Struct {
+  @Int32()
+  external int fieldA;
+
+  external Pointer<Void> fieldB;
+}
+
+final class ExampleStruct extends Struct with HeaderFields {
+//                                            ^^^^^^^^^^^^
+// [diag.subtypeOfStructClassInWith] The class 'ExampleStruct' can't mix in 'HeaderFields' because 'HeaderFields' is a subtype of 'Struct', 'Union', or 'AbiSpecificInteger'.
+  @Uint32()
+  external int fieldC;
+}
+''');
+  }
+
   test_with_struct() async {
     await resolveTestCodeWithDiagnostics(r'''
 import 'dart:ffi';

--- a/tests/ffi/static_checks/regress_63388_test.dart
+++ b/tests/ffi/static_checks/regress_63388_test.dart
@@ -1,0 +1,25 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Regression test for https://github.com/dart-lang/sdk/issues/63388
+
+import 'dart:ffi';
+
+base mixin HeaderFields on Struct {
+  @Int32()
+  external int fieldA;
+
+  external Pointer<Void> fieldB;
+}
+
+final class ExampleStruct extends Struct with HeaderFields {
+  //        ^^^^^^^^^^^^^
+  // [cfe] Class 'Struct with HeaderFields' cannot be extended or implemented.
+  //                                          ^^^^^^^^^^^^
+  // [analyzer] COMPILE_TIME_ERROR.SUBTYPE_OF_STRUCT_CLASS
+  @Uint32()
+  external int fieldC;
+}
+
+void main() {}

--- a/tests/ffi/static_checks/regress_63388_test.dart
+++ b/tests/ffi/static_checks/regress_63388_test.dart
@@ -22,4 +22,31 @@ final class ExampleStruct extends Struct with HeaderFields {
   external int fieldC;
 }
 
+// An unconstrained mixin cannot be applied to a struct either: the mixin
+// application class is itself treated as a struct, so the CFE rejects it.
+mixin ExtraGetters {
+  int get extra => 4;
+}
+
+final class GetterStruct extends Struct with ExtraGetters {
+  //        ^^^^^^^^^^^^
+  // [cfe] Class 'Struct with ExtraGetters' cannot be extended or implemented.
+  // [cfe] Struct 'Struct with ExtraGetters' is empty. Empty structs and unions are undefined behavior.
+  @Int32()
+  external int fieldD;
+}
+
+// Sharing members through a plain interface is allowed.
+abstract interface class HasChecksum {
+  int get checksum;
+}
+
+final class ChecksumStruct extends Struct implements HasChecksum {
+  @Int32()
+  external int payload;
+
+  @override
+  int get checksum => payload ^ 0xFF;
+}
+
 void main() {}


### PR DESCRIPTION
The inheritance-clause checks in FfiVerifier only inspected ClassElement
supertypes. A mixin's on-clause types are exposed through
MixinElement.allSupertypes, so Struct-constrained mixins bypassed the
existing with and implements diagnostics.

Use the shared InterfaceElement API for that lookup. Add separate analyzer
tests for both clause paths and an FFI static check for the reported mixin
application.

Fixes: https://github.com/dart-lang/sdk/issues/63388

TEST=pkg/analyzer/test/src/diagnostics/subtype_of_struct_class_test.dart
TEST=tests/ffi/static_checks/regress_63388_test.dart

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
