### PR TITLE
linter: Fix avoid_field_initializers_in_const_classes for primary constructors

### DIFF
--- a/pkg/linter/lib/src/rules/avoid_field_initializers_in_const_classes.dart
+++ b/pkg/linter/lib/src/rules/avoid_field_initializers_in_const_classes.dart
@@ -97,10 +97,23 @@ class _Visitor(final AnalysisRule rule) extends SimpleAstVisitor<void> {
       if (declaredElement.constructors.every((e) => !e.isConst)) {
         return;
       }
+      // Only the parameters of a primary constructor are in scope in a field
+      // initializer.
+      var namePart = parent.namePart;
+      var primaryConstructor = namePart is PrimaryConstructorDeclaration
+          ? namePart.declaredFragment?.element
+          : null;
       for (var variable in node.fields.variables) {
-        if (variable.initializer != null) {
-          rule.reportAtNode(variable);
+        var initializer = variable.initializer;
+        if (initializer == null) continue;
+        if (primaryConstructor != null) {
+          var visitor = HasParameterReferenceVisitor(
+            primaryConstructor.formalParameters,
+          );
+          initializer.accept(visitor);
+          if (visitor.useParameter) continue;
         }
+        rule.reportAtNode(variable);
       }
     }
   }

--- a/pkg/linter/test/rules/avoid_field_initializers_in_const_classes_test.dart
+++ b/pkg/linter/test/rules/avoid_field_initializers_in_const_classes_test.dart
@@ -71,6 +71,22 @@ class C {
 ''');
   }
 
+  test_constClass_fieldInitializer_primary() async {
+    await assertDiagnosticsFromMarkup(r'''
+class const C(int x) {
+  final y = x + 2, [!z = 0!];
+}
+''');
+  }
+
+  test_constClass_fieldInitializer_primary_usingParameter() async {
+    await assertNoDiagnostics(r'''
+class const C(int x) {
+  final int y = x + 2;
+}
+''');
+  }
+
   test_constClass_multipleConstructors() async {
     await assertNoDiagnostics(r'''
 class C {


### PR DESCRIPTION
A final field with an initializer in a class with a const constructor gets reported by `visitFieldDeclaration`, whatever the initializer reads. A primary constructor puts its parameters in scope in those initializers, and an initializer that reads one is not a constant expression, so the rule should not report it. The same check already sits in `visitConstructorFieldInitializer`, and I applied it to field declarations too, per variable.

Fixes https://github.com/dart-lang/sdk/issues/64001

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
