### PR TITLE
Omit const in AddKeyToConstructors when the class can't be const

### DIFF
--- a/pkg/analysis_server/lib/src/services/correction/dart/add_key_to_constructors.dart
+++ b/pkg/analysis_server/lib/src/services/correction/dart/add_key_to_constructors.dart
@@ -10,6 +10,10 @@ import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type.dart';
+import 'package:analyzer/error/listener.dart';
+import 'package:analyzer/src/dart/constant/evaluation.dart';
+import 'package:analyzer/src/dart/constant/value.dart';
+import 'package:analyzer/src/dart/element/element.dart';
 import 'package:analyzer_plugin/utilities/change_builder/change_builder_core.dart';
 import 'package:analyzer_plugin/utilities/change_builder/change_builder_dart.dart';
 import 'package:analyzer_plugin/utilities/fixes/fixes.dart';
@@ -58,16 +62,35 @@ class AddKeyToConstructors extends ResolvedCorrectionProducer {
       }
     }
 
+    var library = libraryElement2 as LibraryElementImpl;
+    var evaluationEngine = ConstantEvaluationEngine(
+      declaredVariables: library.session.declaredVariables,
+      configuration: ConstantEvaluationConfiguration(),
+    );
+    var diagnosticReporter = DiagnosticReporter(
+      DiagnosticListener.nullListener,
+      unitResult.libraryFragment.source,
+    );
+
     for (var member in classDeclaration.body.members) {
       if (member is FieldDeclaration && !member.isStatic) {
         if (!member.fields.isFinal) {
           return false;
         }
+        if (member.fields.isLate) {
+          return false;
+        }
         for (var variableDeclaration in member.fields.variables) {
-          var initializer = variableDeclaration.initializer;
-          if (initializer is InstanceCreationExpression &&
-              !initializer.isConst) {
-            return false;
+          // ignore: experimental_member_use
+          var initializer = variableDeclaration.initializer2;
+          if (initializer != null) {
+            // ignore: experimental_member_use
+            var result = initializer.accept2(
+              ConstantVisitor(evaluationEngine, library, diagnosticReporter),
+            );
+            if (result is! DartObjectImpl) {
+              return false;
+            }
           }
         }
       }

--- a/pkg/analysis_server/test/src/services/correction/fix/add_key_to_constructors_test.dart
+++ b/pkg/analysis_server/test/src/services/correction/fix/add_key_to_constructors_test.dart
@@ -401,6 +401,29 @@ class MyWidget extends StatelessWidget {
 ''');
   }
 
+  Future<void> test_initializer_final_constant_identifier() async {
+    await resolveTestCode('''
+import 'package:flutter/material.dart';
+
+const int value = 3;
+
+class MyWidget extends StatelessWidget {
+  final int x = value;
+}
+''');
+    await assertHasFix('''
+import 'package:flutter/material.dart';
+
+const int value = 3;
+
+class MyWidget extends StatelessWidget {
+  final int x = value;
+
+  const MyWidget({super.key});
+}
+''');
+  }
+
   Future<void> test_initializer_final_not_constant() async {
     await resolveTestCode('''
 import 'package:flutter/material.dart';
@@ -416,6 +439,71 @@ class MyWidget extends StatelessWidget {
   final c = Container();
 
   MyWidget({super.key});
+}
+''');
+  }
+
+  Future<void> test_initializer_final_not_constant_identifier() async {
+    await resolveTestCode('''
+import 'package:flutter/material.dart';
+
+int value = 3;
+
+class MyWidget extends StatelessWidget {
+  final int x = value;
+}
+''');
+    await assertHasFix('''
+import 'package:flutter/material.dart';
+
+int value = 3;
+
+class MyWidget extends StatelessWidget {
+  final int x = value;
+
+  MyWidget({super.key});
+}
+''');
+  }
+
+  Future<void> test_initializer_final_not_constant_listLiteral() async {
+    await resolveTestCode('''
+import 'package:flutter/material.dart';
+
+class MyWidget extends StatelessWidget {
+  final List<int> l = [1, 2];
+}
+''');
+    await assertHasFix('''
+import 'package:flutter/material.dart';
+
+class MyWidget extends StatelessWidget {
+  final List<int> l = [1, 2];
+
+  MyWidget({super.key});
+}
+''');
+  }
+
+  Future<void> test_initializer_final_not_constant_methodInvocation() async {
+    await resolveTestCode('''
+import 'package:flutter/material.dart';
+
+class MyWidget extends StatelessWidget {
+  final String txt = getNonConstString();
+
+  static String getNonConstString() => 'Hello World';
+}
+''');
+    await assertHasFix('''
+import 'package:flutter/material.dart';
+
+class MyWidget extends StatelessWidget {
+  final String txt = getNonConstString();
+
+  MyWidget({super.key});
+
+  static String getNonConstString() => 'Hello World';
 }
 ''');
   }
@@ -477,6 +565,25 @@ class MyWidget extends StatelessWidget {
   static Text t = const Text('');
 
   const MyWidget({super.key});
+}
+''');
+  }
+
+  Future<void> test_lateField() async {
+    await resolveTestCode('''
+import 'package:flutter/material.dart';
+
+class MyWidget extends StatelessWidget {
+  late final int x = 5;
+}
+''');
+    await assertHasFix('''
+import 'package:flutter/material.dart';
+
+class MyWidget extends StatelessWidget {
+  late final int x = 5;
+
+  MyWidget({super.key});
 }
 ''');
   }
@@ -947,6 +1054,29 @@ class MyWidget extends StatelessWidget {
 ''');
   }
 
+  Future<void> test_initializer_final_constant_identifier() async {
+    await resolveTestCode('''
+import 'package:flutter/material.dart';
+
+const int value = 3;
+
+class MyWidget extends StatelessWidget {
+  final int x = value;
+}
+''');
+    await assertHasFix('''
+import 'package:flutter/material.dart';
+
+const int value = 3;
+
+class MyWidget extends StatelessWidget {
+  final int x = value;
+
+  const MyWidget({Key? key}) : super(key: key);
+}
+''');
+  }
+
   Future<void> test_initializer_final_not_constant() async {
     await resolveTestCode('''
 import 'package:flutter/material.dart';
@@ -962,6 +1092,71 @@ class MyWidget extends StatelessWidget {
   final c = Container();
 
   MyWidget({Key? key}) : super(key: key);
+}
+''');
+  }
+
+  Future<void> test_initializer_final_not_constant_identifier() async {
+    await resolveTestCode('''
+import 'package:flutter/material.dart';
+
+int value = 3;
+
+class MyWidget extends StatelessWidget {
+  final int x = value;
+}
+''');
+    await assertHasFix('''
+import 'package:flutter/material.dart';
+
+int value = 3;
+
+class MyWidget extends StatelessWidget {
+  final int x = value;
+
+  MyWidget({Key? key}) : super(key: key);
+}
+''');
+  }
+
+  Future<void> test_initializer_final_not_constant_listLiteral() async {
+    await resolveTestCode('''
+import 'package:flutter/material.dart';
+
+class MyWidget extends StatelessWidget {
+  final List<int> l = [1, 2];
+}
+''');
+    await assertHasFix('''
+import 'package:flutter/material.dart';
+
+class MyWidget extends StatelessWidget {
+  final List<int> l = [1, 2];
+
+  MyWidget({Key? key}) : super(key: key);
+}
+''');
+  }
+
+  Future<void> test_initializer_final_not_constant_methodInvocation() async {
+    await resolveTestCode('''
+import 'package:flutter/material.dart';
+
+class MyWidget extends StatelessWidget {
+  final String txt = getNonConstString();
+
+  static String getNonConstString() => 'Hello World';
+}
+''');
+    await assertHasFix('''
+import 'package:flutter/material.dart';
+
+class MyWidget extends StatelessWidget {
+  final String txt = getNonConstString();
+
+  MyWidget({Key? key}) : super(key: key);
+
+  static String getNonConstString() => 'Hello World';
 }
 ''');
   }
@@ -1023,6 +1218,25 @@ class MyWidget extends StatelessWidget {
   static Text t = const Text('');
 
   const MyWidget({Key? key}) : super(key: key);
+}
+''');
+  }
+
+  Future<void> test_lateField() async {
+    await resolveTestCode('''
+import 'package:flutter/material.dart';
+
+class MyWidget extends StatelessWidget {
+  late final int x = 5;
+}
+''');
+    await assertHasFix('''
+import 'package:flutter/material.dart';
+
+class MyWidget extends StatelessWidget {
+  late final int x = 5;
+
+  MyWidget({Key? key}) : super(key: key);
 }
 ''');
   }


### PR DESCRIPTION
The fix decided to write const by checking only for non-const InstanceCreationExpression initializers. Any other non-constant initializer slipped through:

    class Foo extends StatelessWidget {
      final String txt = getNonConstString();
      static String getNonConstString() => 'Hello World';
    }

generated const Foo({super.key}); which then reports const_constructor_with_field_initialized_by_non_const and const_eval_method_invocation.

_canBeConst now evaluates each instance field initializer with ConstantVisitor, the same way ConstantVerifier decides const_constructor_with_field_initialized_by_non_const, so the fix and the diagnostic can't disagree. It also rejects late final fields (lateFinalFieldWithConstConstructor). Tests added for method invocation, non-const identifier, list literal, constant identifier (const kept), and late final, in both test classes. Uses initializer2 and accept2 to match ConstantVerifier; those are experimental outside pkg/analyzer, hence the two ignores.

- [x] I've reviewed the contributor guide and applied the relevant portions to this submission.

Closes https://github.com/dart-lang/sdk/issues/63965