### PR TITLE
[analysis_server] Infer nullable type in 'Add type annotation' when assignment isn't unconditional

### DIFF
--- a/pkg/analysis_server/lib/src/services/correction/dart/add_type_annotation.dart
+++ b/pkg/analysis_server/lib/src/services/correction/dart/add_type_annotation.dart
@@ -9,8 +9,10 @@ import 'package:analysis_server_plugin/edit/dart/correction_producer.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:analyzer/dart/element/type_system.dart';
+import 'package:analyzer/src/dart/element/type.dart';
 import 'package:analyzer/src/utilities/extensions/ast.dart';
 import 'package:analyzer_plugin/utilities/assist/assist.dart';
 import 'package:analyzer_plugin/utilities/change_builder/change_builder_core.dart';
@@ -242,11 +244,82 @@ class AddTypeAnnotation extends ResolvedCorrectionProducer {
     }
     var statements = block.statements;
     var index = statements.indexOf(statement);
+    var laterStatements = statements.sublist(index + 1);
     var visitor = _AssignedTypeCollector(typeSystem, element);
-    for (var i = index + 1; i < statements.length; i++) {
-      statements[i].accept(visitor);
+    for (var laterStatement in laterStatements) {
+      laterStatement.accept(visitor);
     }
-    return visitor.bestType;
+    var type = visitor.bestType;
+    if (type == null) {
+      return null;
+    }
+    // If none of the later statements is guaranteed to assign a value to
+    // the variable (for example, because the only assignment is inside the
+    // body of a loop, a single-branch `if`, or a `try` block), then the
+    // variable might still hold its implicit initial value, `null`, so the
+    // inferred type needs to be nullable.
+    if (!laterStatements.any((s) => _isDefinitelyAssigned(s, element))) {
+      type = (type as TypeImpl).withNullability(NullabilitySuffix.question);
+    }
+    return type;
+  }
+
+  /// Returns whether executing [statement] to normal completion is
+  /// guaranteed to assign a value to [variable].
+  static bool _isDefinitelyAssigned(
+    Statement statement,
+    LocalVariableElement variable,
+  ) {
+    switch (statement) {
+      case ExpressionStatement(:var expression):
+        return switch (expression) {
+          AssignmentExpression(leftHandSide: SimpleIdentifier(:var element)) =>
+            element == variable,
+          _ => _isDefinitelyAssignedByImmediateInvocation(expression, variable),
+        };
+      case Block(:var statements):
+        return statements.any((s) => _isDefinitelyAssigned(s, variable));
+      case IfStatement(:var thenStatement, :var elseStatement):
+        return elseStatement != null &&
+            _isDefinitelyAssigned(thenStatement, variable) &&
+            _isDefinitelyAssigned(elseStatement, variable);
+      case TryStatement(:var finallyBlock):
+        // A `finally` block runs no matter how the `try` statement
+        // completes (including via an exception), so if it definitely
+        // assigns the variable, so does the whole `try` statement.
+        return finallyBlock != null &&
+            _isDefinitelyAssigned(finallyBlock, variable);
+      case DoStatement(:var body):
+        // The body of a `do`-`while` loop always runs at least once.
+        return _isDefinitelyAssigned(body, variable);
+      case LabeledStatement(:var statement):
+        return _isDefinitelyAssigned(statement, variable);
+      default:
+        return false;
+    }
+  }
+
+  /// Returns whether [expression] is the invocation of a synchronous,
+  /// non-generator closure literal that's called immediately (an IIFE), and
+  /// whose body is guaranteed to assign a value to [variable]. Such an
+  /// invocation runs the closure body to completion as part of evaluating
+  /// [expression].
+  static bool _isDefinitelyAssignedByImmediateInvocation(
+    Expression expression,
+    LocalVariableElement variable,
+  ) {
+    if (expression is! FunctionExpressionInvocation) {
+      return false;
+    }
+    var function = expression.function;
+    if (function is! FunctionExpression) {
+      return false;
+    }
+    var body = function.body;
+    if (body is! BlockFunctionBody || !body.isSynchronous || body.isGenerator) {
+      return false;
+    }
+    return _isDefinitelyAssigned(body.block, variable);
   }
 }
 

