### PR TITLE
[analysis_server] Offer "create constructor" fix for non-final uninitialized fields

### DIFF
--- a/pkg/analysis_server/lib/src/services/correction/dart/create_constructor_for_final_fields.dart
+++ b/pkg/analysis_server/lib/src/services/correction/dart/create_constructor_for_final_fields.dart
@@ -60,13 +60,15 @@ class CreateConstructorForFinalFields extends ResolvedCorrectionProducer {
     _FixContext fixContext;
     switch (container) {
       case ClassDeclaration():
-        superType = container.declaredFragment?.element.supertype;
+        var classElement = container.declaredFragment?.element;
+        superType = classElement?.supertype;
         if (superType == null) {
           return;
         }
         fixContext = _FixContext(
           builder: builder,
           containerName: container.namePart.typeName.lexeme,
+          classElement: classElement,
           superType: superType,
           variableLists: container.body.members.interestingVariableLists,
         );
@@ -78,6 +80,7 @@ class CreateConstructorForFinalFields extends ResolvedCorrectionProducer {
         fixContext = _FixContext(
           builder: builder,
           containerName: container.namePart.typeName.lexeme,
+          classElement: null,
           superType: superType,
           variableLists: container.body.members.interestingVariableLists,
         );
@@ -518,12 +521,19 @@ class _Field {
 class _FixContext {
   final ChangeBuilder builder;
   final String containerName;
+
+  /// The element of the class being fixed, or `null` if it's an enum.
+  ///
+  /// Enum instance fields must always be final, so [canBeConst] doesn't need
+  /// this to determine whether an enum's generated constructor can be const.
+  final ClassElement? classElement;
   final InterfaceType superType;
   final Iterable<VariableDeclarationList> variableLists;
 
   new({
     required this.builder,
     required this.containerName,
+    required this.classElement,
     required this.superType,
     required this.variableLists,
   });
@@ -539,9 +549,14 @@ class _FixContext {
   }
 
   /// Whether a generated constructor initializing [variableLists] can be
-  /// `const`. A `const` constructor requires every instance field to be
-  /// final, so this is false as soon as a non-final field is included.
-  bool get canBeConst => variableLists.every((e) => e.isFinal);
+  /// `const`. A `const` constructor requires every instance field, own or
+  /// inherited, to be final.
+  bool get canBeConst {
+    var classElement = this.classElement;
+    return classElement != null
+        ? !classElement.hasNonFinalField
+        : variableLists.every((e) => e.isFinal);
+  }
 }
 
 enum _Style {

--- a/pkg/analysis_server/lib/src/services/correction/dart/create_constructor_for_final_fields.dart
+++ b/pkg/analysis_server/lib/src/services/correction/dart/create_constructor_for_final_fields.dart
@@ -113,6 +113,11 @@ class CreateConstructorForFinalFields extends ResolvedCorrectionProducer {
       var type = variableList.type?.type;
       var hasNonNullableType =
           type != null && typeSystem.isPotentiallyNonNullable(type);
+      // A nullable non-final field without an initializer is already valid
+      // Dart (it defaults to `null`); don't force it into the constructor.
+      if (!variableList.isFinal && !hasNonNullableType) {
+        continue;
+      }
 
       for (var field in variableList.variables) {
         var typeAnnotation = variableList.type;
@@ -175,7 +180,9 @@ class CreateConstructorForFinalFields extends ResolvedCorrectionProducer {
       builder.insertConstructor(classDeclaration, (builder) {
         // TODO(srawlins): Replace this block with `writeConstructorDeclaration`
         // and `parameterWriter`.
-        builder.write('const ');
+        if (fixContext.canBeConst) {
+          builder.write('const ');
+        }
         if (isEnabled(Feature.primary_constructors)) {
           builder.write('new');
         } else {
@@ -229,7 +236,9 @@ class CreateConstructorForFinalFields extends ResolvedCorrectionProducer {
       builder.insertConstructor(classDeclaration, (builder) {
         // TODO(srawlins): Replace this block with `writeConstructorDeclaration`
         // and `parameterWriter`.
-        builder.write('const ');
+        if (fixContext.canBeConst) {
+          builder.write('const ');
+        }
         if (isEnabled(Feature.primary_constructors)) {
           builder.write('new');
         } else {
@@ -528,6 +537,11 @@ class _FixContext {
     }
     return null;
   }
+
+  /// Whether a generated constructor initializing [variableLists] can be
+  /// `const`. A `const` constructor requires every instance field to be
+  /// final, so this is false as soon as a non-final field is included.
+  bool get canBeConst => variableLists.every((e) => e.isFinal);
 }
 
 enum _Style {
@@ -544,7 +558,13 @@ enum _Style {
 extension on List<ClassMember> {
   Iterable<VariableDeclarationList> get interestingVariableLists =>
       whereType<FieldDeclaration>()
+          .where(
+            (e) =>
+                !e.isStatic &&
+                e.abstractKeyword == null &&
+                e.externalKeyword == null,
+          )
           .map((e) => e.fields)
-          .where((e) => e.isFinal && !e.isLate)
+          .where((e) => !e.isLate)
           .toList();
 }

--- a/pkg/analysis_server/lib/src/services/correction/fix_internal.dart
+++ b/pkg/analysis_server/lib/src/services/correction/fix_internal.dart
@@ -737,6 +737,8 @@ final _builtInNonLintGenerators = <DiagnosticCode, List<ProducerGenerator>>{
   diag.notAType: [ChangeTo.classOrMixin],
   diag.notInitializedNonNullableInstanceField: [
     AddLate.new,
+    CreateConstructorForFinalFields.requiredNamed,
+    CreateConstructorForFinalFields.requiredPositional,
     MakeVariableNullable.new,
   ],
   diag.notInitializedNonNullableVariable: [

--- a/pkg/analysis_server/test/src/services/correction/fix/create_constructor_for_final_fields_test.dart
+++ b/pkg/analysis_server/test/src/services/correction/fix/create_constructor_for_final_fields_test.dart
@@ -227,6 +227,39 @@ class Test extends StatelessWidget {
     );
   }
 
+  Future<void> test_class_flutter_inheritedNonFinal() async {
+    writeTestPackageConfig(flutter: true);
+    await resolveTestCode('''
+import 'package:flutter/widgets.dart';
+
+mixin M {
+  int counter = 0;
+}
+
+class Test extends StatelessWidget with M {
+  final int a;
+}
+''');
+    await assertHasFix(
+      '''
+import 'package:flutter/widgets.dart';
+
+mixin M {
+  int counter = 0;
+}
+
+class Test extends StatelessWidget with M {
+  final int a;
+
+  new({super.key, required this.a});
+}
+''',
+      filter: (error) {
+        return error.message.contains("'a' must be initialized");
+      },
+    );
+  }
+
   Future<void> test_class_nonFinal_mixedWithFinal() async {
     await resolveTestCode('''
 class Test {

--- a/pkg/analysis_server/test/src/services/correction/fix/create_constructor_for_final_fields_test.dart
+++ b/pkg/analysis_server/test/src/services/correction/fix/create_constructor_for_final_fields_test.dart
@@ -185,6 +185,30 @@ class Test {
     );
   }
 
+  Future<void>
+  test_class_nonFinal_hasPrivate_unsupportedPrivateNamedParameters() async {
+    await resolveTestCode('''
+// @dart=3.11
+class Test {
+  int _a;
+}
+''');
+    await assertHasFix(
+      '''
+// @dart=3.11
+class Test {
+  int _a;
+
+  Test({required int a}) : _a = a;
+}
+''',
+      filter: (error) {
+        return error.diagnosticCode ==
+            diag.notInitializedNonNullableInstanceField;
+      },
+    );
+  }
+
   Future<void> test_class_nonFinal_nullableNotTouched() async {
     await resolveTestCode('''
 class Test {

--- a/pkg/analysis_server/test/src/services/correction/fix/create_constructor_for_final_fields_test.dart
+++ b/pkg/analysis_server/test/src/services/correction/fix/create_constructor_for_final_fields_test.dart
@@ -132,6 +132,123 @@ class Test extends Base {
 ''');
   }
 
+  Future<void> test_class_nonFinal_single() async {
+    await resolveTestCode('''
+class Test {
+  int a;
+}
+''');
+    await assertHasFix('''
+class Test {
+  int a;
+
+  new({required this.a});
+}
+''');
+  }
+
+  Future<void> test_class_nonFinal_excludesLate() async {
+    await resolveTestCode('''
+class Test {
+  int a;
+  late int b;
+}
+''');
+    await assertHasFix('''
+class Test {
+  int a;
+  late int b;
+
+  new({required this.a});
+}
+''');
+  }
+
+  Future<void> test_class_nonFinal_hasPrivate() async {
+    await resolveTestCode('''
+class Test {
+  int _a;
+}
+''');
+    await assertHasFix(
+      '''
+class Test {
+  int _a;
+
+  new({required this._a});
+}
+''',
+      filter: (error) {
+        return error.diagnosticCode ==
+            diag.notInitializedNonNullableInstanceField;
+      },
+    );
+  }
+
+  Future<void> test_class_nonFinal_nullableNotTouched() async {
+    await resolveTestCode('''
+class Test {
+  int a;
+  int? b;
+}
+''');
+    await assertHasFix('''
+class Test {
+  int a;
+  int? b;
+
+  new({required this.a});
+}
+''');
+  }
+
+  Future<void> test_class_flutter_nonFinal() async {
+    writeTestPackageConfig(flutter: true);
+    await resolveTestCode('''
+import 'package:flutter/widgets.dart';
+
+class Test extends StatelessWidget {
+  int a;
+}
+''');
+    await assertHasFix(
+      '''
+import 'package:flutter/widgets.dart';
+
+class Test extends StatelessWidget {
+  int a;
+
+  new({super.key, required this.a});
+}
+''',
+      filter: (error) {
+        return error.message.contains("'a' must be initialized");
+      },
+    );
+  }
+
+  Future<void> test_class_nonFinal_mixedWithFinal() async {
+    await resolveTestCode('''
+class Test {
+  final int a;
+  int b;
+}
+''');
+    await assertHasFix(
+      '''
+class Test {
+  final int a;
+  int b;
+
+  new({required this.a, required this.b});
+}
+''',
+      filter: (error) {
+        return error.message.contains("'b'");
+      },
+    );
+  }
+
   Future<void> test_class_hasSuperClass_withOptionalNamed() async {
     await resolveTestCode('''
 class A {
@@ -543,6 +660,28 @@ class Test {
 ''',
       filter: (error) {
         return error.message.contains("'a'");
+      },
+    );
+  }
+
+  Future<void> test_class_nonFinal_mixedWithFinal() async {
+    await resolveTestCode('''
+class Test {
+  final int a;
+  int b;
+}
+''');
+    await assertHasFix(
+      '''
+class Test {
+  final int a;
+  int b;
+
+  new(this.a, this.b);
+}
+''',
+      filter: (error) {
+        return error.message.contains("'b'");
       },
     );
   }


### PR DESCRIPTION
Fixes #47389

If you write `int a;` with no initializer, analyzer only offers to fix it with "Add late". But if you write `final int a;` instead, you also get a "create a constructor for me" quick-fix — that option just never got extended to non-final fields, even though nothing about the underlying logic actually required `final`.

This reuses the same constructor-generating producer for the non-final case. As a bonus, it also handles classes that mix final and non-final uninitialized fields in one shot — previously you'd only get a fix that covered the final ones.

Two things needed guarding since non-final fields behave differently from final ones:
- A nullable non-final field (`int? b;`) is already valid Dart without a constructor, so those are left alone.
- Flutter widget constructors are generated as `const`, but `const` requires every field to be final — that gets dropped automatically when a non-final field is involved.

## Test plan
- Added 7 new test cases to `create_constructor_for_final_fields_test.dart` covering: a single non-final field, mixed final/non-final fields, private fields, late-field exclusion, nullable-non-final fields being left untouched, and the Flutter widget case (confirming `const` is correctly dropped).
- Full `pkg/analysis_server/test/src/services/correction/fix/` suite (4762 tests) passes with no regressions.
- `dart format` / `dart analyze` clean.