### PR TITLE
read the zlib dictionary length once in CopyDictionary

### DIFF
--- a/runtime/bin/filter.cc
+++ b/runtime/bin/filter.cc
@@ -33,8 +33,10 @@ static Dart_Handle GetFilter(Dart_Handle filter_obj, Filter** filter) {
 }
 
 static Dart_Handle CopyDictionary(Dart_Handle dictionary_obj,
-                                  uint8_t** dictionary) {
+                                  uint8_t** dictionary,
+                                  intptr_t* dictionary_length) {
   ASSERT(dictionary != nullptr);
+  ASSERT(dictionary_length != nullptr);
   uint8_t* src = nullptr;
   intptr_t size;
   Dart_TypedData_Type type;
@@ -63,6 +65,7 @@ static Dart_Handle CopyDictionary(Dart_Handle dictionary_obj,
   }
 
   *dictionary = result;
+  *dictionary_length = size;
   return Dart_Null();
 }
 
@@ -77,17 +80,11 @@ void FUNCTION_NAME(Filter_CreateZLibInflate)(Dart_NativeArguments args) {
   uint8_t* dictionary = nullptr;
   intptr_t dictionary_length = 0;
   if (!Dart_IsNull(dict_obj)) {
-    err = CopyDictionary(dict_obj, &dictionary);
+    err = CopyDictionary(dict_obj, &dictionary, &dictionary_length);
     if (Dart_IsError(err)) {
       Dart_PropagateError(err);
     }
     ASSERT(dictionary != nullptr);
-    dictionary_length = 0;
-    err = Dart_ListLength(dict_obj, &dictionary_length);
-    if (Dart_IsError(err)) {
-      delete[] dictionary;
-      Dart_PropagateError(err);
-    }
   }
 
   ZLibInflateFilter* filter =
@@ -127,17 +124,11 @@ void FUNCTION_NAME(Filter_CreateZLibDeflate)(Dart_NativeArguments args) {
   uint8_t* dictionary = nullptr;
   intptr_t dictionary_length = 0;
   if (!Dart_IsNull(dict_obj)) {
-    err = CopyDictionary(dict_obj, &dictionary);
+    err = CopyDictionary(dict_obj, &dictionary, &dictionary_length);
     if (Dart_IsError(err)) {
       Dart_PropagateError(err);
     }
     ASSERT(dictionary != nullptr);
-    dictionary_length = 0;
-    err = Dart_ListLength(dict_obj, &dictionary_length);
-    if (Dart_IsError(err)) {
-      delete[] dictionary;
-      Dart_PropagateError(err);
-    }
   }
 
   ZLibDeflateFilter* filter = new ZLibDeflateFilter(

--- a/runtime/bin/filter.cc
+++ b/runtime/bin/filter.cc
@@ -4,6 +4,9 @@
 
 #include "bin/filter.h"
 
+#include <memory>
+#include <utility>
+
 #include "bin/dartutils.h"
 #include "bin/io_buffer.h"
 
@@ -33,39 +36,25 @@ static Dart_Handle GetFilter(Dart_Handle filter_obj, Filter** filter) {
 }
 
 static Dart_Handle CopyDictionary(Dart_Handle dictionary_obj,
-                                  uint8_t** dictionary,
-                                  intptr_t* dictionary_length) {
-  ASSERT(dictionary != nullptr);
-  ASSERT(dictionary_length != nullptr);
-  uint8_t* src = nullptr;
+                                  Filter::Dictionary* result) {
+  ASSERT(result != nullptr);
   intptr_t size;
-  Dart_TypedData_Type type;
-
   Dart_Handle err = Dart_ListLength(dictionary_obj, &size);
   if (Dart_IsError(err)) {
     return err;
   }
 
-  uint8_t* result = new uint8_t[size];
-  if (result == nullptr) {
-    return Dart_NewApiError("Could not allocate new dictionary");
+  Filter::Dictionary dict;
+  dict.data = std::make_unique<uint8_t[]>(size);
+  dict.length = size;
+
+  // Dart_ListGetAsBytes already takes the fast path for typed data internally.
+  err = Dart_ListGetAsBytes(dictionary_obj, 0, dict.data.get(), size);
+  if (Dart_IsError(err)) {
+    return err;
   }
 
-  err = Dart_TypedDataAcquireData(dictionary_obj, &type,
-                                  reinterpret_cast<void**>(&src), &size);
-  if (!Dart_IsError(err)) {
-    memmove(result, src, size);
-    Dart_TypedDataReleaseData(dictionary_obj);
-  } else {
-    err = Dart_ListGetAsBytes(dictionary_obj, 0, result, size);
-    if (Dart_IsError(err)) {
-      delete[] result;
-      return err;
-    }
-  }
-
-  *dictionary = result;
-  *dictionary_length = size;
+  *result = std::move(dict);
   return Dart_Null();
 }
 
@@ -76,22 +65,19 @@ void FUNCTION_NAME(Filter_CreateZLibInflate)(Dart_NativeArguments args) {
   Dart_Handle dict_obj = Dart_GetNativeArgument(args, 3);
   bool raw = DartUtils::GetNativeBooleanArgument(args, 4);
 
-  Dart_Handle err;
-  uint8_t* dictionary = nullptr;
-  intptr_t dictionary_length = 0;
+  Filter::Dictionary dictionary;
   if (!Dart_IsNull(dict_obj)) {
-    err = CopyDictionary(dict_obj, &dictionary, &dictionary_length);
+    Dart_Handle err = CopyDictionary(dict_obj, &dictionary);
     if (Dart_IsError(err)) {
       Dart_PropagateError(err);
     }
-    ASSERT(dictionary != nullptr);
+    ASSERT(dictionary.data != nullptr);
   }
+  intptr_t dictionary_length = dictionary.length;
 
-  ZLibInflateFilter* filter =
-      new ZLibInflateFilter(gzip, static_cast<int32_t>(window_bits), dictionary,
-                            dictionary_length, raw);
+  ZLibInflateFilter* filter = new ZLibInflateFilter(
+      gzip, static_cast<int32_t>(window_bits), std::move(dictionary), raw);
   if (filter == nullptr) {
-    delete[] dictionary;
     Dart_PropagateError(
         Dart_NewApiError("Could not allocate ZLibInflateFilter"));
   }
@@ -100,7 +86,7 @@ void FUNCTION_NAME(Filter_CreateZLibInflate)(Dart_NativeArguments args) {
     Dart_ThrowException(
         DartUtils::NewInternalError("Failed to create ZLibInflateFilter"));
   }
-  err = Filter::SetFilterAndCreateFinalizer(
+  Dart_Handle err = Filter::SetFilterAndCreateFinalizer(
       filter_obj, filter, sizeof(*filter) + dictionary_length);
   if (Dart_IsError(err)) {
     delete filter;
@@ -120,23 +106,21 @@ void FUNCTION_NAME(Filter_CreateZLibDeflate)(Dart_NativeArguments args) {
   Dart_Handle dict_obj = Dart_GetNativeArgument(args, 6);
   bool raw = DartUtils::GetNativeBooleanArgument(args, 7);
 
-  Dart_Handle err;
-  uint8_t* dictionary = nullptr;
-  intptr_t dictionary_length = 0;
+  Filter::Dictionary dictionary;
   if (!Dart_IsNull(dict_obj)) {
-    err = CopyDictionary(dict_obj, &dictionary, &dictionary_length);
+    Dart_Handle err = CopyDictionary(dict_obj, &dictionary);
     if (Dart_IsError(err)) {
       Dart_PropagateError(err);
     }
-    ASSERT(dictionary != nullptr);
+    ASSERT(dictionary.data != nullptr);
   }
+  intptr_t dictionary_length = dictionary.length;
 
   ZLibDeflateFilter* filter = new ZLibDeflateFilter(
       gzip, static_cast<int32_t>(level), static_cast<int32_t>(window_bits),
       static_cast<int32_t>(mem_level), static_cast<int32_t>(strategy),
-      dictionary, dictionary_length, raw);
+      std::move(dictionary), raw);
   if (filter == nullptr) {
-    delete[] dictionary;
     Dart_PropagateError(
         Dart_NewApiError("Could not allocate ZLibDeflateFilter"));
   }
@@ -252,7 +236,6 @@ Dart_Handle Filter::GetFilterNativeField(Dart_Handle filter,
 }
 
 ZLibDeflateFilter::~ZLibDeflateFilter() {
-  delete[] dictionary_;
   delete[] current_buffer_;
   if (initialized()) {
     deflateEnd(&stream_);
@@ -285,10 +268,10 @@ bool ZLibDeflateFilter::Init() {
   if (result != Z_OK) {
     return false;
   }
-  if ((dictionary_ != nullptr) && !gzip_ && !raw_) {
-    result = deflateSetDictionary(&stream_, dictionary_, dictionary_length_);
-    delete[] dictionary_;
-    dictionary_ = nullptr;
+  if ((dictionary_.data != nullptr) && !gzip_ && !raw_) {
+    result = deflateSetDictionary(&stream_, dictionary_.data.get(),
+                                  dictionary_.length);
+    dictionary_.data.reset();
     if (result != Z_OK) {
       return false;
     }
@@ -338,7 +321,6 @@ intptr_t ZLibDeflateFilter::Processed(uint8_t* buffer,
 }
 
 ZLibInflateFilter::~ZLibInflateFilter() {
-  delete[] dictionary_;
   delete[] current_buffer_;
   if (initialized()) {
     inflateEnd(&stream_);
@@ -414,13 +396,12 @@ intptr_t ZLibInflateFilter::Processed(uint8_t* buffer,
     }
 
     case Z_NEED_DICT:
-      if (dictionary_ == nullptr) {
+      if (dictionary_.data == nullptr) {
         error = true;
       } else {
-        int result =
-            inflateSetDictionary(&stream_, dictionary_, dictionary_length_);
-        delete[] dictionary_;
-        dictionary_ = nullptr;
+        int result = inflateSetDictionary(&stream_, dictionary_.data.get(),
+                                          dictionary_.length);
+        dictionary_.data.reset();
         error = result != Z_OK;
       }
       if (error) {

--- a/runtime/bin/filter.h
+++ b/runtime/bin/filter.h
@@ -5,6 +5,8 @@
 #ifndef RUNTIME_BIN_FILTER_H_
 #define RUNTIME_BIN_FILTER_H_
 
+#include <memory>
+
 #include "bin/builtin.h"
 #include "bin/utils.h"
 
@@ -15,6 +17,13 @@ namespace bin {
 
 class Filter {
  public:
+  // A dictionary copied out of Dart and owned by the filter, kept together
+  // with the length that was actually copied so the two can never disagree.
+  struct Dictionary {
+    std::unique_ptr<uint8_t[]> data;
+    intptr_t length = 0;
+  };
+
   virtual ~Filter() {}
 
   virtual bool Init() = 0;
@@ -59,16 +68,14 @@ class ZLibDeflateFilter : public Filter {
                     int32_t window_bits,
                     int32_t mem_level,
                     int32_t strategy,
-                    uint8_t* dictionary,
-                    intptr_t dictionary_length,
+                    Dictionary dictionary,
                     bool raw)
       : gzip_(gzip),
         level_(level),
         window_bits_(window_bits),
         mem_level_(mem_level),
         strategy_(strategy),
-        dictionary_(dictionary),
-        dictionary_length_(dictionary_length),
+        dictionary_(std::move(dictionary)),
         raw_(raw),
         current_buffer_(nullptr) {}
   virtual ~ZLibDeflateFilter();
@@ -86,8 +93,7 @@ class ZLibDeflateFilter : public Filter {
   const int32_t window_bits_;
   const int32_t mem_level_;
   const int32_t strategy_;
-  uint8_t* dictionary_;
-  const intptr_t dictionary_length_;
+  Dictionary dictionary_;
   const bool raw_;
   uint8_t* current_buffer_;
   z_stream stream_;
@@ -99,13 +105,11 @@ class ZLibInflateFilter : public Filter {
  public:
   ZLibInflateFilter(bool gzip,
                     int32_t window_bits,
-                    uint8_t* dictionary,
-                    intptr_t dictionary_length,
+                    Dictionary dictionary,
                     bool raw)
       : gzip_(gzip),
         window_bits_(window_bits),
-        dictionary_(dictionary),
-        dictionary_length_(dictionary_length),
+        dictionary_(std::move(dictionary)),
         raw_(raw),
         current_buffer_(nullptr) {}
   virtual ~ZLibInflateFilter();
@@ -120,8 +124,7 @@ class ZLibInflateFilter : public Filter {
  private:
   const bool gzip_;
   const int32_t window_bits_;
-  uint8_t* dictionary_;
-  const intptr_t dictionary_length_;
+  Dictionary dictionary_;
   const bool raw_;
   uint8_t* current_buffer_;
   z_stream stream_;


### PR DESCRIPTION
`CopyDictionary` in `runtime/bin/filter.cc` sizes the dictionary heap buffer from one `Dart_ListLength` call, and `Filter_CreateZLibInflate` / `Filter_CreateZLibDeflate` then call `Dart_ListLength` on the same object a second time to get the length they hand to the filter. For a user-defined class implementing `List<int>` that call dispatches to the Dart `length` getter, so the two reads can disagree, and a getter that returns a bigger value the second time leaves `dictionary_length_` pointing past the end of the allocation that `inflateSetDictionary` / `deflateSetDictionary` later read from. `ZLibCodec`, `ZLibEncoder` and `ZLibDecoder` all pass the caller's `List<int>` straight through to these natives, so no copy happens on the Dart side first.

Having `CopyDictionary` report the number of bytes it actually copied keeps the buffer and the length in sync and drops the second lookup at both call sites.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