--- a/pkg/analysis_server/lib/src/services/correction/dart/add_type_annotation.dart
+++ b/pkg/analysis_server/lib/src/services/correction/dart/add_type_annotation.dart
@@ -266,6 +266,14 @@ class AddTypeAnnotation extends ResolvedCorrectionProducer {
 
   /// Returns whether executing [statement] to normal completion is
   /// guaranteed to assign a value to [variable].
+  ///
+  /// This is a heuristic, not a full definite-assignment analysis: in
+  /// particular, the [Block] case doesn't account for a preceding statement
+  /// exiting the block early (for example via `break`, `continue`, `return`,
+  /// or a thrown exception) before an assigning statement is reached. Such a
+  /// case can cause this method to incorrectly report that a variable is
+  /// definitely assigned, which in turn can cause the computed type to be
+  /// non-nullable when it should be nullable.
   static bool _isDefinitelyAssigned(
     Statement statement,
     LocalVariableElement variable,

--- a/pkg/analysis_server/test/src/services/correction/fix/add_type_annotation_test.dart
+++ b/pkg/analysis_server/test/src/services/correction/fix/add_type_annotation_test.dart
@@ -452,6 +452,152 @@ void f() {
 }
 ''');
   }
+
+  Future<void> test_local_assignedInDoWhileLoopBody() async {
+    // The body of a `do`-`while` loop always runs at least once, so the
+    // assignment is unconditional.
+    await resolveTestCode('''
+int f() {
+  var result;
+  do {
+    result = 0;
+  } while (false);
+  return result;
+}
+''');
+    await assertHasFix('''
+int f() {
+  int result;
+  do {
+    result = 0;
+  } while (false);
+  return result;
+}
+''');
+  }
+
+  Future<void> test_local_assignedInForEachLoopBody() async {
+    // The loop might run zero times, so `result` might still be `null`.
+    await resolveTestCode('''
+int? f() {
+  var result;
+  for (var i in [1, 2, 3]) {
+    result = i;
+  }
+  return result;
+}
+''');
+    await assertHasFix('''
+int? f() {
+  int? result;
+  for (var i in [1, 2, 3]) {
+    result = i;
+  }
+  return result;
+}
+''');
+  }
+
+  Future<void> test_local_assignedInIfWithoutElse() async {
+    // There's no `else` branch, so `result` might still be `null`.
+    await resolveTestCode('''
+int? f() {
+  var result;
+  if (1 == 1) {
+    result = 0;
+  }
+  return result;
+}
+''');
+    await assertHasFix('''
+int? f() {
+  int? result;
+  if (1 == 1) {
+    result = 0;
+  }
+  return result;
+}
+''');
+  }
+
+  Future<void> test_local_assignedInIfWithElse() async {
+    // Both branches assign, so the assignment is unconditional.
+    await resolveTestCode('''
+int f() {
+  var result;
+  if (1 == 1) {
+    result = 0;
+  } else {
+    result = 1;
+  }
+  return result;
+}
+''');
+    await assertHasFix('''
+int f() {
+  int result;
+  if (1 == 1) {
+    result = 0;
+  } else {
+    result = 1;
+  }
+  return result;
+}
+''');
+  }
+
+  Future<void> test_local_assignedInTryCatch() async {
+    // The `try` body might complete without throwing, so the `catch` block
+    // might never run, and `result` might still be `null`.
+    await resolveTestCode('''
+Object? f() {
+  var result;
+  try {
+    throw '';
+  } catch (e) {
+    result = e;
+  }
+  return result;
+}
+''');
+    await assertHasFix('''
+Object? f() {
+  Object? result;
+  try {
+    throw '';
+  } catch (e) {
+    result = e;
+  }
+  return result;
+}
+''');
+  }
+
+  Future<void> test_local_assignedInTryFinally() async {
+    // A `finally` block always runs, so the assignment is unconditional.
+    await resolveTestCode('''
+int f() {
+  var result;
+  try {
+    // Nothing.
+  } finally {
+    result = 0;
+  }
+  return result;
+}
+''');
+    await assertHasFix('''
+int f() {
+  int result;
+  try {
+    // Nothing.
+  } finally {
+    result = 0;
+  }
+  return result;
+}
+''');
+  }
 }
 
 @reflectiveTest

--- a/pkg/analysis_server/test/src/services/correction/fix/add_type_annotation_test.dart
+++ b/pkg/analysis_server/test/src/services/correction/fix/add_type_annotation_test.dart
@@ -498,28 +498,6 @@ int? f() {
 ''');
   }
 
-  Future<void> test_local_assignedInIfWithoutElse() async {
-    // There's no `else` branch, so `result` might still be `null`.
-    await resolveTestCode('''
-int? f() {
-  var result;
-  if (1 == 1) {
-    result = 0;
-  }
-  return result;
-}
-''');
-    await assertHasFix('''
-int? f() {
-  int? result;
-  if (1 == 1) {
-    result = 0;
-  }
-  return result;
-}
-''');
-  }
-
   Future<void> test_local_assignedInIfWithElse() async {
     // Both branches assign, so the assignment is unconditional.
     await resolveTestCode('''
@@ -540,6 +518,28 @@ int f() {
     result = 0;
   } else {
     result = 1;
+  }
+  return result;
+}
+''');
+  }
+
+  Future<void> test_local_assignedInIfWithoutElse() async {
+    // There's no `else` branch, so `result` might still be `null`.
+    await resolveTestCode('''
+int? f() {
+  var result;
+  if (1 == 1) {
+    result = 0;
+  }
+  return result;
+}
+''');
+    await assertHasFix('''
+int? f() {
+  int? result;
+  if (1 == 1) {
+    result = 0;
   }
   return result;
 }


### PR DESCRIPTION
## Summary

The `Add type annotation` fix/assist (triggered e.g. by `prefer_typing_uninitialized_variables`) infers an uninitialized variable's type from assignments found anywhere in the rest of the enclosing block, without regard to whether those assignments are guaranteed to run. For a variable only assigned inside a loop body, a single-branch `if`, or a `try` block, that code might not execute, so the variable could still hold its implicit initial value, `null`, at the point of use — but the fix inferred a non-nullable type anyway.

```dart
int? f() {
  var result;
  for (var i in [1, 2, 3]) {
    result = i;
  }
  return result; // fix incorrectly inferred `int`, should be `int?`
}
```

This adds a conservative check for whether at least one of the remaining statements is guaranteed to assign the variable — accounting for `if`/`else` (both branches), `try`/`finally`, `do`-`while` (body always runs once), labeled statements, and immediately-invoked closures — and makes the inferred type nullable when it isn't.

Fixes #64015

## Test plan
- [x] Added regression tests for the issue's for-each loop, single-branch `if`, and `try`/`catch` cases, plus counterexamples (`if`/`else`, `do`-`while`, `try`/`finally`) that must remain non-nullable
- [x] `pkg/analysis_server/test/src/services/correction/fix/add_type_annotation_test.dart` — 43/43 pass
- [x] `pkg/analysis_server/test/src/services/correction/assist/add_type_annotation_test.dart` — 75/75 pass
- [x] `pkg/analysis_server/test/src/services/correction/test_all.dart` (full correction suite) — 6385/6385 pass, no regressions
- [x] `dart format` / `dart analyze` clean on changed files