### PR TITLE
[ffi] Add NativeFinalizer.callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Libraries
 
+#### `dart:ffi`
+- Added `NativeFinalizer.callback`, which returns the finalization callback the
+  finalizer was created with.
+  For more details, see SDK issue [#63811][]
+
+[#63811]: https://github.com/dart-lang/sdk/issues/63811
+
 #### `dart:js_interop`
 - The `isA<JSArray>` check now uses both `Array.isArray` and `instanceof` to
   verify if a value is an array; it is considered an array if either condition

--- a/sdk/lib/_internal/vm/lib/ffi_native_finalizer_patch.dart
+++ b/sdk/lib/_internal/vm/lib/ffi_native_finalizer_patch.dart
@@ -37,6 +37,9 @@ final class _NativeFinalizer extends FinalizerBase implements NativeFinalizer {
     isolateRegisterFinalizer();
   }
 
+  @override
+  Pointer<NativeFinalizerFunction> get callback => _callback;
+
   void attach(
     Object value,
     Pointer<Void> token, {

--- a/sdk/lib/ffi/native_finalizer.dart
+++ b/sdk/lib/ffi/native_finalizer.dart
@@ -360,6 +360,15 @@ abstract final class NativeFinalizer {
   /// current isolate group but will not have a current isolate.
   external factory NativeFinalizer(Pointer<NativeFinalizerFunction> callback);
 
+  /// The finalization callback this finalizer was created with.
+  ///
+  /// An object that eagerly releases the native resource it owns, for example
+  /// in a `dispose` method, can [detach] from this finalizer and then run the
+  /// callback itself with [NativeFunctionPointer.asFunction], instead of
+  /// separately keeping track of the callback.
+  @Since('3.14')
+  Pointer<NativeFinalizerFunction> get callback;
+
   /// Attaches this finalizer to [value].
   ///
   /// When [value] is no longer accessible to the program,

--- a/tests/ffi/vmspecific_native_finalizer_test.dart
+++ b/tests/ffi/vmspecific_native_finalizer_test.dart
@@ -7,11 +7,27 @@
 import 'dart:ffi';
 import 'dart:io';
 
+import 'package:expect/expect.dart';
+
 import 'ffi_test_helpers.dart';
 
 void main() {
+  testCallback();
   testMallocFree();
   print('end of test, shutting down');
+}
+
+void testCallback() {
+  if (Platform.isWindows) {
+    // `free` not supported, so `freePtr` cannot be looked up.
+    return;
+  }
+
+  Expect.equals(freePtr, freeFinalizer.callback);
+
+  final resource = MyNativeResource();
+  resource.closeUsingCallback();
+  doGC();
 }
 
 void testMallocFree() {
@@ -64,6 +80,14 @@ class MyNativeResource implements Finalizable {
     _closed = true;
     freeFinalizer.detach(this);
     free(pointer);
+  }
+
+  /// Like [close], but obtains the finalization callback from the finalizer
+  /// itself instead of holding on to `free` separately.
+  void closeUsingCallback() {
+    _closed = true;
+    freeFinalizer.detach(this);
+    freeFinalizer.callback.asFunction<void Function(Pointer<Void>)>()(pointer);
   }
 
   void useResource() {


### PR DESCRIPTION
Exposes the finalization callback a `NativeFinalizer` was created with.

An object that wraps a native resource and wants to release it eagerly, for example in a `dispose` method, currently has to hold on to both the `NativeFinalizer` and its callback, because detaching from a finalizer does not run the callback. With this getter it only needs to keep the `NativeFinalizer`.

`Finalizer` in `dart:core` deliberately does not get the same getter: it stores the callback wrapped in `Zone.bindUnaryCallbackGuarded`, so the getter would not return what the caller passed in. `NativeFinalizer` stores the pointer as-is.

`NativeFinalizer` is `abstract final`, so it cannot be implemented or extended outside `dart:ffi`, which makes this a non-breaking addition.

Closes https://github.com/dart-lang/sdk/issues/63811

TEST=./tools/test.py -n vm-mac-release-arm64 ffi/vmspecific_native_finalizer

- Thanks for your contribution! Please replace this text with a description of what this PR is changing or adding and why, list any relevant issues, and review the contribution guidelines below.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
