### PR TITLE
[analyzer/ffi] Add fromFunction tests for invalid and unresolved code

### DIFF
--- a/pkg/analyzer/test/src/diagnostics/ffi_from_function_test.dart
+++ b/pkg/analyzer/test/src/diagnostics/ffi_from_function_test.dart
@@ -1,0 +1,127 @@
+// Copyright (c) 2026, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test_reflective_loader/test_reflective_loader.dart';
+
+import '../dart/resolution/context_collection_resolution.dart';
+
+main() {
+  defineReflectiveSuite(() {
+    defineReflectiveTests(FfiFromFunctionInvalidCodeTest);
+  });
+}
+
+/// Exercises `_validateFromFunction` on invalid and unresolved code at each
+/// argument position, so that resolution failures keep producing diagnostics
+/// instead of crashing the verifier.
+///
+/// https://github.com/dart-lang/sdk/issues/44773
+@reflectiveTest
+class FfiFromFunctionInvalidCodeTest extends PubPackageResolutionTest {
+  test_fromFunction_exceptionalReturn_prefix() async {
+    await resolveTestCodeWithDiagnostics(r'''
+import 'dart:ffi';
+import 'dart:math' as prefix;
+int f(int x) => x;
+void main() {
+  Pointer.fromFunction<Int32 Function(Int32)>(f, prefix);
+//                                               ^^^^^^
+// [diag.prefixIdentifierNotFollowedByDot] The name 'prefix' refers to an import prefix, so it must be followed by '.'.
+// [diag.mustBeASubtype] The type 'InvalidType' must be a subtype of 'Int32' for 'fromFunction'.
+// [diag.argumentMustBeAConstant] Argument 'exceptionalReturn' must be a constant.
+}
+''');
+  }
+
+  test_fromFunction_exceptionalReturn_undefinedNamedParameter() async {
+    await resolveTestCodeWithDiagnostics(r'''
+import 'dart:ffi';
+int f(int x) => x;
+void main() {
+  Pointer.fromFunction<Int32 Function(Int32)>(f, exceptional: 1);
+//                                               ^^^^^^^^^^^
+// [diag.undefinedNamedParameter] The named parameter 'exceptional' isn't defined.
+}
+''');
+  }
+
+  test_fromFunction_exceptionalReturn_unresolvedIdentifier() async {
+    await resolveTestCodeWithDiagnostics(r'''
+import 'dart:ffi';
+int f(int x) => x;
+void main() {
+  Pointer.fromFunction<Int32 Function(Int32)>(f, undefinedConst);
+//                                               ^^^^^^^^^^^^^^
+// [diag.undefinedIdentifier] Undefined name 'undefinedConst'.
+// [diag.mustBeASubtype] The type 'InvalidType' must be a subtype of 'Int32' for 'fromFunction'.
+// [diag.argumentMustBeAConstant] Argument 'exceptionalReturn' must be a constant.
+}
+''');
+  }
+
+  test_fromFunction_function_prefix() async {
+    await resolveTestCodeWithDiagnostics(r'''
+import 'dart:ffi';
+import 'dart:math' as prefix;
+void main() {
+  Pointer.fromFunction<Void Function()>(prefix);
+//                                      ^^^^^^
+// [diag.prefixIdentifierNotFollowedByDot] The name 'prefix' refers to an import prefix, so it must be followed by '.'.
+// [diag.mustBeASubtype] The type 'InvalidType' must be a subtype of 'Void Function()' for 'fromFunction'.
+}
+''');
+  }
+
+  test_fromFunction_function_unresolvedIdentifier() async {
+    await resolveTestCodeWithDiagnostics(r'''
+import 'dart:ffi';
+void main() {
+  Pointer.fromFunction<Void Function()>(undefinedFn);
+//                                      ^^^^^^^^^^^
+// [diag.undefinedIdentifier] Undefined name 'undefinedFn'.
+// [diag.mustBeASubtype] The type 'InvalidType' must be a subtype of 'Void Function()' for 'fromFunction'.
+}
+''');
+  }
+
+  test_fromFunction_typeArgument_none() async {
+    await resolveTestCodeWithDiagnostics(r'''
+import 'dart:ffi';
+int f(int x) => x;
+void main() {
+  Pointer.fromFunction(f);
+//        ^^^^^^^^^^^^
+// [diag.mustBeANativeFunctionType] The type 'Function' given to 'fromFunction' must be a valid 'dart:ffi' native function type.
+}
+''');
+  }
+
+  test_fromFunction_typeArgument_unresolved() async {
+    await resolveTestCodeWithDiagnostics(r'''
+import 'dart:ffi';
+int f(int x) => x;
+void main() {
+  Pointer.fromFunction<Unresolved Function()>(f, 0);
+//                     ^^^^^^^^^^
+// [diag.undefinedClass] Undefined class 'Unresolved'.
+//                     ^^^^^^^^^^^^^^^^^^^^^
+// [diag.mustBeANativeFunctionType] The type 'InvalidType Function()' given to 'fromFunction' must be a valid 'dart:ffi' native function type.
+}
+''');
+  }
+
+  test_fromFunction_typeArgument_wrongCount() async {
+    await resolveTestCodeWithDiagnostics(r'''
+import 'dart:ffi';
+int f(int x) => x;
+void main() {
+  Pointer.fromFunction<Int32 Function(Int32), Int8>(f, 0);
+//                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+// [diag.wrongNumberOfTypeArgumentsElement] The method 'fromFunction' is declared with 1 type parameters, but 2 type arguments are given.
+//                     ^^^^^^^^^^^^^^^^^^^^^
+// [diag.mustBeANativeFunctionType] The type 'dynamic' given to 'fromFunction' must be a valid 'dart:ffi' native function type.
+}
+''');
+  }
+}

