### PR TITLE
escape non-ascii bytes by value in NormalizeEscapes

### DIFF
--- a/runtime/bin/uri.cc
+++ b/runtime/bin/uri.cc
@@ -149,7 +149,8 @@ CStringUniquePtr NormalizeEscapes(const char* str, intptr_t len) {
         buffer_pos++;
       } else {
         // Escape funky characters.
-        Utils::SNPrint(buffer + buffer_pos, 4, "%%%02X", c);
+        Utils::SNPrint(buffer + buffer_pos, 4, "%%%02X",
+                       static_cast<unsigned char>(c));
         buffer_pos += 3;
       }
       pos++;

--- a/runtime/bin/uri_test.cc
+++ b/runtime/bin/uri_test.cc
@@ -276,6 +276,18 @@ TEST_CASE(ParseUri_NormalizeEscapes_UppercaseEscapeInHost) {
   EXPECT(uri->fragment == nullptr);
 }
 
+TEST_CASE(ParseUri_NormalizeEscapes_NonAsciiBytes) {
+  auto uri = ParseUri("scheme:/caf\xC3\xA9");
+  EXPECT(uri);
+  EXPECT_USTREQ("scheme", uri->scheme);
+  EXPECT(uri->userinfo == nullptr);
+  EXPECT(uri->host == nullptr);
+  EXPECT(uri->port == nullptr);
+  EXPECT_USTREQ("/caf%C3%A9", uri->path);  // Each byte keeps its own value.
+  EXPECT(uri->query == nullptr);
+  EXPECT(uri->fragment == nullptr);
+}
+
 TEST_CASE(ParseUri_BrokenEscapeSequence) {
   auto uri = ParseUri("scheme:/%1g");
   EXPECT(uri);


### PR DESCRIPTION
NormalizeEscapes in `runtime/bin/uri.cc` formats an unescaped byte with `SNPrint(buffer + buffer_pos, 4, "%%%02X", c)` where `c` is a plain `char`, so on targets where `char` is signed every byte >= 0x80 sign-extends and `%02X` renders it as `FFFFFF80`; the size-4 buffer then truncates that to `%FF`. The effect is that any non-ASCII byte in a path, query, fragment, userinfo or host normalizes to `%FF` regardless of its value, so `scheme:/caf\xC3\xA9` becomes `/caf%FF%FF` and distinct URIs can normalize to the same string. Casting to `unsigned char` at that one call keeps each byte's own value, and I added a case to `uri_test.cc` alongside the other NormalizeEscapes tests.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
