### PR TITLE
Offer CreateEnumConstant for bare identifiers with an enum context type

### DIFF
--- a/pkg/analysis_server/lib/src/services/correction/dart/create_enum_constant.dart
+++ b/pkg/analysis_server/lib/src/services/correction/dart/create_enum_constant.dart
@@ -44,6 +44,20 @@ class CreateEnumConstant extends ResolvedCorrectionProducer {
         parent,
         unitResult.libraryElement,
       );
+    } else {
+      var contextTypeElement = computeDotShorthandContextTypeElement(
+        node,
+        unitResult.libraryElement,
+      );
+      // For a bare identifier, adding the constant only resolves the
+      // diagnostic when the identifier is lexically inside the body of the
+      // target enum itself. Outside the enum, the identifier still can't
+      // resolve without an `E.` or `.` prefix, so don't offer the fix.
+      var enclosingEnum = node.thisOrAncestorOfType<EnumDeclaration>();
+      if (enclosingEnum != null &&
+          enclosingEnum.declaredFragment?.element == contextTypeElement) {
+        targetElement = contextTypeElement;
+      }
     }
 
     if (targetElement is! EnumElement) return;

--- a/pkg/analysis_server/lib/src/services/correction/fix_internal.dart
+++ b/pkg/analysis_server/lib/src/services/correction/fix_internal.dart
@@ -854,6 +854,7 @@ final _builtInNonLintGenerators = <DiagnosticCode, List<ProducerGenerator>>{
   ],
   diag.undefinedIdentifier: [
     ChangeTo.getterOrSetter,
+    CreateEnumConstant.new,
     CreateField.new,
     CreateGetter.new,
     CreateLocalVariable.new,

--- a/pkg/analysis_server/test/src/services/correction/fix/create_enum_constant_test.dart
+++ b/pkg/analysis_server/test/src/services/correction/fix/create_enum_constant_test.dart
@@ -722,6 +722,81 @@ void f() {
     );
   }
 
+  Future<void> test_undefinedIdentifier_differentEnum_noFix() async {
+    await resolveTestCode('''
+enum E {
+  a;
+  void m() {
+    F x = b;
+  }
+}
+
+enum F { c }
+''');
+    await assertNoFix(
+      filter: (e) => e.diagnosticCode == diag.undefinedIdentifier,
+    );
+  }
+
+  Future<void> test_undefinedIdentifier_insideEnumMethod() async {
+    await resolveTestCode('''
+enum E {
+  a;
+  E m() => b;
+}
+''');
+    await assertHasFix('''
+enum E {
+  a, b;
+  E m() => b;
+}
+''');
+  }
+
+  Future<void>
+  test_undefinedIdentifier_insideEnumMethod_withConstructor() async {
+    await resolveTestCode('''
+enum E {
+  a(1);
+  final int i;
+  const E(this.i);
+  E m() => b;
+}
+''');
+    await assertHasFix('''
+enum E {
+  a(1), b(i);
+  final int i;
+  const E(this.i);
+  E m() => b;
+}
+''');
+  }
+
+  Future<void> test_undefinedIdentifier_notEnum_noFix() async {
+    await resolveTestCode('''
+void f() {
+  int x = b;
+}
+''');
+    await assertNoFix(
+      filter: (e) => e.diagnosticCode == diag.undefinedIdentifier,
+    );
+  }
+
+  Future<void> test_undefinedIdentifier_outsideEnum_noFix() async {
+    await resolveTestCode('''
+enum E { a }
+
+void f() {
+  E x = b;
+}
+''');
+    await assertNoFix(
+      filter: (e) => e.diagnosticCode == diag.undefinedIdentifier,
+    );
+  }
+
   Future<void> test_unnamed() async {
     await resolveTestCode('''
 enum E {


### PR DESCRIPTION
`CreateEnumConstant` previously only resolved the target enum from a prefixed identifier (`E.b`) or a dot shorthand (`.b`). A bare undefined identifier whose context type is an enum was not handled, so no fix was offered even though the intent is clear from the context type:

    enum E {
      a;
      void m() {
        E x = b;
      }
    }

This resolves the target enum from the identifier's context type when the identifier is neither a prefixed identifier nor a dot shorthand, and registers `CreateEnumConstant` for the `undefinedIdentifier` diagnostic.

This is the third and final PR addressing #61847:
1. Merged: rename `AddEnumConstant` to `CreateEnumConstant`
2. Merged: handle enum constructors with parameters
3. This PR: offer the fix for bare identifiers with an enum context type

The remaining `dot_shorthand_undefined_member` case (e.g. `super(.b())`) currently has no fixes registered at all, and is left as a separate follow-up.

Refs #61847

- [x] I've reviewed the contributor guide and applied the relevant portions to this PR.