--- a/pkg/analyzer/test/src/diagnostics/ffi_from_function_test.dart
+++ b/pkg/analyzer/test/src/diagnostics/ffi_from_function_test.dart
@@ -12,9 +12,10 @@ main() {
   });
 }
 
-/// Exercises `_validateFromFunction` on invalid and unresolved code at each
-/// argument position, so that resolution failures keep producing diagnostics
-/// instead of crashing the verifier.
+/// Exercises `_validateFromFunction` with broken input at each argument
+/// position, pinning the diagnostics reported there. The failure these tests
+/// guard against is a crash, including on code another diagnostic already
+/// flags.
 ///
 /// https://github.com/dart-lang/sdk/issues/44773
 @reflectiveTest

--- a/pkg/analyzer/test/src/diagnostics/test_all.dart
+++ b/pkg/analyzer/test/src/diagnostics/test_all.dart
@@ -335,6 +335,7 @@ import 'extraneous_modifier_test.dart' as extraneous_modifier;
 import 'ffi_address_of_cast_test.dart' as ffi_addresss_of_cast;
 import 'ffi_array_test.dart' as ffi_array;
 import 'ffi_async_callback_test.dart' as ffi_async_callback;
+import 'ffi_from_function_test.dart' as ffi_from_function;
 import 'ffi_leaf_call_must_not_use_handle_test.dart'
     as ffi_leaf_call_must_not_use_handle;
 import 'ffi_native_test.dart' as ffi_native;
@@ -1183,6 +1184,7 @@ main() {
     ffi_addresss_of_cast.main();
     ffi_array.main();
     ffi_async_callback.main();
+    ffi_from_function.main();
     ffi_leaf_call_must_not_use_handle.main();
     ffi_native.main();
     field_initializer_factory_constructor.main();


### PR DESCRIPTION
Exercises `_validateFromFunction` with broken input at each argument
position: the type argument (absent, unresolved, wrong count), the
callback (unresolved identifier, bare import prefix), and the
exceptional return (unresolved identifier, bare import prefix, unknown
named parameter). All of them resolve to diagnostics today; the tests
pin that so resolution failures keep diagnosing instead of crashing.

The bare-prefix cases are the closest this method gets to a null static
type. The prefix resolves to `InvalidType` rather than null, so
`typeOrThrow` on both expression reads holds up. The wrong-count case
pins that `typeArgumentTypes![0]` stays populated.

Eight of the pinned FFI messages sit on code another diagnostic already
flags. Five name `InvalidType`, one names `dynamic`, and two say the
exceptional return is not a constant. That is not specific to
`fromFunction`. `isolateLocal` runs the same
`_validateCompatibleFunctionTypes` and reports the `InvalidType` subtype
message today as well. The tests pin what the verifier does now. If it
should stay quiet on already-flagged code, that is its own change, and
these are a baseline to move from.

Bug: https://github.com/dart-lang/sdk/issues/44773

TEST=pkg/analyzer/test/src/diagnostics/ffi_from_function_test.dart

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>

