### PR TITLE
Fix misleading variance context message

### DIFF
--- a/pkg/front_end/lib/src/codes/diagnostic.g.dart
+++ b/pkg/front_end/lib/src/codes/diagnostic.g.dart
@@ -5731,11 +5731,11 @@ const MessageCode incorrectTypeArgumentVariable = const MessageCode(
       """This is the type variable whose bound isn't conformed to.""",
 );
 
+// DO NOT EDIT. THIS FILE IS GENERATED. SEE TOP OF FILE.
 const MessageCode incorrectVariancePositionVariable = const MessageCode(
   "IncorrectVariancePositionVariable",
   severity: CfeSeverity.context,
-  problemMessage:
-      """This is the type variable which is referenced from an invalid position.""",
+  problemMessage: """This is the type variable which is referenced from an invalid position.""",
 );
 
 // DO NOT EDIT. THIS FILE IS GENERATED. SEE TOP OF FILE.

--- a/pkg/front_end/lib/src/codes/diagnostic.g.dart
+++ b/pkg/front_end/lib/src/codes/diagnostic.g.dart
@@ -5731,6 +5731,13 @@ const MessageCode incorrectTypeArgumentVariable = const MessageCode(
       """This is the type variable whose bound isn't conformed to.""",
 );
 
+const MessageCode incorrectVariancePositionVariable = const MessageCode(
+  "IncorrectVariancePositionVariable",
+  severity: CfeSeverity.context,
+  problemMessage:
+      """This is the type variable which is referenced from an invalid position.""",
+);
+
 // DO NOT EDIT. THIS FILE IS GENERATED. SEE TOP OF FILE.
 const Template<Message Function({required String parameterName})>
 incrementalCompilerIllegalParameter = const Template(

--- a/pkg/front_end/lib/src/source/check_helper.dart
+++ b/pkg/front_end/lib/src/source/check_helper.dart
@@ -841,6 +841,7 @@ extension CheckHelper on ProblemReporting {
     TypeParameter? typeParameter,
     DartType? superBoundedAttempt,
     DartType? superBoundedAttemptInverted,
+    bool isVariancePosition = false,
   }) {
     List<LocatedMessage>? context;
     // Skip reporting location for function-type type parameters as it's a
@@ -851,7 +852,10 @@ extension CheckHelper on ProblemReporting {
       // It looks like when parameters come from augmentation libraries, they
       // don't have a reportable location.
       (context ??= <LocatedMessage>[]).add(
-        diag.incorrectTypeArgumentVariable.withLocation(
+        (isVariancePosition
+                ? diag.incorrectVariancePositionVariable
+                : diag.incorrectTypeArgumentVariable)
+            .withLocation(
           typeParameter.location!.file,
           typeParameter.fileOffset,
           noLength,

--- a/pkg/front_end/lib/src/source/check_helper.dart
+++ b/pkg/front_end/lib/src/source/check_helper.dart
@@ -851,9 +851,11 @@ extension CheckHelper on ProblemReporting {
         typeParameter.location?.file != null) {
       // It looks like when parameters come from augmentation libraries, they
       // don't have a reportable location.
-      MessageCode message = diag.incorrectTypeArgumentVariable;
+      MessageCode message;
       if (isVariancePosition) {
         message = diag.incorrectVariancePositionVariable;
+      } else {
+        message = diag.incorrectTypeArgumentVariable;
       }
       (context ??= <LocatedMessage>[]).add(
         message.withLocation(

--- a/pkg/front_end/lib/src/source/check_helper.dart
+++ b/pkg/front_end/lib/src/source/check_helper.dart
@@ -851,11 +851,12 @@ extension CheckHelper on ProblemReporting {
         typeParameter.location?.file != null) {
       // It looks like when parameters come from augmentation libraries, they
       // don't have a reportable location.
+      MessageCode message = diag.incorrectTypeArgumentVariable;
+      if (isVariancePosition) {
+        message = diag.incorrectVariancePositionVariable;
+      }
       (context ??= <LocatedMessage>[]).add(
-        (isVariancePosition
-                ? diag.incorrectVariancePositionVariable
-                : diag.incorrectTypeArgumentVariable)
-            .withLocation(
+        message.withLocation(
           typeParameter.location!.file,
           typeParameter.fileOffset,
           noLength,

--- a/pkg/front_end/lib/src/source/source_class_builder.dart
+++ b/pkg/front_end/lib/src/source/source_class_builder.dart
@@ -1355,6 +1355,7 @@ class SourceClassBuilder extends ClassBuilderImpl
         fileUri: fileUri,
         fileOffset: fileOffset,
         typeParameter: typeParameter,
+        isVariancePosition: true,
       );
     }
   }

--- a/pkg/front_end/messages.yaml
+++ b/pkg/front_end/messages.yaml
@@ -4747,6 +4747,11 @@ incorrectTypeArgumentVariable:
   problemMessage: "This is the type variable whose bound isn't conformed to."
   severity: CONTEXT
 
+incorrectVariancePositionVariable:
+  parameters: none
+  problemMessage: "This is the type variable which is referenced from an invalid position."
+  severity: CONTEXT
+
 superBoundedHint:
   parameters:
     Type attemptedType: The type that the user appears to be attempting to make super-bounded.

--- a/pkg/front_end/testcases/variance/getter.dart.strong.expect
+++ b/pkg/front_end/testcases/variance/getter.dart.strong.expect
@@ -5,98 +5,98 @@ library;
 // pkg/front_end/testcases/variance/getter.dart:8:11: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   final T a = throw "uncalled"; // Error
 //           ^
-// pkg/front_end/testcases/variance/getter.dart:7:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/getter.dart:7:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/getter.dart:9:22: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   final T Function() b = () => throw "uncalled"; // Error
 //                      ^
-// pkg/front_end/testcases/variance/getter.dart:7:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/getter.dart:7:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/getter.dart:10:9: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   T get c => throw "uncalled"; // Error
 //         ^
-// pkg/front_end/testcases/variance/getter.dart:7:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/getter.dart:7:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/getter.dart:11:10: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   late T d; // Error
 //          ^
-// pkg/front_end/testcases/variance/getter.dart:7:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/getter.dart:7:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/getter.dart:12:20: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   covariant late T e; // Error
 //                    ^
-// pkg/front_end/testcases/variance/getter.dart:7:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/getter.dart:7:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/getter.dart:13:6: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   T? f = null; // Error
 //      ^
-// pkg/front_end/testcases/variance/getter.dart:7:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/getter.dart:7:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/getter.dart:17:11: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   final T a = throw "uncalled"; // Error
 //           ^
-// pkg/front_end/testcases/variance/getter.dart:16:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/getter.dart:16:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/getter.dart:18:22: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   final T Function() b = () => throw "uncalled"; // Error
 //                      ^
-// pkg/front_end/testcases/variance/getter.dart:16:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/getter.dart:16:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/getter.dart:19:9: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   T get c => throw "uncalled"; // Error
 //         ^
-// pkg/front_end/testcases/variance/getter.dart:16:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/getter.dart:16:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/getter.dart:20:10: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   late T d; // Error
 //          ^
-// pkg/front_end/testcases/variance/getter.dart:16:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/getter.dart:16:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/getter.dart:21:20: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   covariant late T e; // Error
 //                    ^
-// pkg/front_end/testcases/variance/getter.dart:16:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/getter.dart:16:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/getter.dart:22:6: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   T? f = null; // Error
 //      ^
-// pkg/front_end/testcases/variance/getter.dart:16:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/getter.dart:16:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/getter.dart:26:9: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   T get a; // Error
 //         ^
-// pkg/front_end/testcases/variance/getter.dart:25:21: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/getter.dart:25:21: Context: This is the type variable which is referenced from an invalid position.
 // abstract class C<in T> {
 //                     ^
 //
 // pkg/front_end/testcases/variance/getter.dart:30:7: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   var a; // Error
 //       ^
-// pkg/front_end/testcases/variance/getter.dart:29:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/getter.dart:29:12: Context: This is the type variable which is referenced from an invalid position.
 // class D<in T> extends C<T> {
 //            ^
 //

--- a/pkg/front_end/testcases/variance/getter.dart.strong.modular.expect
+++ b/pkg/front_end/testcases/variance/getter.dart.strong.modular.expect
@@ -5,98 +5,98 @@ library;
 // pkg/front_end/testcases/variance/getter.dart:8:11: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   final T a = throw "uncalled"; // Error
 //           ^
-// pkg/front_end/testcases/variance/getter.dart:7:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/getter.dart:7:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/getter.dart:9:22: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   final T Function() b = () => throw "uncalled"; // Error
 //                      ^
-// pkg/front_end/testcases/variance/getter.dart:7:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/getter.dart:7:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/getter.dart:10:9: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   T get c => throw "uncalled"; // Error
 //         ^
-// pkg/front_end/testcases/variance/getter.dart:7:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/getter.dart:7:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/getter.dart:11:10: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   late T d; // Error
 //          ^
-// pkg/front_end/testcases/variance/getter.dart:7:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/getter.dart:7:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/getter.dart:12:20: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   covariant late T e; // Error
 //                    ^
-// pkg/front_end/testcases/variance/getter.dart:7:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/getter.dart:7:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/getter.dart:13:6: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   T? f = null; // Error
 //      ^
-// pkg/front_end/testcases/variance/getter.dart:7:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/getter.dart:7:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/getter.dart:17:11: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   final T a = throw "uncalled"; // Error
 //           ^
-// pkg/front_end/testcases/variance/getter.dart:16:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/getter.dart:16:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/getter.dart:18:22: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   final T Function() b = () => throw "uncalled"; // Error
 //                      ^
-// pkg/front_end/testcases/variance/getter.dart:16:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/getter.dart:16:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/getter.dart:19:9: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   T get c => throw "uncalled"; // Error
 //         ^
-// pkg/front_end/testcases/variance/getter.dart:16:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/getter.dart:16:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/getter.dart:20:10: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   late T d; // Error
 //          ^
-// pkg/front_end/testcases/variance/getter.dart:16:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/getter.dart:16:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/getter.dart:21:20: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   covariant late T e; // Error
 //                    ^
-// pkg/front_end/testcases/variance/getter.dart:16:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/getter.dart:16:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/getter.dart:22:6: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   T? f = null; // Error
 //      ^
-// pkg/front_end/testcases/variance/getter.dart:16:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/getter.dart:16:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/getter.dart:26:9: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   T get a; // Error
 //         ^
-// pkg/front_end/testcases/variance/getter.dart:25:21: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/getter.dart:25:21: Context: This is the type variable which is referenced from an invalid position.
 // abstract class C<in T> {
 //                     ^
 //
 // pkg/front_end/testcases/variance/getter.dart:30:7: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   var a; // Error
 //       ^
-// pkg/front_end/testcases/variance/getter.dart:29:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/getter.dart:29:12: Context: This is the type variable which is referenced from an invalid position.
 // class D<in T> extends C<T> {
 //            ^
 //

--- a/pkg/front_end/testcases/variance/getter.dart.strong.outline.expect
+++ b/pkg/front_end/testcases/variance/getter.dart.strong.outline.expect
@@ -5,98 +5,98 @@ library;
 // pkg/front_end/testcases/variance/getter.dart:8:11: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   final T a = throw "uncalled"; // Error
 //           ^
-// pkg/front_end/testcases/variance/getter.dart:7:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/getter.dart:7:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/getter.dart:9:22: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   final T Function() b = () => throw "uncalled"; // Error
 //                      ^
-// pkg/front_end/testcases/variance/getter.dart:7:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/getter.dart:7:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/getter.dart:10:9: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   T get c => throw "uncalled"; // Error
 //         ^
-// pkg/front_end/testcases/variance/getter.dart:7:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/getter.dart:7:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/getter.dart:11:10: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   late T d; // Error
 //          ^
-// pkg/front_end/testcases/variance/getter.dart:7:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/getter.dart:7:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/getter.dart:12:20: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   covariant late T e; // Error
 //                    ^
-// pkg/front_end/testcases/variance/getter.dart:7:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/getter.dart:7:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/getter.dart:13:6: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   T? f = null; // Error
 //      ^
-// pkg/front_end/testcases/variance/getter.dart:7:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/getter.dart:7:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/getter.dart:17:11: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   final T a = throw "uncalled"; // Error
 //           ^
-// pkg/front_end/testcases/variance/getter.dart:16:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/getter.dart:16:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/getter.dart:18:22: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   final T Function() b = () => throw "uncalled"; // Error
 //                      ^
-// pkg/front_end/testcases/variance/getter.dart:16:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/getter.dart:16:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/getter.dart:19:9: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   T get c => throw "uncalled"; // Error
 //         ^
-// pkg/front_end/testcases/variance/getter.dart:16:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/getter.dart:16:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/getter.dart:20:10: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   late T d; // Error
 //          ^
-// pkg/front_end/testcases/variance/getter.dart:16:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/getter.dart:16:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/getter.dart:21:20: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   covariant late T e; // Error
 //                    ^
-// pkg/front_end/testcases/variance/getter.dart:16:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/getter.dart:16:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/getter.dart:22:6: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   T? f = null; // Error
 //      ^
-// pkg/front_end/testcases/variance/getter.dart:16:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/getter.dart:16:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/getter.dart:26:9: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   T get a; // Error
 //         ^
-// pkg/front_end/testcases/variance/getter.dart:25:21: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/getter.dart:25:21: Context: This is the type variable which is referenced from an invalid position.
 // abstract class C<in T> {
 //                     ^
 //
 // pkg/front_end/testcases/variance/getter.dart:30:7: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   var a; // Error
 //       ^
-// pkg/front_end/testcases/variance/getter.dart:29:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/getter.dart:29:12: Context: This is the type variable which is referenced from an invalid position.
 // class D<in T> extends C<T> {
 //            ^
 //

--- a/pkg/front_end/testcases/variance/getter.dart.strong.transformed.expect
+++ b/pkg/front_end/testcases/variance/getter.dart.strong.transformed.expect
@@ -5,98 +5,98 @@ library;
 // pkg/front_end/testcases/variance/getter.dart:8:11: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   final T a = throw "uncalled"; // Error
 //           ^
-// pkg/front_end/testcases/variance/getter.dart:7:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/getter.dart:7:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/getter.dart:9:22: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   final T Function() b = () => throw "uncalled"; // Error
 //                      ^
-// pkg/front_end/testcases/variance/getter.dart:7:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/getter.dart:7:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/getter.dart:10:9: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   T get c => throw "uncalled"; // Error
 //         ^
-// pkg/front_end/testcases/variance/getter.dart:7:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/getter.dart:7:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/getter.dart:11:10: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   late T d; // Error
 //          ^
-// pkg/front_end/testcases/variance/getter.dart:7:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/getter.dart:7:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/getter.dart:12:20: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   covariant late T e; // Error
 //                    ^
-// pkg/front_end/testcases/variance/getter.dart:7:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/getter.dart:7:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/getter.dart:13:6: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   T? f = null; // Error
 //      ^
-// pkg/front_end/testcases/variance/getter.dart:7:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/getter.dart:7:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/getter.dart:17:11: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   final T a = throw "uncalled"; // Error
 //           ^
-// pkg/front_end/testcases/variance/getter.dart:16:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/getter.dart:16:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/getter.dart:18:22: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   final T Function() b = () => throw "uncalled"; // Error
 //                      ^
-// pkg/front_end/testcases/variance/getter.dart:16:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/getter.dart:16:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/getter.dart:19:9: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   T get c => throw "uncalled"; // Error
 //         ^
-// pkg/front_end/testcases/variance/getter.dart:16:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/getter.dart:16:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/getter.dart:20:10: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   late T d; // Error
 //          ^
-// pkg/front_end/testcases/variance/getter.dart:16:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/getter.dart:16:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/getter.dart:21:20: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   covariant late T e; // Error
 //                    ^
-// pkg/front_end/testcases/variance/getter.dart:16:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/getter.dart:16:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/getter.dart:22:6: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   T? f = null; // Error
 //      ^
-// pkg/front_end/testcases/variance/getter.dart:16:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/getter.dart:16:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/getter.dart:26:9: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   T get a; // Error
 //         ^
-// pkg/front_end/testcases/variance/getter.dart:25:21: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/getter.dart:25:21: Context: This is the type variable which is referenced from an invalid position.
 // abstract class C<in T> {
 //                     ^
 //
 // pkg/front_end/testcases/variance/getter.dart:30:7: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   var a; // Error
 //       ^
-// pkg/front_end/testcases/variance/getter.dart:29:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/getter.dart:29:12: Context: This is the type variable which is referenced from an invalid position.
 // class D<in T> extends C<T> {
 //            ^
 //

--- a/pkg/front_end/testcases/variance/method.dart.strong.expect
+++ b/pkg/front_end/testcases/variance/method.dart.strong.expect
@@ -5,371 +5,371 @@ library;
 // pkg/front_end/testcases/variance/method.dart:14:5: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   T method1() => throw "uncalled";
 //     ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:15:26: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method2(Contra<T> x) {}
 //                          ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:16:10: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   Cov<T> method3() {
 //          ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:19:31: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method4(Contra<Cov<T>> x) {}
 //                               ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:20:31: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method5(Cov<Contra<T>> x) {}
 //                               ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:21:21: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   Contra<Contra<T>> method6() => (Contra<T> x) {};
 //                     ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:22:15: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   Cov<Cov<T>> method7() {
 //               ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:27:10: Error: Can't use 'in' type variable 'T' in an 'inout' position in the return type.
 //   Inv<T> method8() => throw "uncalled";
 //          ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:28:23: Error: Can't use 'in' type variable 'T' in an 'inout' position.
 //   void method9(Inv<T> x) {}
 //                       ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:29:16: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   Covariant<T> method10() => throw "uncalled";
 //                ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:30:34: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method11(Contravariant<T> x) {}
 //                                  ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:31:16: Error: Can't use 'in' type variable 'T' in an 'inout' position in the return type.
 //   Invariant<T> method12() => throw "uncalled";
 //                ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:32:30: Error: Can't use 'in' type variable 'T' in an 'inout' position.
 //   void method13(Invariant<T> x) {}
 //                              ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:33:45: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method14(Contravariant<Covariant<T>> x) {}
 //                                             ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:34:45: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method15(Covariant<Contravariant<T>> x) {}
 //                                             ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:35:35: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   Contravariant<Contravariant<T>> method16() =>
 //                                   ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:37:27: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   Covariant<Covariant<T>> method17() => Covariant<Covariant<T>>();
 //                           ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:38:17: Error: Can't use 'in' type variable 'T' in an 'inout' position.
 //   void method18<X extends T>() {}
 //                 ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:39:17: Error: Can't use 'in' type variable 'T' in an 'inout' position.
 //   void method19<X extends Cov<T>>() {}
 //                 ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:40:17: Error: Can't use 'in' type variable 'T' in an 'inout' position.
 //   void method20<X extends Covariant<T>>() {}
 //                 ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:41:37: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method21({required Contra<T> x}) {}
 //                                     ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:42:44: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method22({required Contravariant<T> x}) {}
 //                                            ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:43:69: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method23({required Covariant<T> x, required Contravariant<T> y}) {}
 //                                                                     ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:44:17: Error: Can't use 'in' type variable 'T' in an 'inout' position.
 //   void method24<X extends Contra<T>>() {}
 //                 ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:45:17: Error: Can't use 'in' type variable 'T' in an 'inout' position.
 //   void method25<X extends Contravariant<T>>() {}
 //                 ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:48:5: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   T method1() => throw "uncalled";
 //     ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:49:26: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method2(Contra<T> x) {}
 //                          ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:50:10: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   Cov<T> method3() {
 //          ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:53:31: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method4(Contra<Cov<T>> x) {}
 //                               ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:54:31: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method5(Cov<Contra<T>> x) {}
 //                               ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:55:21: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   Contra<Contra<T>> method6() => (Contra<T> x) {};
 //                     ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:56:15: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   Cov<Cov<T>> method7() {
 //               ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:61:10: Error: Can't use 'in' type variable 'T' in an 'inout' position in the return type.
 //   Inv<T> method8() => throw "uncalled";
 //          ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:62:23: Error: Can't use 'in' type variable 'T' in an 'inout' position.
 //   void method9(Inv<T> x) {}
 //                       ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:63:16: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   Covariant<T> method10() => throw "uncalled";
 //                ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:64:34: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method11(Contravariant<T> x) {}
 //                                  ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:65:16: Error: Can't use 'in' type variable 'T' in an 'inout' position in the return type.
 //   Invariant<T> method12() => throw "uncalled";
 //                ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:66:30: Error: Can't use 'in' type variable 'T' in an 'inout' position.
 //   void method13(Invariant<T> x) {}
 //                              ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:67:45: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method14(Contravariant<Covariant<T>> x) {}
 //                                             ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:68:45: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method15(Covariant<Contravariant<T>> x) {}
 //                                             ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:69:35: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   Contravariant<Contravariant<T>> method16() =>
 //                                   ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:71:27: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   Covariant<Covariant<T>> method17() => Covariant<Covariant<T>>();
 //                           ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:72:17: Error: Can't use 'in' type variable 'T' in an 'inout' position.
 //   void method18<X extends T>() {}
 //                 ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:73:17: Error: Can't use 'in' type variable 'T' in an 'inout' position.
 //   void method19<X extends Cov<T>>() {}
 //                 ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:74:17: Error: Can't use 'in' type variable 'T' in an 'inout' position.
 //   void method20<X extends Covariant<T>>() {}
 //                 ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:75:37: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method21({required Contra<T> x}) {}
 //                                     ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:76:44: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method22({required Contravariant<T> x}) {}
 //                                            ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:77:69: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method23({required Covariant<T> x, required Contravariant<T> y}) {}
 //                                                                     ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:78:17: Error: Can't use 'in' type variable 'T' in an 'inout' position.
 //   void method24<X extends Contra<T>>() {}
 //                 ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:79:17: Error: Can't use 'in' type variable 'T' in an 'inout' position.
 //   void method25<X extends Contravariant<T>>() {}
 //                 ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:82:21: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method1(A<T> x) {}
 //                     ^
-// pkg/front_end/testcases/variance/method.dart:81:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:81:12: Context: This is the type variable which is referenced from an invalid position.
 // class B<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:83:16: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   Contra<A<T>> method2() {
 //                ^
-// pkg/front_end/testcases/variance/method.dart:81:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:81:12: Context: This is the type variable which is referenced from an invalid position.
 // class B<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:92:32: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method(void Function(T) x) {}
 //                                ^
-// pkg/front_end/testcases/variance/method.dart:90:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:90:12: Context: This is the type variable which is referenced from an invalid position.
 // class D<in T> extends C<void Function(T)> {
 //            ^
 //

--- a/pkg/front_end/testcases/variance/method.dart.strong.modular.expect
+++ b/pkg/front_end/testcases/variance/method.dart.strong.modular.expect
@@ -5,371 +5,371 @@ library;
 // pkg/front_end/testcases/variance/method.dart:14:5: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   T method1() => throw "uncalled";
 //     ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:15:26: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method2(Contra<T> x) {}
 //                          ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:16:10: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   Cov<T> method3() {
 //          ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:19:31: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method4(Contra<Cov<T>> x) {}
 //                               ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:20:31: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method5(Cov<Contra<T>> x) {}
 //                               ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:21:21: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   Contra<Contra<T>> method6() => (Contra<T> x) {};
 //                     ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:22:15: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   Cov<Cov<T>> method7() {
 //               ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:27:10: Error: Can't use 'in' type variable 'T' in an 'inout' position in the return type.
 //   Inv<T> method8() => throw "uncalled";
 //          ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:28:23: Error: Can't use 'in' type variable 'T' in an 'inout' position.
 //   void method9(Inv<T> x) {}
 //                       ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:29:16: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   Covariant<T> method10() => throw "uncalled";
 //                ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:30:34: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method11(Contravariant<T> x) {}
 //                                  ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:31:16: Error: Can't use 'in' type variable 'T' in an 'inout' position in the return type.
 //   Invariant<T> method12() => throw "uncalled";
 //                ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:32:30: Error: Can't use 'in' type variable 'T' in an 'inout' position.
 //   void method13(Invariant<T> x) {}
 //                              ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:33:45: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method14(Contravariant<Covariant<T>> x) {}
 //                                             ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:34:45: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method15(Covariant<Contravariant<T>> x) {}
 //                                             ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:35:35: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   Contravariant<Contravariant<T>> method16() =>
 //                                   ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:37:27: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   Covariant<Covariant<T>> method17() => Covariant<Covariant<T>>();
 //                           ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:38:17: Error: Can't use 'in' type variable 'T' in an 'inout' position.
 //   void method18<X extends T>() {}
 //                 ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:39:17: Error: Can't use 'in' type variable 'T' in an 'inout' position.
 //   void method19<X extends Cov<T>>() {}
 //                 ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:40:17: Error: Can't use 'in' type variable 'T' in an 'inout' position.
 //   void method20<X extends Covariant<T>>() {}
 //                 ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:41:37: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method21({required Contra<T> x}) {}
 //                                     ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:42:44: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method22({required Contravariant<T> x}) {}
 //                                            ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:43:69: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method23({required Covariant<T> x, required Contravariant<T> y}) {}
 //                                                                     ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:44:17: Error: Can't use 'in' type variable 'T' in an 'inout' position.
 //   void method24<X extends Contra<T>>() {}
 //                 ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:45:17: Error: Can't use 'in' type variable 'T' in an 'inout' position.
 //   void method25<X extends Contravariant<T>>() {}
 //                 ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:48:5: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   T method1() => throw "uncalled";
 //     ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:49:26: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method2(Contra<T> x) {}
 //                          ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:50:10: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   Cov<T> method3() {
 //          ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:53:31: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method4(Contra<Cov<T>> x) {}
 //                               ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:54:31: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method5(Cov<Contra<T>> x) {}
 //                               ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:55:21: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   Contra<Contra<T>> method6() => (Contra<T> x) {};
 //                     ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:56:15: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   Cov<Cov<T>> method7() {
 //               ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:61:10: Error: Can't use 'in' type variable 'T' in an 'inout' position in the return type.
 //   Inv<T> method8() => throw "uncalled";
 //          ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:62:23: Error: Can't use 'in' type variable 'T' in an 'inout' position.
 //   void method9(Inv<T> x) {}
 //                       ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:63:16: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   Covariant<T> method10() => throw "uncalled";
 //                ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:64:34: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method11(Contravariant<T> x) {}
 //                                  ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:65:16: Error: Can't use 'in' type variable 'T' in an 'inout' position in the return type.
 //   Invariant<T> method12() => throw "uncalled";
 //                ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:66:30: Error: Can't use 'in' type variable 'T' in an 'inout' position.
 //   void method13(Invariant<T> x) {}
 //                              ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:67:45: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method14(Contravariant<Covariant<T>> x) {}
 //                                             ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:68:45: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method15(Covariant<Contravariant<T>> x) {}
 //                                             ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:69:35: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   Contravariant<Contravariant<T>> method16() =>
 //                                   ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:71:27: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   Covariant<Covariant<T>> method17() => Covariant<Covariant<T>>();
 //                           ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:72:17: Error: Can't use 'in' type variable 'T' in an 'inout' position.
 //   void method18<X extends T>() {}
 //                 ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:73:17: Error: Can't use 'in' type variable 'T' in an 'inout' position.
 //   void method19<X extends Cov<T>>() {}
 //                 ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:74:17: Error: Can't use 'in' type variable 'T' in an 'inout' position.
 //   void method20<X extends Covariant<T>>() {}
 //                 ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:75:37: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method21({required Contra<T> x}) {}
 //                                     ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:76:44: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method22({required Contravariant<T> x}) {}
 //                                            ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:77:69: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method23({required Covariant<T> x, required Contravariant<T> y}) {}
 //                                                                     ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:78:17: Error: Can't use 'in' type variable 'T' in an 'inout' position.
 //   void method24<X extends Contra<T>>() {}
 //                 ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:79:17: Error: Can't use 'in' type variable 'T' in an 'inout' position.
 //   void method25<X extends Contravariant<T>>() {}
 //                 ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:82:21: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method1(A<T> x) {}
 //                     ^
-// pkg/front_end/testcases/variance/method.dart:81:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:81:12: Context: This is the type variable which is referenced from an invalid position.
 // class B<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:83:16: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   Contra<A<T>> method2() {
 //                ^
-// pkg/front_end/testcases/variance/method.dart:81:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:81:12: Context: This is the type variable which is referenced from an invalid position.
 // class B<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:92:32: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method(void Function(T) x) {}
 //                                ^
-// pkg/front_end/testcases/variance/method.dart:90:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:90:12: Context: This is the type variable which is referenced from an invalid position.
 // class D<in T> extends C<void Function(T)> {
 //            ^
 //

--- a/pkg/front_end/testcases/variance/method.dart.strong.outline.expect
+++ b/pkg/front_end/testcases/variance/method.dart.strong.outline.expect
@@ -5,371 +5,371 @@ library;
 // pkg/front_end/testcases/variance/method.dart:14:5: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   T method1() => throw "uncalled";
 //     ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:15:26: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method2(Contra<T> x) {}
 //                          ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:16:10: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   Cov<T> method3() {
 //          ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:19:31: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method4(Contra<Cov<T>> x) {}
 //                               ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:20:31: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method5(Cov<Contra<T>> x) {}
 //                               ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:21:21: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   Contra<Contra<T>> method6() => (Contra<T> x) {};
 //                     ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:22:15: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   Cov<Cov<T>> method7() {
 //               ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:27:10: Error: Can't use 'in' type variable 'T' in an 'inout' position in the return type.
 //   Inv<T> method8() => throw "uncalled";
 //          ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:28:23: Error: Can't use 'in' type variable 'T' in an 'inout' position.
 //   void method9(Inv<T> x) {}
 //                       ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:29:16: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   Covariant<T> method10() => throw "uncalled";
 //                ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:30:34: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method11(Contravariant<T> x) {}
 //                                  ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:31:16: Error: Can't use 'in' type variable 'T' in an 'inout' position in the return type.
 //   Invariant<T> method12() => throw "uncalled";
 //                ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:32:30: Error: Can't use 'in' type variable 'T' in an 'inout' position.
 //   void method13(Invariant<T> x) {}
 //                              ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:33:45: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method14(Contravariant<Covariant<T>> x) {}
 //                                             ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:34:45: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method15(Covariant<Contravariant<T>> x) {}
 //                                             ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:35:35: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   Contravariant<Contravariant<T>> method16() =>
 //                                   ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:37:27: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   Covariant<Covariant<T>> method17() => Covariant<Covariant<T>>();
 //                           ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:38:17: Error: Can't use 'in' type variable 'T' in an 'inout' position.
 //   void method18<X extends T>() {}
 //                 ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:39:17: Error: Can't use 'in' type variable 'T' in an 'inout' position.
 //   void method19<X extends Cov<T>>() {}
 //                 ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:40:17: Error: Can't use 'in' type variable 'T' in an 'inout' position.
 //   void method20<X extends Covariant<T>>() {}
 //                 ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:41:37: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method21({required Contra<T> x}) {}
 //                                     ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:42:44: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method22({required Contravariant<T> x}) {}
 //                                            ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:43:69: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method23({required Covariant<T> x, required Contravariant<T> y}) {}
 //                                                                     ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:44:17: Error: Can't use 'in' type variable 'T' in an 'inout' position.
 //   void method24<X extends Contra<T>>() {}
 //                 ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:45:17: Error: Can't use 'in' type variable 'T' in an 'inout' position.
 //   void method25<X extends Contravariant<T>>() {}
 //                 ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:48:5: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   T method1() => throw "uncalled";
 //     ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:49:26: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method2(Contra<T> x) {}
 //                          ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:50:10: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   Cov<T> method3() {
 //          ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:53:31: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method4(Contra<Cov<T>> x) {}
 //                               ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:54:31: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method5(Cov<Contra<T>> x) {}
 //                               ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:55:21: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   Contra<Contra<T>> method6() => (Contra<T> x) {};
 //                     ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:56:15: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   Cov<Cov<T>> method7() {
 //               ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:61:10: Error: Can't use 'in' type variable 'T' in an 'inout' position in the return type.
 //   Inv<T> method8() => throw "uncalled";
 //          ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:62:23: Error: Can't use 'in' type variable 'T' in an 'inout' position.
 //   void method9(Inv<T> x) {}
 //                       ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:63:16: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   Covariant<T> method10() => throw "uncalled";
 //                ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:64:34: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method11(Contravariant<T> x) {}
 //                                  ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:65:16: Error: Can't use 'in' type variable 'T' in an 'inout' position in the return type.
 //   Invariant<T> method12() => throw "uncalled";
 //                ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:66:30: Error: Can't use 'in' type variable 'T' in an 'inout' position.
 //   void method13(Invariant<T> x) {}
 //                              ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:67:45: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method14(Contravariant<Covariant<T>> x) {}
 //                                             ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:68:45: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method15(Covariant<Contravariant<T>> x) {}
 //                                             ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:69:35: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   Contravariant<Contravariant<T>> method16() =>
 //                                   ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:71:27: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   Covariant<Covariant<T>> method17() => Covariant<Covariant<T>>();
 //                           ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:72:17: Error: Can't use 'in' type variable 'T' in an 'inout' position.
 //   void method18<X extends T>() {}
 //                 ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:73:17: Error: Can't use 'in' type variable 'T' in an 'inout' position.
 //   void method19<X extends Cov<T>>() {}
 //                 ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:74:17: Error: Can't use 'in' type variable 'T' in an 'inout' position.
 //   void method20<X extends Covariant<T>>() {}
 //                 ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:75:37: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method21({required Contra<T> x}) {}
 //                                     ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:76:44: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method22({required Contravariant<T> x}) {}
 //                                            ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:77:69: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method23({required Covariant<T> x, required Contravariant<T> y}) {}
 //                                                                     ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:78:17: Error: Can't use 'in' type variable 'T' in an 'inout' position.
 //   void method24<X extends Contra<T>>() {}
 //                 ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:79:17: Error: Can't use 'in' type variable 'T' in an 'inout' position.
 //   void method25<X extends Contravariant<T>>() {}
 //                 ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:82:21: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method1(A<T> x) {}
 //                     ^
-// pkg/front_end/testcases/variance/method.dart:81:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:81:12: Context: This is the type variable which is referenced from an invalid position.
 // class B<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:83:16: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   Contra<A<T>> method2() {
 //                ^
-// pkg/front_end/testcases/variance/method.dart:81:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:81:12: Context: This is the type variable which is referenced from an invalid position.
 // class B<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:92:32: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method(void Function(T) x) {}
 //                                ^
-// pkg/front_end/testcases/variance/method.dart:90:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:90:12: Context: This is the type variable which is referenced from an invalid position.
 // class D<in T> extends C<void Function(T)> {
 //            ^
 //

--- a/pkg/front_end/testcases/variance/method.dart.strong.transformed.expect
+++ b/pkg/front_end/testcases/variance/method.dart.strong.transformed.expect
@@ -5,371 +5,371 @@ library;
 // pkg/front_end/testcases/variance/method.dart:14:5: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   T method1() => throw "uncalled";
 //     ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:15:26: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method2(Contra<T> x) {}
 //                          ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:16:10: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   Cov<T> method3() {
 //          ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:19:31: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method4(Contra<Cov<T>> x) {}
 //                               ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:20:31: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method5(Cov<Contra<T>> x) {}
 //                               ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:21:21: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   Contra<Contra<T>> method6() => (Contra<T> x) {};
 //                     ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:22:15: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   Cov<Cov<T>> method7() {
 //               ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:27:10: Error: Can't use 'in' type variable 'T' in an 'inout' position in the return type.
 //   Inv<T> method8() => throw "uncalled";
 //          ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:28:23: Error: Can't use 'in' type variable 'T' in an 'inout' position.
 //   void method9(Inv<T> x) {}
 //                       ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:29:16: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   Covariant<T> method10() => throw "uncalled";
 //                ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:30:34: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method11(Contravariant<T> x) {}
 //                                  ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:31:16: Error: Can't use 'in' type variable 'T' in an 'inout' position in the return type.
 //   Invariant<T> method12() => throw "uncalled";
 //                ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:32:30: Error: Can't use 'in' type variable 'T' in an 'inout' position.
 //   void method13(Invariant<T> x) {}
 //                              ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:33:45: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method14(Contravariant<Covariant<T>> x) {}
 //                                             ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:34:45: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method15(Covariant<Contravariant<T>> x) {}
 //                                             ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:35:35: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   Contravariant<Contravariant<T>> method16() =>
 //                                   ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:37:27: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   Covariant<Covariant<T>> method17() => Covariant<Covariant<T>>();
 //                           ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:38:17: Error: Can't use 'in' type variable 'T' in an 'inout' position.
 //   void method18<X extends T>() {}
 //                 ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:39:17: Error: Can't use 'in' type variable 'T' in an 'inout' position.
 //   void method19<X extends Cov<T>>() {}
 //                 ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:40:17: Error: Can't use 'in' type variable 'T' in an 'inout' position.
 //   void method20<X extends Covariant<T>>() {}
 //                 ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:41:37: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method21({required Contra<T> x}) {}
 //                                     ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:42:44: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method22({required Contravariant<T> x}) {}
 //                                            ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:43:69: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method23({required Covariant<T> x, required Contravariant<T> y}) {}
 //                                                                     ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:44:17: Error: Can't use 'in' type variable 'T' in an 'inout' position.
 //   void method24<X extends Contra<T>>() {}
 //                 ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:45:17: Error: Can't use 'in' type variable 'T' in an 'inout' position.
 //   void method25<X extends Contravariant<T>>() {}
 //                 ^
-// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:13:12: Context: This is the type variable which is referenced from an invalid position.
 // class A<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:48:5: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   T method1() => throw "uncalled";
 //     ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:49:26: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method2(Contra<T> x) {}
 //                          ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:50:10: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   Cov<T> method3() {
 //          ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:53:31: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method4(Contra<Cov<T>> x) {}
 //                               ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:54:31: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method5(Cov<Contra<T>> x) {}
 //                               ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:55:21: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   Contra<Contra<T>> method6() => (Contra<T> x) {};
 //                     ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:56:15: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   Cov<Cov<T>> method7() {
 //               ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:61:10: Error: Can't use 'in' type variable 'T' in an 'inout' position in the return type.
 //   Inv<T> method8() => throw "uncalled";
 //          ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:62:23: Error: Can't use 'in' type variable 'T' in an 'inout' position.
 //   void method9(Inv<T> x) {}
 //                       ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:63:16: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   Covariant<T> method10() => throw "uncalled";
 //                ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:64:34: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method11(Contravariant<T> x) {}
 //                                  ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:65:16: Error: Can't use 'in' type variable 'T' in an 'inout' position in the return type.
 //   Invariant<T> method12() => throw "uncalled";
 //                ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:66:30: Error: Can't use 'in' type variable 'T' in an 'inout' position.
 //   void method13(Invariant<T> x) {}
 //                              ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:67:45: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method14(Contravariant<Covariant<T>> x) {}
 //                                             ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:68:45: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method15(Covariant<Contravariant<T>> x) {}
 //                                             ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:69:35: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   Contravariant<Contravariant<T>> method16() =>
 //                                   ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:71:27: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   Covariant<Covariant<T>> method17() => Covariant<Covariant<T>>();
 //                           ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:72:17: Error: Can't use 'in' type variable 'T' in an 'inout' position.
 //   void method18<X extends T>() {}
 //                 ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:73:17: Error: Can't use 'in' type variable 'T' in an 'inout' position.
 //   void method19<X extends Cov<T>>() {}
 //                 ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:74:17: Error: Can't use 'in' type variable 'T' in an 'inout' position.
 //   void method20<X extends Covariant<T>>() {}
 //                 ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:75:37: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method21({required Contra<T> x}) {}
 //                                     ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:76:44: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method22({required Contravariant<T> x}) {}
 //                                            ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:77:69: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method23({required Covariant<T> x, required Contravariant<T> y}) {}
 //                                                                     ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:78:17: Error: Can't use 'in' type variable 'T' in an 'inout' position.
 //   void method24<X extends Contra<T>>() {}
 //                 ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:79:17: Error: Can't use 'in' type variable 'T' in an 'inout' position.
 //   void method25<X extends Contravariant<T>>() {}
 //                 ^
-// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:47:17: Context: This is the type variable which is referenced from an invalid position.
 // mixin BMixin<in T> {
 //                 ^
 //
 // pkg/front_end/testcases/variance/method.dart:82:21: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method1(A<T> x) {}
 //                     ^
-// pkg/front_end/testcases/variance/method.dart:81:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:81:12: Context: This is the type variable which is referenced from an invalid position.
 // class B<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:83:16: Error: Can't use 'in' type variable 'T' in an 'out' position in the return type.
 //   Contra<A<T>> method2() {
 //                ^
-// pkg/front_end/testcases/variance/method.dart:81:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:81:12: Context: This is the type variable which is referenced from an invalid position.
 // class B<in T> {
 //            ^
 //
 // pkg/front_end/testcases/variance/method.dart:92:32: Error: Can't use 'in' type variable 'T' in an 'out' position.
 //   void method(void Function(T) x) {}
 //                                ^
-// pkg/front_end/testcases/variance/method.dart:90:12: Context: This is the type variable whose bound isn't conformed to.
+// pkg/front_end/testcases/variance/method.dart:90:12: Context: This is the type variable which is referenced from an invalid position.
 // class D<in T> extends C<void Function(T)> {
 //            ^
 //


### PR DESCRIPTION
This PR fixes an issue where variance errors reported a misleading context message (`This is the type variable whose bound isn't conformed to.`) instead of pointing out the actual variance violation. 

**Changes included:**
* Added a new diagnostic message: `incorrectVariancePositionVariable` ("This is the type variable which is referenced from an invalid position.").
* Updated `reportTypeArgumentIssue` in `check_helper.dart` to accept an `isVariancePosition` flag.
* Passed `isVariancePosition: true` from `source_class_builder.dart` when reporting variance position errors.
* Updated the `.expect` test expectation files in `pkg/front_end/testcases/variance/` to match the correct context message.

Fixes #63875

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>