### PR TITLE
Fix incorrect example in future_sync_value

### DIFF
--- a/pkg/linter/messages.yaml
+++ b/pkg/linter/messages.yaml
@@ -5821,7 +5821,7 @@ LinterLintCode:
 
       **GOOD:**
       ```dart
-      Future<int> f() => Future.value(1);
+      Future<int> f() => Future.syncValue(1);
       ```
   hashAndEquals:
     type: lint


### PR DESCRIPTION
Updates the example in the `future_sync_value` lint to use the expected `Future.syncValue` instead of `Future.value`.

Fixes https://github.com/dart-lang/site-www/issues/7446

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
