### PR TITLE
reject CR, LF and NUL in HttpResponse.reasonPhrase

### DIFF
--- a/sdk/lib/_http/http_impl.dart
+++ b/sdk/lib/_http/http_impl.dart
@@ -1273,6 +1273,18 @@ class _HttpResponse extends _HttpOutboundMessage<HttpResponse>
   String get reasonPhrase => _findReasonPhrase(statusCode);
   void set reasonPhrase(String reasonPhrase) {
     if (_outgoing.headersWritten) throw StateError("Header already sent");
+    for (int i = 0; i < reasonPhrase.length; i++) {
+      int codeUnit = reasonPhrase.codeUnitAt(i);
+      if (codeUnit == _CharCode.CR ||
+          codeUnit == _CharCode.LF ||
+          codeUnit == 0) {
+        throw ArgumentError.value(
+          reasonPhrase,
+          "reasonPhrase",
+          "Reason phrase cannot contain CR, LF or NUL",
+        );
+      }
+    }
     _reasonPhrase = reasonPhrase;
   }
 

--- a/tests/standalone/io/http_reason_phrase_invalid_test.dart
+++ b/tests/standalone/io/http_reason_phrase_invalid_test.dart
@@ -1,0 +1,51 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// VMOptions=
+// VMOptions=--short_socket_read
+// VMOptions=--short_socket_write
+// VMOptions=--short_socket_read --short_socket_write
+
+// A reason phrase containing CR, LF or NUL would let an application inject
+// extra lines into the response status line (response splitting). Setting one
+// must be rejected, while a valid custom phrase still reaches the client.
+
+import "dart:async";
+import "dart:io";
+
+import "package:expect/expect.dart";
+
+Future<void> reasonPhraseValidation() async {
+  final server = await HttpServer.bind("127.0.0.1", 0);
+  server.listen((request) {
+    final response = request.response;
+    for (final phrase in [
+      "OK\r\nX-Injected: yes",
+      "OK\nX-Injected: yes",
+      "OK\rX-Injected: yes",
+      "OK\x00bad",
+    ]) {
+      Expect.throws<ArgumentError>(() => response.reasonPhrase = phrase);
+    }
+    // A valid custom phrase is still accepted.
+    response.reasonPhrase = "Totally Fine";
+    response.close();
+  });
+
+  final client = HttpClient();
+  final request = await client.getUrl(
+    Uri.parse("http://127.0.0.1:${server.port}/"),
+  );
+  final response = await request.close();
+  Expect.equals("Totally Fine", response.reasonPhrase);
+  // None of the rejected phrases reached the wire, so no header was injected.
+  Expect.isNull(response.headers["x-injected"]);
+  await response.drain();
+  client.close();
+  await server.close();
+}
+
+void main() async {
+  await reasonPhraseValidation();
+}


### PR DESCRIPTION
1. every user-supplied field written to a response gets validated except the reason phrase: header names go through _validateField, header values through _validateValue, a redirect Location through headers.set, and cookie name/value at construction.
2. _writeHeader emits reasonPhrase.codeUnits straight into the status line before the CRLF, so a phrase like "OK\r\nX-Injected: 1" adds an extra header line (response splitting).

The setter now rejects CR, LF and NUL with an ArgumentError, matching the same CR/LF/NUL rule the parser already applies to header values. Regression test added under tests/standalone/io.