### PR TITLE
[analyzer/ffi] Handle NativeCallable arguments independently of source order

### DIFF
--- a/pkg/analyzer/lib/src/generated/ffi_verifier.dart
+++ b/pkg/analyzer/lib/src/generated/ffi_verifier.dart
@@ -1937,7 +1937,24 @@ class FfiVerifier extends RecursiveAstVisitor2<void> {
       return;
     }
 
-    var f = node.argumentList.arguments2[0];
+    ArgumentImpl? f;
+    NamedArgumentImpl? exceptionalReturn;
+    for (var argument in node.argumentList.arguments2) {
+      if (argument is NamedArgumentImpl) {
+        exceptionalReturn = argument;
+      } else if (f == null) {
+        f = argument;
+      } else {
+        // There are other diagnostics reported against the invocation and the
+        // diagnostics generated below might be inaccurate, so don't report
+        // them.
+        return;
+      }
+    }
+    if (f == null) {
+      return;
+    }
+
     var funcType = f.argumentExpression2.typeOrThrow;
     if (!_validateCompatibleFunctionTypes(
       _FfiTypeCheckDirection.dartToNative,
@@ -1962,20 +1979,19 @@ class FfiVerifier extends RecursiveAstVisitor2<void> {
           natRetType.isPointer ||
           natRetType.isHandle ||
           natRetType.isCompoundSubtype) {
-        if (argCount != 1) {
+        if (exceptionalReturn != null) {
           _diagnosticReporter.report(
             diag.invalidExceptionValue
                 .withArguments(methodName: name)
-                .at(node.argumentList.arguments2[1]),
+                .at(exceptionalReturn),
           );
         }
-      } else if (argCount != 2) {
+      } else if (exceptionalReturn == null) {
         _diagnosticReporter.report(
           diag.missingExceptionValue.withArguments(methodName: name).at(node),
         );
       } else {
-        var e = (node.argumentList.arguments2[1] as NamedArgument)
-            .argumentExpression2;
+        var e = exceptionalReturn.argumentExpression2;
         var eType = e.typeOrThrow;
         if (!_validateCompatibleNativeType(
           _FfiTypeCheckDirection.dartToNative,

--- a/pkg/analyzer/test/src/diagnostics/ffi_async_callback_test.dart
+++ b/pkg/analyzer/test/src/diagnostics/ffi_async_callback_test.dart
@@ -28,6 +28,19 @@ void g() {
 ''');
   }
 
+  test_NativeCallable_isolateLocal_argumentMustBeAConstant_namedFirst() async {
+    await resolveTestCodeWithDiagnostics(r'''
+import 'dart:ffi';
+int f(int i) => i * 2;
+void g() {
+  int e = 123;
+  NativeCallable<Int32 Function(Int32)>.isolateLocal(exceptionalReturn: e, f);
+//                                                                      ^
+// [diag.argumentMustBeAConstant] Argument 'exceptionalReturn' must be a constant.
+}
+''');
+  }
+
   test_NativeCallable_isolateLocal_exceptionMustBeASubtype() async {
     await resolveTestCodeWithDiagnostics(r'''
 import 'dart:ffi';
@@ -35,6 +48,18 @@ int f(int i) => i * 2;
 void g() {
   NativeCallable<Int32 Function(Int32)>.isolateLocal(f, exceptionalReturn: '?');
 //                                                                         ^^^
+// [diag.mustBeASubtype] The type 'String' must be a subtype of 'Int32' for 'isolateLocal'.
+}
+''');
+  }
+
+  test_NativeCallable_isolateLocal_exceptionMustBeASubtype_namedFirst() async {
+    await resolveTestCodeWithDiagnostics(r'''
+import 'dart:ffi';
+int f(int i) => i * 2;
+void g() {
+  NativeCallable<Int32 Function(Int32)>.isolateLocal(exceptionalReturn: '?', f);
+//                                                                      ^^^
 // [diag.mustBeASubtype] The type 'String' must be a subtype of 'Int32' for 'isolateLocal'.
 }
 ''');
@@ -60,6 +85,29 @@ void g() {
   NativeCallable<Void Function(Int32)>.isolateLocal(f, exceptionalReturn: 4);
 //                                                     ^^^^^^^^^^^^^^^^^^^^
 // [diag.invalidExceptionValue] The method isolateLocal can't have an exceptional return value (the second argument) when the return type of the function is either 'void', 'Handle' or 'Pointer'.
+}
+''');
+  }
+
+  test_NativeCallable_isolateLocal_invalidExceptionValue_namedFirst() async {
+    await resolveTestCodeWithDiagnostics(r'''
+import 'dart:ffi';
+void f(int i) => i * 2;
+void g() {
+  NativeCallable<Void Function(Int32)>.isolateLocal(exceptionalReturn: 4, f);
+//                                                  ^^^^^^^^^^^^^^^^^^^^
+// [diag.invalidExceptionValue] The method isolateLocal can't have an exceptional return value (the second argument) when the return type of the function is either 'void', 'Handle' or 'Pointer'.
+}
+''');
+  }
+
+  test_NativeCallable_isolateLocal_missingCallback() async {
+    await resolveTestCodeWithDiagnostics(r'''
+import 'dart:ffi';
+void g() {
+  NativeCallable<Int32 Function(Int32)>.isolateLocal(exceptionalReturn: 0);
+//                                                   ^^^^^^^^^^^^^^^^^
+// [diag.notEnoughPositionalArgumentsNameSingular] 1 positional argument expected by 'isolateLocal', but 0 found.
 }
 ''');
   }
@@ -100,6 +148,18 @@ void g() {
 ''');
   }
 
+  test_NativeCallable_isolateLocal_mustBeASubtype_namedFirst() async {
+    await resolveTestCodeWithDiagnostics(r'''
+import 'dart:ffi';
+int f(int i) => i * 2;
+void g() {
+  NativeCallable<Int32 Function(Double)>.isolateLocal(exceptionalReturn: 4, f);
+//                                                                          ^
+// [diag.mustBeASubtype] The type 'int Function(int)' must be a subtype of 'Int32 Function(Double)' for 'NativeCallable'.
+}
+''');
+  }
+
   test_NativeCallable_isolateLocal_mustHaveTypeArgs() async {
     await resolveTestCodeWithDiagnostics(r'''
 import 'dart:ffi';
@@ -122,12 +182,46 @@ void g() {
 ''');
   }
 
+  test_NativeCallable_isolateLocal_ok_namedFirst() async {
+    await resolveTestCodeWithDiagnostics(r'''
+import 'dart:ffi';
+int f(int i) => i * 2;
+void g() {
+  NativeCallable<Int32 Function(Int32)>.isolateLocal(exceptionalReturn: 4, f);
+}
+''');
+  }
+
   test_NativeCallable_isolateLocal_okVoid() async {
     await resolveTestCodeWithDiagnostics(r'''
 import 'dart:ffi';
 void f(int i) => i * 2;
 void g() {
   NativeCallable<Void Function(Int32)>.isolateLocal(f);
+}
+''');
+  }
+
+  test_NativeCallable_isolateLocal_positionalExceptionalReturn() async {
+    await resolveTestCodeWithDiagnostics(r'''
+import 'dart:ffi';
+int f(int i) => i * 2;
+void g() {
+  NativeCallable<Int32 Function(Int32)>.isolateLocal(f, 0);
+//                                                      ^
+// [diag.extraPositionalArgumentsCouldBeNamed] Too many positional arguments: 1 expected, but 2 found.
+}
+''');
+  }
+
+  test_NativeCallable_isolateLocal_positionalExceptionalReturn_void() async {
+    await resolveTestCodeWithDiagnostics(r'''
+import 'dart:ffi';
+void f(int i) => i * 2;
+void g() {
+  NativeCallable<Void Function(Int32)>.isolateLocal(f, 0);
+//                                                     ^
+// [diag.extraPositionalArgumentsCouldBeNamed] Too many positional arguments: 1 expected, but 2 found.
 }
 ''');
   }


### PR DESCRIPTION
`_validateNativeCallable` treats the arguments to
`NativeCallable.isolateLocal` by source position. A second positional argument
can reach a `NamedArgument` cast and crash for a non-void callback. For a void
callback it adds a redundant FFI diagnostic. Named arguments can also appear
before positional arguments, so valid code can put `exceptionalReturn:` before
the callback; in that order the verifier checks the exceptional value as if it
were the callback.

Identify the positional callback and named exceptional return independently of
source order. If an invalid invocation contains a second positional argument,
leave it to the resolver diagnostic instead of running the FFI-specific checks.
Add regression tests for both invalid positional paths and for named-first
calls across the relevant FFI validations.

This is the first verifier crash found while working through
https://github.com/dart-lang/sdk/issues/44773. The broader invalid and
unresolved-position coverage remains separate.

TEST=pkg/analyzer/test/src/diagnostics/ffi_async_callback_test.dart

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
