### PR TITLE
generate the websocket handshake nonce with a secure prng

### DIFF
--- a/sdk/lib/_http/websocket_impl.dart
+++ b/sdk/lib/_http/websocket_impl.dart
@@ -1322,12 +1322,8 @@ class _WebSocketImpl extends Stream with _ServiceObject implements WebSocket {
       throw WebSocketException("Unsupported URL scheme '${uri.scheme}'");
     }
 
-    Random random = Random();
     // Generate 16 random bytes.
-    Uint8List nonceData = Uint8List(16);
-    for (int i = 0; i < 16; i++) {
-      nonceData[i] = random.nextInt(256);
-    }
+    Uint8List nonceData = _CryptoUtils.getRandomBytes(16);
     String nonce = base64Encode(nonceData);
 
     final callerStackTrace = StackTrace.current;


### PR DESCRIPTION
_WebSocketImpl.connect builds the 16-byte Sec-WebSocket-Key nonce from `dart:math`'s `Random()`, whose default seed is only 32 bits wide (`_Random._nextSeed` returns `state & 0xFFFFFFFF`), so the 128-bit handshake key really carries at most 32 bits of entropy and the generator state behind an observed key can be recovered by exhaustive search over the seed space in about seven seconds on one core. RFC 6455 asks for an unpredictable nonce because that is what stops an attacker who can talk to the same origin from precomputing a matching Sec-WebSocket-Accept and persuading an intermediary that a non-WebSocket response completed the handshake. This switches to `_CryptoUtils.getRandomBytes`, which is `Random.secure()` backed and is already what the same file uses for frame masking keys.

---

- [x] I've reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
