### PR TITLE
[analyzer] Normalize inherited getter and setter types before comparing

### DIFF
--- a/pkg/analyzer/lib/src/dart/element/type_system.dart
+++ b/pkg/analyzer/lib/src/dart/element/type_system.dart
@@ -137,6 +137,18 @@ class TypeSystemImpl implements TypeSystem {
     return t is FunctionType || t.isDartCoreFunction;
   }
 
+  /// Whether the normal forms of [T1] and [T2] are structurally equal.
+  ///
+  /// Normalization rewrites `FutureOr<Object>` to `Object`, so a getter typed
+  /// `Object` and a setter typed `FutureOr<Object>` compare equal here.
+  /// `dynamic` and `Object?` normalize to themselves.
+  ///
+  /// https://github.com/dart-lang/language
+  /// See `resources/type-system/normalization.md`
+  bool areStructurallyEqualAfterNormalization(TypeImpl T1, TypeImpl T2) {
+    return normalize(T1) == normalize(T2);
+  }
+
   /// Checks if an instance of [left] could possibly also be an instance of
   /// [right]. For example, an instance of `num` could be `int`, so
   /// canBeSubtypeOf(`num`, `int`) would return `true`, even though `num` is

--- a/pkg/analyzer/lib/src/summary2/instance_member_inferrer.dart
+++ b/pkg/analyzer/lib/src/summary2/instance_member_inferrer.dart
@@ -302,12 +302,11 @@ class InstanceMemberInferrer {
           var setterType = combinedSetterType();
 
           if (getterType != null && setterType != null) {
-            // The two have to be the *same type*, the notion that normalizes
-            // `FutureOr`, so a getter typed `Object` and a setter typed
-            // `FutureOr<Object>` agree. `dynamic` and `Object?` still do not.
-            if (typeSystem.normalize(getterType) ==
-                typeSystem.normalize(setterType)) {
-              field.type = getterType;
+            if (typeSystem.areStructurallyEqualAfterNormalization(
+              getterType,
+              setterType,
+            )) {
+              field.type = setterType;
             } else {
               field.typeInferenceError =
                   TopLevelInferenceErrorDifferentGetterAndSetterTypes(

--- a/pkg/analyzer/lib/src/summary2/instance_member_inferrer.dart
+++ b/pkg/analyzer/lib/src/summary2/instance_member_inferrer.dart
@@ -301,14 +301,20 @@ class InstanceMemberInferrer {
           var getterType = combinedGetterType();
           var setterType = combinedSetterType();
 
-          if (getterType != null && getterType == setterType) {
-            field.type = getterType;
-          } else if (getterType != null && setterType != null) {
-            field.typeInferenceError =
-                TopLevelInferenceErrorDifferentGetterAndSetterTypes(
-                  getterType: getterType.getDisplayString(),
-                  setterType: setterType.getDisplayString(),
-                );
+          if (getterType != null && setterType != null) {
+            // The two have to be the *same type*, the notion that normalizes
+            // `FutureOr`, so a getter typed `Object` and a setter typed
+            // `FutureOr<Object>` agree. `dynamic` and `Object?` still do not.
+            if (typeSystem.normalize(getterType) ==
+                typeSystem.normalize(setterType)) {
+              field.type = getterType;
+            } else {
+              field.typeInferenceError =
+                  TopLevelInferenceErrorDifferentGetterAndSetterTypes(
+                    getterType: getterType.getDisplayString(),
+                    setterType: setterType.getDisplayString(),
+                  );
+            }
           }
           return;
         }

--- a/pkg/analyzer/test/src/diagnostics/different_inherited_getter_and_setter_types_test.dart
+++ b/pkg/analyzer/test/src/diagnostics/different_inherited_getter_and_setter_types_test.dart
@@ -58,6 +58,24 @@ class C extends A {
 ''');
   }
 
+  test_notSameType_dynamicAndObjectQuestion() async {
+    await resolveTestCodeWithDiagnostics('''
+abstract class A {
+  dynamic get foo;
+  set foo(Object? _);
+//    ^^^
+// [context 1] The setter being overridden.
+}
+
+class B extends A {
+  var foo = 0;
+//    ^^^
+// [diag.differentInheritedGetterAndSetterTypes] Can't infer a type for 'foo' because the combined member signature of the getter has return type 'dynamic', which is not the same as the parameter type 'Object?' of the combined member signature of the setter.
+// [diag.invalidOverrideSetter][context 1] The setter 'B.foo' ('void Function(int)') isn't a valid override of 'A.foo' ('void Function(Object?)').
+}
+''');
+  }
+
   test_sameType() async {
     await resolveTestCodeWithDiagnostics('''
 class A {
@@ -87,6 +105,21 @@ class C {
 
 class D implements A, B, C {
   var foo = 0;
+}
+''');
+  }
+
+  test_sameType_futureOrObject() async {
+    await resolveTestCodeWithDiagnostics('''
+import 'dart:async';
+
+abstract class A {
+  Object get foo;
+  set foo(FutureOr<Object> _);
+}
+
+class B extends A {
+  var foo = Object();
 }
 ''');
   }

--- a/pkg/analyzer/test/src/summary/top_level_inference_test.dart
+++ b/pkg/analyzer/test/src/summary/top_level_inference_test.dart
@@ -11681,6 +11681,157 @@ library
 ''');
   }
 
+  test_instanceField_fromGetterSetter_same_field_futureOr() async {
+    var library = await _encodeDecodeLibrary(r'''
+import 'dart:async';
+
+abstract class A {
+  Object get x;
+}
+abstract class B {
+  void set x(FutureOr<Object> _);
+}
+class C implements A, B {
+  var x;
+}
+''');
+    checkElementText(library, r'''
+library
+  reference: <testLibrary>
+  fragments
+    #F0 <testLibraryFragment>
+      element: <testLibrary>
+      libraryImports
+        dart:async
+      classes
+        #F1 isAbstract class A (nameOffset:37) (firstTokenOffset:22) (offset:37)
+          element: <testLibrary>::@class::A
+          fields
+            #F2 isOriginGetterSetter x (nameOffset:<null>) (firstTokenOffset:<null>) (offset:37)
+              element: <testLibrary>::@class::A::@field::x
+          constructors
+            #F3 isOriginImplicitDefault new (nameOffset:<null>) (firstTokenOffset:<null>) (offset:37)
+              element: <testLibrary>::@class::A::@constructor::new
+              typeName: A
+          getters
+            #F4 isAbstract isOriginDeclaration x (nameOffset:54) (firstTokenOffset:43) (offset:54)
+              element: <testLibrary>::@class::A::@getter::x
+        #F5 isAbstract class B (nameOffset:74) (firstTokenOffset:59) (offset:74)
+          element: <testLibrary>::@class::B
+          fields
+            #F6 isOriginGetterSetter x (nameOffset:<null>) (firstTokenOffset:<null>) (offset:74)
+              element: <testLibrary>::@class::B::@field::x
+          constructors
+            #F7 isOriginImplicitDefault new (nameOffset:<null>) (firstTokenOffset:<null>) (offset:74)
+              element: <testLibrary>::@class::B::@constructor::new
+              typeName: B
+          setters
+            #F8 isAbstract isOriginDeclaration x (nameOffset:89) (firstTokenOffset:80) (offset:89)
+              element: <testLibrary>::@class::B::@setter::x
+              formalParameters
+                #F9 requiredPositional isOriginDeclaration _ (nameOffset:108) (firstTokenOffset:91) (offset:108)
+                  element: <testLibrary>::@class::B::@setter::x::@formalParameter::_
+        #F10 class C (nameOffset:120) (firstTokenOffset:114) (offset:120)
+          element: <testLibrary>::@class::C
+          fields
+            #F11 hasImplicitType isOriginDeclaration x (nameOffset:146) (firstTokenOffset:146) (offset:146)
+              element: <testLibrary>::@class::C::@field::x
+              inducedGetter: #F12
+              inducedSetter: #F13
+          constructors
+            #F14 isOriginImplicitDefault new (nameOffset:<null>) (firstTokenOffset:<null>) (offset:120)
+              element: <testLibrary>::@class::C::@constructor::new
+              typeName: C
+          getters
+            #F12 isComplete isOriginVariable x (nameOffset:<null>) (firstTokenOffset:<null>) (offset:146)
+              element: <testLibrary>::@class::C::@getter::x
+              inducingVariable: #F11
+          setters
+            #F13 isComplete isOriginVariable x (nameOffset:<null>) (firstTokenOffset:<null>) (offset:146)
+              element: <testLibrary>::@class::C::@setter::x
+              inducingVariable: #F11
+              formalParameters
+                #F15 requiredPositional value (nameOffset:<null>) (firstTokenOffset:<null>) (offset:146)
+                  element: <testLibrary>::@class::C::@setter::x::@formalParameter::value
+  classes
+    isAbstract isSimplyBounded class A
+      reference: <testLibrary>::@class::A
+      firstFragment: #F1
+      fields
+        isOriginGetterSetter x
+          reference: <testLibrary>::@class::A::@field::x
+          firstFragment: #F2
+          type: Object
+          getter: <testLibrary>::@class::A::@getter::x
+      constructors
+        isOriginImplicitDefault new
+          reference: <testLibrary>::@class::A::@constructor::new
+          firstFragment: #F3
+      getters
+        isOriginDeclaration x
+          reference: <testLibrary>::@class::A::@getter::x
+          firstFragment: #F4
+          returnType: Object
+          variable: <testLibrary>::@class::A::@field::x
+    isAbstract isSimplyBounded class B
+      reference: <testLibrary>::@class::B
+      firstFragment: #F5
+      fields
+        isOriginGetterSetter x
+          reference: <testLibrary>::@class::B::@field::x
+          firstFragment: #F6
+          type: FutureOr<Object>
+          setter: <testLibrary>::@class::B::@setter::x
+      constructors
+        isOriginImplicitDefault new
+          reference: <testLibrary>::@class::B::@constructor::new
+          firstFragment: #F7
+      setters
+        isOriginDeclaration x
+          reference: <testLibrary>::@class::B::@setter::x
+          firstFragment: #F8
+          formalParameters
+            #E0 requiredPositional _
+              firstFragment: #F9
+              type: FutureOr<Object>
+          returnType: void
+          variable: <testLibrary>::@class::B::@field::x
+    hasNonFinalField isSimplyBounded class C
+      reference: <testLibrary>::@class::C
+      firstFragment: #F10
+      interfaces
+        A
+        B
+      fields
+        hasImplicitType isOriginDeclaration x
+          reference: <testLibrary>::@class::C::@field::x
+          firstFragment: #F11
+          type: FutureOr<Object>
+          getter: <testLibrary>::@class::C::@getter::x
+          setter: <testLibrary>::@class::C::@setter::x
+      constructors
+        isOriginImplicitDefault new
+          reference: <testLibrary>::@class::C::@constructor::new
+          firstFragment: #F14
+      getters
+        isOriginVariable x
+          reference: <testLibrary>::@class::C::@getter::x
+          firstFragment: #F12
+          returnType: FutureOr<Object>
+          variable: <testLibrary>::@class::C::@field::x
+      setters
+        isOriginVariable x
+          reference: <testLibrary>::@class::C::@setter::x
+          firstFragment: #F13
+          formalParameters
+            #E1 requiredPositional value
+              firstFragment: #F15
+              type: FutureOr<Object>
+          returnType: void
+          variable: <testLibrary>::@class::C::@field::x
+''');
+  }
+
   test_instanceField_fromGetterSetter_same_getter() async {
     var library = await _encodeDecodeLibrary(r'''
 abstract class A {


### PR DESCRIPTION
The check compared the combined getter and setter types with `==`, which
is structural. The notion of "same type" used elsewhere in the language
normalizes `FutureOr`, so `NORM(FutureOr<Object>)` is `Object` and a
getter typed `Object` agrees with a setter typed `FutureOr<Object>`.
`dynamic` and `Object?` normalize to themselves and keep reporting.

This is the analyzer half of what `@eernstg` described in the issue, on
the example `@scheglov` asked about there.

Two tests. `Object` against `FutureOr<Object>` was red before this change
and is green after; `dynamic` against `Object?` pins the behavior that
must not move.

The CFE half is still open. `inferFieldType` in `members_node.dart`
compares the same two types with kernel `==`, so it reports on the example
today and the two disagree until it changes as well. Happy to follow it
into the front end if that is the order you want.

Bug: https://github.com/dart-lang/sdk/issues/63635
TEST=pkg/analyzer/test/src/diagnostics/different_inherited_getter_and_setter_types_test.dart

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
