### PR TITLE
Add test for CreateMethod on enum dot-shorthand invocation in argument position

### DIFF
--- a/pkg/analysis_server/test/src/services/correction/fix/create_method_test.dart
+++ b/pkg/analysis_server/test/src/services/correction/fix/create_method_test.dart
@@ -1796,6 +1796,29 @@ void test() {
 ''');
   }
 
+  Future<void> test_enum_invocation_static_dotShorthand_argument() async {
+    await resolveTestCode('''
+enum E {
+  a;
+}
+void f(E e) {}
+void g() {
+  f(.b());
+}
+''');
+    await assertHasFix('''
+enum E {
+  a;
+
+  static E b() {}
+}
+void f(E e) {}
+void g() {
+  f(.b());
+}
+''');
+  }
+
   Future<void> test_functionType_argument() async {
     await resolveTestCode('''
 class A {


### PR DESCRIPTION
The `CreateMethod` fix for dot-shorthand invocations was recently made to generate a static method (4e432bd60cf). The existing tests cover the variable-declaration context (`E e = .bar()`), but not the function-argument context (`f(.b())` where `f(E e)`), which computes the context type through a different path.

This adds a test for the argument-position case, confirming a static method is generated there too.

Refs #63934

- [x] I've reviewed the contributor guide and applied the relevant portions to this PR.