### PR TITLE
[analysis_server] Look through cascades when removing a declared type

### DIFF
--- a/pkg/analysis_server/lib/src/services/correction/dart/remove_type_annotation.dart
+++ b/pkg/analysis_server/lib/src/services/correction/dart/remove_type_annotation.dart
@@ -98,6 +98,11 @@ class RemoveTypeAnnotation extends ParsedCorrectionProducer {
 
     String? insertionText;
     int? insertionOffset;
+    // The context type of a cascade expression is passed on to its target, so
+    // the target is the expression that depends on the declared type.
+    if (initializer is CascadeExpression) {
+      initializer = initializer.target;
+    }
     if (isDotShorthand(initializer)) {
       // Inserts the type before the dot shorthand (e.g. `E.a` where type is
       // `E`) because we erase the required context type when we replace the
@@ -108,9 +113,6 @@ class RemoveTypeAnnotation extends ParsedCorrectionProducer {
     } else if (type is NamedType) {
       var typeArguments = type.typeArguments;
       if (typeArguments != null) {
-        if (initializer is CascadeExpression) {
-          initializer = initializer.target;
-        }
         if (initializer is TypedLiteral) {
           if (initializer.typeArguments == null) {
             insertionText = utils.getNodeText(typeArguments);

--- a/pkg/analysis_server/lib/src/services/correction/dart/replace_with_var.dart
+++ b/pkg/analysis_server/lib/src/services/correction/dart/replace_with_var.dart
@@ -59,6 +59,11 @@ class ReplaceWithVar extends ResolvedCorrectionProducer {
       var initializer = variables[0].initializer;
       String? insertionText;
       int? insertionOffset;
+      // The context type of a cascade expression is passed on to its target, so
+      // the target is the expression that depends on the declared type.
+      if (initializer is CascadeExpression) {
+        initializer = initializer.target;
+      }
       if (initializer != null && isDotShorthand(initializer)) {
         // Inserts the type before the dot shorthand (e.g. `E.a` where type is
         // `E`) because we erase the required context type when we replace the
@@ -68,9 +73,6 @@ class ReplaceWithVar extends ResolvedCorrectionProducer {
       } else if (type is NamedType) {
         var typeArguments = type.typeArguments;
         if (typeArguments != null) {
-          if (initializer is CascadeExpression) {
-            initializer = initializer.target;
-          }
           if (initializer is TypedLiteral) {
             if (initializer.typeArguments == null) {
               insertionText = utils.getNodeText(typeArguments);

--- a/pkg/analysis_server/test/src/services/correction/assist/remove_type_annotation_test.dart
+++ b/pkg/analysis_server/test/src/services/correction/assist/remove_type_annotation_test.dart
@@ -183,6 +183,24 @@ Set f() {
 ''');
   }
 
+  Future<void>
+  test_generic_instanceCreation_cascade_dotShorthandTarget() async {
+    await resolveTestCode('''
+C<int> f() {
+  final ^C<int> c = .new()..toString();
+  return c;
+}
+class C<T> {}
+''');
+    await assertHasAssist('''
+C<int> f() {
+  final c = C<int>.new()..toString();
+  return c;
+}
+class C<T> {}
+''');
+  }
+
   Future<void> test_generic_instanceCreation_withoutArguments() async {
     await resolveTestCode('''
 C<int> ^c = C();
@@ -224,6 +242,16 @@ List f() {
     await resolveTestCode('''
 Set f() {
   ^Set s = {};
+  return s;
+}
+''');
+    await assertNoAssist();
+  }
+
+  Future<void> test_generic_setLiteral_ambiguous_cascade() async {
+    await resolveTestCode('''
+Set f() {
+  ^Set s = {}..addAll([]);
   return s;
 }
 ''');

--- a/pkg/analysis_server/test/src/services/correction/assist/replace_with_var_test.dart
+++ b/pkg/analysis_server/test/src/services/correction/assist/replace_with_var_test.dart
@@ -182,6 +182,24 @@ Set f() {
 ''');
   }
 
+  Future<void>
+  test_generic_instanceCreation_cascade_dotShorthandTarget() async {
+    await resolveTestCode('''
+C<int> f() {
+  ^C<int> c = .new()..toString();
+  return c;
+}
+class C<T> {}
+''');
+    await assertHasAssist('''
+C<int> f() {
+  var c = C<int>.new()..toString();
+  return c;
+}
+class C<T> {}
+''');
+  }
+
   Future<void> test_generic_instanceCreation_withArguments() async {
     await resolveTestCode('''
 C<int> f() {
@@ -282,6 +300,16 @@ Set f() {
     await resolveTestCode('''
 Set f() {
   ^Set s = {};
+  return s;
+}
+''');
+    await assertNoAssist();
+  }
+
+  Future<void> test_generic_setLiteral_ambiguous_cascade() async {
+    await resolveTestCode('''
+Set f() {
+  ^Set s = {}..addAll([]);
   return s;
 }
 ''');

--- a/pkg/analysis_server/test/src/services/correction/fix/remove_type_annotation_test.dart
+++ b/pkg/analysis_server/test/src/services/correction/fix/remove_type_annotation_test.dart
@@ -467,6 +467,24 @@ Set f() {
   }
 
   Future<void>
+  test_generic_instanceCreation_cascade_dotShorthandTarget() async {
+    await resolveTestCode('''
+C<int> f() {
+  C<int> c = .new()..toString();
+  return c;
+}
+class C<T> {}
+''');
+    await assertHasFix('''
+C<int> f() {
+  var c = C<int>.new()..toString();
+  return c;
+}
+class C<T> {}
+''');
+  }
+
+  Future<void>
   test_generic_instanceCreation_withoutArguments_dotShorthand() async {
     await resolveTestCode('''
 C<int> f() {

--- a/pkg/analysis_server/test/src/services/correction/fix/replace_with_var_test.dart
+++ b/pkg/analysis_server/test/src/services/correction/fix/replace_with_var_test.dart
@@ -295,6 +295,24 @@ Set f() {
 ''');
   }
 
+  Future<void>
+  test_generic_instanceCreation_cascade_dotShorthandTarget() async {
+    await resolveTestCode('''
+C<int> f() {
+  C<int> c = .new()..toString();
+  return c;
+}
+class C<T> {}
+''');
+    await assertHasFix('''
+C<int> f() {
+  var c = C<int>.new()..toString();
+  return c;
+}
+class C<T> {}
+''');
+  }
+
   Future<void> test_generic_instanceCreation_withArguments() async {
     await resolveTestCode('''
 C<int> f() {
@@ -457,6 +475,16 @@ Set f() {
     await resolveTestCode('''
 Set f() {
   Set s = {};
+  return s;
+}
+''');
+    await assertNoFix();
+  }
+
+  Future<void> test_generic_setLiteral_ambiguous_cascade() async {
+    await resolveTestCode('''
+Set f() {
+  Set s = {}..addAll([]);
   return s;
 }
 ''');


### PR DESCRIPTION
Dropping the declared type drops the context type that a dot shorthand
resolves against, so both producers write the type back in front of it.
Neither unwrapped the cascade first: `C<int> c = .new()..toString();`
became `var c = .new()..toString();`, which stopped resolving.

The set-or-map ambiguity guard had the same blind spot. Both producers still
fired on a plain `Set s = {}..addAll([]);`, and the result was a map whose
`addAll` call no longer compiled. I moved the unwrap ahead of the shorthand
check and the guard in `RemoveTypeAnnotation` and `ReplaceWithVar`. Now the
shorthand keeps its type, and the ambiguous literal just isn't offered
anymore.

Fixes https://github.com/dart-lang/sdk/issues/63911

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
