### PR TITLE
[vm] Forward correct initial values for non-input closure fields in load forwarding

### DIFF
--- a/runtime/tests/vm/dart/regress_64035_test.dart
+++ b/runtime/tests/vm/dart/regress_64035_test.dart
@@ -1,0 +1,27 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+//
+// Regression test for https://github.com/dart-lang/sdk/issues/64035.
+//
+// Closure allocation initializes the closure's hash field to Smi 0, not
+// null, and _Closure.get:hashCode relies on that to detect a not yet
+// computed hash code. Load forwarding used to replace a load of the hash
+// field of a freshly allocated closure with null, making an inlined
+// hashCode return null out of a non-nullable int getter.
+//
+// VMOptions=--optimization-counter-threshold=100 --deterministic
+
+import 'package:expect/expect.dart';
+
+@pragma('vm:never-inline')
+int hashOf() {
+  final c = () {};
+  return c.hashCode;
+}
+
+void main() {
+  for (var i = 0; i < 10000; i++) {
+    Expect.type<int>(hashOf());
+  }
+}

--- a/runtime/vm/compiler/backend/il.cc
+++ b/runtime/vm/compiler/backend/il.cc
@@ -976,16 +976,6 @@ Definition* AllocateClosureInstr::Canonicalize(FlowGraph* flow_graph) {
 
 Definition* AllocateClosureInstr::InitialValueForSlot(FlowGraph* graph,
                                                       const Slot& slot) {
-  // Closure allocation initializes some fields of the new closure to
-  // non-null values (see Closure::New and
-  // StubCodeCompiler::GenerateAllocateClosureStub): the hash field is set
-  // to Smi 0 (meaning "hash not computed yet"), the length_and_flags field
-  // is set to the encoded length and flags, and the delayed type arguments
-  // element, if present, is set to the empty type arguments vector.
-  // Forwarding null for these fields would be unsound: for instance, it
-  // would make an inlined _Closure.get:hashCode return null out of a
-  // non-nullable int getter, as the getter compares the hash field against
-  // Smi 0 to detect a not-yet-computed hash code.
   if (slot.IsIdentical(Slot::Closure_hash())) {
     return graph->GetConstant(Object::smi_zero());
   }
@@ -993,9 +983,7 @@ Definition* AllocateClosureInstr::InitialValueForSlot(FlowGraph* graph,
     return graph->GetConstant(
         Smi::ZoneHandle(graph->zone(), Smi::New(EncodedLengthAndFlags())));
   }
-  if (UntaggedClosure::HasDelayedTypeArgumentsBit::decode(
-          EncodedLengthAndFlags()) &&
-      (slot.kind() == Slot::Kind::kClosureElement) &&
+  if (has_delayed_type_args_ && (slot.kind() == Slot::Kind::kClosureElement) &&
       (slot.offset_in_bytes() ==
        compiler::target::Closure::element_offset(
            UntaggedClosure::kDelayedTypeArgumentsIndex))) {

--- a/runtime/vm/compiler/backend/il.cc
+++ b/runtime/vm/compiler/backend/il.cc
@@ -951,9 +951,57 @@ Definition* AllocateContextInstr::Canonicalize(FlowGraph* flow_graph) {
   return nullptr;
 }
 
+Definition* AllocationInstr::InitialValueForSlot(FlowGraph* graph,
+                                                 const Slot& slot) {
+  for (intptr_t i = 0; i < InputCount(); i++) {
+    auto* const input_slot = SlotForInput(i);
+    if ((input_slot != nullptr) && input_slot->IsIdentical(slot)) {
+      return InputAt(i)->definition();
+    }
+  }
+  // Fields that do not contain tagged values should not have a tagged null
+  // value forwarded for them, similar to payloads of typed data arrays.
+  if (!slot.is_tagged()) {
+    return nullptr;
+  }
+  // Fields that are not provided as an input to the instruction are
+  // initialized to null during allocation.
+  return graph->constant_null();
+}
+
 Definition* AllocateClosureInstr::Canonicalize(FlowGraph* flow_graph) {
   if (!HasUses()) return nullptr;
   return this;
+}
+
+Definition* AllocateClosureInstr::InitialValueForSlot(FlowGraph* graph,
+                                                      const Slot& slot) {
+  // Closure allocation initializes some fields of the new closure to
+  // non-null values (see Closure::New and
+  // StubCodeCompiler::GenerateAllocateClosureStub): the hash field is set
+  // to Smi 0 (meaning "hash not computed yet"), the length_and_flags field
+  // is set to the encoded length and flags, and the delayed type arguments
+  // element, if present, is set to the empty type arguments vector.
+  // Forwarding null for these fields would be unsound: for instance, it
+  // would make an inlined _Closure.get:hashCode return null out of a
+  // non-nullable int getter, as the getter compares the hash field against
+  // Smi 0 to detect a not-yet-computed hash code.
+  if (slot.IsIdentical(Slot::Closure_hash())) {
+    return graph->GetConstant(Object::smi_zero());
+  }
+  if (slot.IsIdentical(Slot::Closure_length_and_flags())) {
+    return graph->GetConstant(
+        Smi::ZoneHandle(graph->zone(), Smi::New(EncodedLengthAndFlags())));
+  }
+  if (UntaggedClosure::HasDelayedTypeArgumentsBit::decode(
+          EncodedLengthAndFlags()) &&
+      (slot.kind() == Slot::Kind::kClosureElement) &&
+      (slot.offset_in_bytes() ==
+       compiler::target::Closure::element_offset(
+           UntaggedClosure::kDelayedTypeArgumentsIndex))) {
+    return graph->GetConstant(Object::empty_type_arguments());
+  }
+  return TemplateAllocation::InitialValueForSlot(graph, slot);
 }
 
 LocationSummary* AllocateClosureInstr::MakeLocationSummary(Zone* zone,

--- a/runtime/vm/compiler/backend/il.h
+++ b/runtime/vm/compiler/backend/il.h
@@ -7453,10 +7453,8 @@ class AllocationInstr : public Definition {
   virtual const Slot* SlotForInput(intptr_t pos) { return nullptr; }
 
   // Returns a definition carrying the initial value of the field
-  // corresponding to the given slot in the allocated object. Returns the
-  // input definition if the field is provided as an input to this
-  // instruction, and null if the initial value is not known or cannot be
-  // represented as a tagged constant.
+  // corresponding to the given slot in the allocated object and
+  // nullptr if such definition can't be computed.
   virtual Definition* InitialValueForSlot(FlowGraph* graph, const Slot& slot);
 
   // Returns whether the allocated object has initialized fields and/or payload

--- a/runtime/vm/compiler/backend/il.h
+++ b/runtime/vm/compiler/backend/il.h
@@ -7452,17 +7452,12 @@ class AllocationInstr : public Definition {
   // or if the input is not stored in the object.
   virtual const Slot* SlotForInput(intptr_t pos) { return nullptr; }
 
-  // Returns the input index that has a corresponding slot which is identical to
-  // the given slot. Returns a negative index if no such input found.
-  intptr_t InputForSlot(const Slot& slot) {
-    for (intptr_t i = 0; i < InputCount(); i++) {
-      auto* const input_slot = SlotForInput(i);
-      if (input_slot != nullptr && input_slot->IsIdentical(slot)) {
-        return i;
-      }
-    }
-    return -1;
-  }
+  // Returns a definition carrying the initial value of the field
+  // corresponding to the given slot in the allocated object. Returns the
+  // input definition if the field is provided as an input to this
+  // instruction, and null if the initial value is not known or cannot be
+  // represented as a tagged constant.
+  virtual Definition* InitialValueForSlot(FlowGraph* graph, const Slot& slot);
 
   // Returns whether the allocated object has initialized fields and/or payload
   // elements. Override for any subclass that returns an uninitialized object.
@@ -7661,6 +7656,8 @@ class AllocateClosureInstr : public TemplateAllocation<2> {
         return TemplateAllocation::SlotForInput(pos);
     }
   }
+
+  virtual Definition* InitialValueForSlot(FlowGraph* graph, const Slot& slot);
 
   virtual Definition* Canonicalize(FlowGraph* flow_graph);
 

--- a/runtime/vm/compiler/backend/redundancy_elimination.cc
+++ b/runtime/vm/compiler/backend/redundancy_elimination.cc
@@ -1828,6 +1828,43 @@ bool DelayAllocations::IsOneTimeUse(BlockEntryInstr* use_block,
   return true;
 }
 
+// Returns a definition carrying the initial value of the field [slot] of
+// the object created by the allocation [alloc], assuming the field is not
+// provided as an input to the allocation instruction.
+//
+// Such fields are usually initialized to null, but closure allocation
+// (see Closure::New and StubCodeCompiler::GenerateAllocateClosureStub)
+// initializes some fields of the new closure to non-null values: the hash
+// field is set to Smi 0 (meaning "hash not computed yet"), the
+// length_and_flags field is set to the encoded length and flags, and the
+// delayed type arguments element, if present, is set to the empty type
+// arguments vector. Forwarding null for those fields is unsound: for
+// instance, it would make an inlined _Closure.get:hashCode return null out
+// of a non-nullable int getter, as the getter compares the hash field
+// against Smi 0 to detect a not-yet-computed hash code.
+static Definition* InitialValueOfNonInputField(FlowGraph* graph,
+                                               AllocationInstr* alloc,
+                                               const Slot& slot) {
+  if (auto* const alloc_closure = alloc->AsAllocateClosure()) {
+    if (slot.IsIdentical(Slot::Closure_hash())) {
+      return graph->GetConstant(Object::smi_zero());
+    }
+    if (slot.IsIdentical(Slot::Closure_length_and_flags())) {
+      return graph->GetConstant(Smi::ZoneHandle(
+          graph->zone(), Smi::New(alloc_closure->EncodedLengthAndFlags())));
+    }
+    if (UntaggedClosure::HasDelayedTypeArgumentsBit::decode(
+            alloc_closure->EncodedLengthAndFlags()) &&
+        (slot.kind() == Slot::Kind::kClosureElement) &&
+        (slot.offset_in_bytes() ==
+         compiler::target::Closure::element_offset(
+             UntaggedClosure::kDelayedTypeArgumentsIndex))) {
+      return graph->GetConstant(Object::empty_type_arguments());
+    }
+  }
+  return graph->constant_null();
+}
+
 class LoadOptimizer : public ValueObject {
  public:
   LoadOptimizer(FlowGraph* graph, AliasedSet* aliased_set)
@@ -2329,8 +2366,9 @@ class LoadOptimizer : public ValueObject {
                 continue;
               } else {
                 // Fields not provided as an input to the instruction are
-                // initialized to null during allocation.
-                forward_def = graph_->constant_null();
+                // initialized during allocation, usually (but not always)
+                // to null.
+                forward_def = InitialValueOfNonInputField(graph_, alloc, *slot);
               }
             }
 

--- a/runtime/vm/compiler/backend/redundancy_elimination.cc
+++ b/runtime/vm/compiler/backend/redundancy_elimination.cc
@@ -1828,43 +1828,6 @@ bool DelayAllocations::IsOneTimeUse(BlockEntryInstr* use_block,
   return true;
 }
 
-// Returns a definition carrying the initial value of the field [slot] of
-// the object created by the allocation [alloc], assuming the field is not
-// provided as an input to the allocation instruction.
-//
-// Such fields are usually initialized to null, but closure allocation
-// (see Closure::New and StubCodeCompiler::GenerateAllocateClosureStub)
-// initializes some fields of the new closure to non-null values: the hash
-// field is set to Smi 0 (meaning "hash not computed yet"), the
-// length_and_flags field is set to the encoded length and flags, and the
-// delayed type arguments element, if present, is set to the empty type
-// arguments vector. Forwarding null for those fields is unsound: for
-// instance, it would make an inlined _Closure.get:hashCode return null out
-// of a non-nullable int getter, as the getter compares the hash field
-// against Smi 0 to detect a not-yet-computed hash code.
-static Definition* InitialValueOfNonInputField(FlowGraph* graph,
-                                               AllocationInstr* alloc,
-                                               const Slot& slot) {
-  if (auto* const alloc_closure = alloc->AsAllocateClosure()) {
-    if (slot.IsIdentical(Slot::Closure_hash())) {
-      return graph->GetConstant(Object::smi_zero());
-    }
-    if (slot.IsIdentical(Slot::Closure_length_and_flags())) {
-      return graph->GetConstant(Smi::ZoneHandle(
-          graph->zone(), Smi::New(alloc_closure->EncodedLengthAndFlags())));
-    }
-    if (UntaggedClosure::HasDelayedTypeArgumentsBit::decode(
-            alloc_closure->EncodedLengthAndFlags()) &&
-        (slot.kind() == Slot::Kind::kClosureElement) &&
-        (slot.offset_in_bytes() ==
-         compiler::target::Closure::element_offset(
-             UntaggedClosure::kDelayedTypeArgumentsIndex))) {
-      return graph->GetConstant(Object::empty_type_arguments());
-    }
-  }
-  return graph->constant_null();
-}
-
 class LoadOptimizer : public ValueObject {
  public:
   LoadOptimizer(FlowGraph* graph, AliasedSet* aliased_set)
@@ -2356,19 +2319,13 @@ class LoadOptimizer : public ValueObject {
                 continue;
               }
 
-              const intptr_t pos = alloc->InputForSlot(*slot);
-              if (pos != -1) {
-                forward_def = alloc->InputAt(pos)->definition();
-              } else if (!slot->is_tagged()) {
-                // Fields that do not contain tagged values should not
-                // have a tagged null value forwarded for them, similar to
-                // payloads of typed data arrays.
-                continue;
+              if (auto* const value =
+                      alloc->InitialValueForSlot(graph_, *slot)) {
+                forward_def = value;
               } else {
-                // Fields not provided as an input to the instruction are
-                // initialized during allocation, usually (but not always)
-                // to null.
-                forward_def = InitialValueOfNonInputField(graph_, alloc, *slot);
+                // The initial value of the field is not known or cannot be
+                // represented as a tagged constant.
+                continue;
               }
             }
 


### PR DESCRIPTION
Fixes https://github.com/dart-lang/sdk/issues/64035

Load forwarding replaced loads of allocation fields that are not inputs of the allocation instruction with `constant_null()`. For `AllocateClosure` three such fields are initialized to non-null values: `hash` (Smi 0), `length_and_flags` (an encoded constant), and the delayed type arguments element (the empty `TypeArguments` vector). Forwarding null for the `hash` field makes an inlined `_Closure.get:hashCode` return null out of a non-nullable `int` getter; see the issue for the full analysis.

The fix forwards the actual initial values for these fields.

Testing (linux x64):
- `runtime/tests/vm/dart/regress_64035_test.dart` fails at HEAD and passes with this change in JIT (ReleaseX64 and DebugX64). In AOT (dartkp) the bug does not manifest; the test passes before and after.
- `language/closure*` and `vm/dart` suites: no new failures.
