### PR TITLE
Fix actions permission error in third-party-deps-scan workflow

### DIFF
--- a/.github/workflows/third-party-deps-scan.yml
+++ b/.github/workflows/third-party-deps-scan.yml
@@ -53,4 +53,5 @@ jobs:
     permissions:
       # Needed to upload the SARIF results to the code-scanning dashboard.
       security-events: write
+      actions: read
       contents: read


### PR DESCRIPTION
Fixes an issue where `google/osv-scanner-action` reusable workflow requires `actions: read` permission, but caller job `vuln-scan` only specified `security-events: write` and `contents: read`.

Adding `actions: read` to `vuln-scan` permissions resolves the workflow validation error.