### PR TITLE
[analyzer] Report a version number error for `@dart="2.0"`

### DIFF
--- a/pkg/analyzer/lib/src/error/language_version_override_verifier.dart
+++ b/pkg/analyzer/lib/src/error/language_version_override_verifier.dart
@@ -217,20 +217,26 @@ class LanguageVersionOverrideVerifier {
       return false;
     }
 
-    if (dartVersionSeparatorLength != 1 ||
-        comment.codeUnitAt(dartVersionSeparatorStartIndex) != 0x3D) {
-      // The separator between "@dart" and the version number is either not
-      // present, or is not a single "=" character. A separator which starts
-      // with "=" has the character it needs, so what follows it is what is not
-      // a version number: `// @dart="2.0"` reads as a quote where a digit
-      // belongs, not as a missing "=".
-      var startsWithEquals =
-          comment.codeUnitAt(dartVersionSeparatorStartIndex) == 0x3D;
+    if (comment.codeUnitAt(dartVersionSeparatorStartIndex) != 0x3D) {
+      // The first non-whitespace character after "@dart" is not "=". Examples
+      // include: "// @dart: 2", "// @dart 2.0".
       _diagnosticReporter.report(
-        (startsWithEquals
-                ? diag.invalidLanguageVersionOverrideNumber
-                : diag.invalidLanguageVersionOverrideEquals)
-            .atOffset(offset: offset, length: length),
+        diag.invalidLanguageVersionOverrideEquals.atOffset(
+          offset: offset,
+          length: length,
+        ),
+      );
+      return false;
+    }
+
+    if (dartVersionSeparatorLength != 1) {
+      // The separator starts with "=", so what follows the "=" is what is not
+      // a version number. Example: `// @dart="2.0"`.
+      _diagnosticReporter.report(
+        diag.invalidLanguageVersionOverrideNumber.atOffset(
+          offset: offset,
+          length: length,
+        ),
       );
       return false;
     }

--- a/pkg/analyzer/lib/src/error/language_version_override_verifier.dart
+++ b/pkg/analyzer/lib/src/error/language_version_override_verifier.dart
@@ -220,12 +220,17 @@ class LanguageVersionOverrideVerifier {
     if (dartVersionSeparatorLength != 1 ||
         comment.codeUnitAt(dartVersionSeparatorStartIndex) != 0x3D) {
       // The separator between "@dart" and the version number is either not
-      // present, or is not a single "=" character.
+      // present, or is not a single "=" character. A separator which starts
+      // with "=" has the character it needs, so what follows it is what is not
+      // a version number: `// @dart="2.0"` reads as a quote where a digit
+      // belongs, not as a missing "=".
+      var startsWithEquals =
+          comment.codeUnitAt(dartVersionSeparatorStartIndex) == 0x3D;
       _diagnosticReporter.report(
-        diag.invalidLanguageVersionOverrideEquals.atOffset(
-          offset: offset,
-          length: length,
-        ),
+        (startsWithEquals
+                ? diag.invalidLanguageVersionOverrideNumber
+                : diag.invalidLanguageVersionOverrideEquals)
+            .atOffset(offset: offset, length: length),
       );
       return false;
     }

--- a/pkg/analyzer/test/src/diagnostics/invalid_language_override_test.dart
+++ b/pkg/analyzer/test/src/diagnostics/invalid_language_override_test.dart
@@ -315,4 +315,12 @@ int i = 0;
 int i = 0;
 ''');
   }
+
+  test_wrongVersion_quoted() async {
+    await resolveTestCodeWithDiagnostics(r'''
+// @dart="2.0"
+// [diag.invalidLanguageVersionOverrideNumber][column 1][length 14] The Dart language version override comment must be specified with a version number, like '2.0', after the '=' character.
+int i = 0;
+''');
+  }
 }


### PR DESCRIPTION
The comment said the override must be specified with an `=` character,
which it was. The separator scan takes every punctuation character
before the version, so the separator is `="` and the length check
rejects it before anything looks at what follows.

A separator which starts with `=` has the character it needs, so the
problem is the version number instead. `// @dart >= 2.0` keeps the old
message: its separator starts with `>`, and junk before the `=` really
does mean the separator is wrong. Junk after it means the version slot
is wrong.

`// @dart='2.0'` takes the same path, since `'` is neither numeric,
alphabetical nor whitespace and lands in the separator exactly like `"`,
so it needs no second test.

This is what the issue asks for: "We should either have another
`HintCode`, or at least get `INVALID_LANGUAGE_VERSION_OVERRIDE_NUMBER`".
The other half of that issue is untouched, so this does not close it:
`// @dart= "2.0"` with a space still produces nothing at all, which the
reporter calls ok while asking for a hint there too.

Bug: https://github.com/dart-lang/sdk/issues/47197
TEST=pkg/analyzer/test/src/diagnostics/invalid_language_override_test.dart

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
