### PR TITLE
[vm/io] Reap exit-handler wakeup process

### DIFF
--- a/runtime/bin/process_linux.cc
+++ b/runtime/bin/process_linux.cc
@@ -164,15 +164,27 @@ class ExitCodeHandler {
 
     // Wake up the [ExitCodeHandler] thread which is blocked on `wait()` (see
     // [ExitCodeHandlerEntry]).
-    if (TEMP_FAILURE_RETRY(fork()) == 0) {
+    pid_t wakeup_pid = TEMP_FAILURE_RETRY(fork());
+    if (wakeup_pid == 0) {
       // Avoid calling any atexit callbacks to prevent deadlocks.
       _exit(0);
+    }
+    if (wakeup_pid < 0) {
+      FATAL("Failed to create exit-handler wakeup process: %d", errno);
     }
 
     monitor_->Notify();
 
     while (!terminate_done_) {
       monitor_->Wait(Monitor::kNoTimeout);
+    }
+
+    // The exit-handler thread normally reaps the wakeup process. If the thread
+    // observed running_ == false before entering wait(), reap it here instead.
+    int status = 0;
+    pid_t result = TEMP_FAILURE_RETRY(waitpid(wakeup_pid, &status, 0));
+    if (result < 0 && errno != ECHILD) {
+      FATAL("Failed to reap exit-handler wakeup process: %d", errno);
     }
   }
 

--- a/runtime/bin/process_macos.cc
+++ b/runtime/bin/process_macos.cc
@@ -165,14 +165,26 @@ class ExitCodeHandler {
     running_ = false;
 
     // Fork to wake up waitpid.
-    if (TEMP_FAILURE_RETRY(fork()) == 0) {
+    pid_t wakeup_pid = TEMP_FAILURE_RETRY(fork());
+    if (wakeup_pid == 0) {
       _Exit(0);
+    }
+    if (wakeup_pid < 0) {
+      FATAL("Failed to create exit-handler wakeup process: %d", errno);
     }
 
     monitor_->Notify();
 
     while (!terminate_done_) {
       monitor_->Wait(Monitor::kNoTimeout);
+    }
+
+    // The exit-handler thread normally reaps the wakeup process. If the thread
+    // observed running_ == false before entering wait(), reap it here instead.
+    int status = 0;
+    pid_t result = TEMP_FAILURE_RETRY(waitpid(wakeup_pid, &status, 0));
+    if (result < 0 && errno != ECHILD) {
+      FATAL("Failed to reap exit-handler wakeup process: %d", errno);
     }
   }
 

--- a/tests/standalone/io/process_exit_handler_zombie_test.dart
+++ b/tests/standalone/io/process_exit_handler_zombie_test.dart
@@ -1,0 +1,128 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import "dart:ffi";
+import "dart:io";
+
+const int _prSetChildSubreaper = 36;
+
+typedef _PrctlNative = Int32 Function(Int32, IntPtr, IntPtr, IntPtr, IntPtr);
+typedef _Prctl = int Function(int, int, int, int, int);
+
+Future<void> main() async {
+  if (!Platform.isLinux) {
+    return;
+  }
+
+  final prctl = DynamicLibrary.process().lookupFunction<_PrctlNative, _Prctl>(
+    "prctl",
+  );
+  if (prctl(_prSetChildSubreaper, 1, 0, 0, 0) != 0) {
+    throw StateError("Failed to become a child subreaper");
+  }
+
+  final tempDir = Directory.systemTemp.createTempSync(
+    "process-exit-handler-zombie-",
+  );
+  try {
+    final dart = _dartExecutable();
+    final packageDir = Directory.fromUri(tempDir.uri.resolve("package/"))
+      ..createSync();
+    final binDir = Directory.fromUri(packageDir.uri.resolve("bin/"))
+      ..createSync();
+    File.fromUri(packageDir.uri.resolve("pubspec.yaml")).writeAsStringSync("""
+name: exit_handler_test
+environment:
+  sdk: ^3.12.0
+executables:
+  exit_handler_test:
+""");
+    File.fromUri(binDir.uri.resolve("exit_handler_test.dart"))
+        .writeAsStringSync("void main() {}\n");
+
+    final pubCache = Directory.fromUri(tempDir.uri.resolve("pub-cache/"));
+    final environment = {
+      "CI": "true",
+      "DASH__SUPPRESS_ANALYTICS": "true",
+      "PUB_CACHE": pubCache.path,
+    };
+    final activation = await Process.run(dart, [
+      "pub",
+      "global",
+      "activate",
+      "--source",
+      "path",
+      packageDir.path,
+    ], environment: environment);
+    if (activation.exitCode != 0) {
+      throw StateError(
+        "Activation failed: ${activation.stdout}\n${activation.stderr}",
+      );
+    }
+
+    final process = await Process.start("nice", [
+      "-n",
+      "15",
+      dart,
+      "pub",
+      "global",
+      "run",
+      "exit_handler_test",
+    ], environment: environment);
+    final stdout = process.stdout.transform(systemEncoding.decoder).join();
+    final stderr = process.stderr.transform(systemEncoding.decoder).join();
+    if (await process.exitCode != 0) {
+      throw StateError("Dart child failed: ${await stdout}\n${await stderr}");
+    }
+    await stdout;
+    await stderr;
+
+    for (var attempt = 0; attempt < 100; attempt++) {
+      final zombies = _zombieChildren();
+      if (zombies.isNotEmpty) {
+        throw StateError("Found zombie children: $zombies");
+      }
+      await Future<void>.delayed(const Duration(milliseconds: 1));
+    }
+  } finally {
+    tempDir.deleteSync(recursive: true);
+  }
+}
+
+String _dartExecutable() {
+  final executable = File(Platform.resolvedExecutable);
+  final sdkDart = File.fromUri(
+    executable.parent.uri.resolve("dart-sdk/bin/dart"),
+  );
+  return sdkDart.existsSync() ? sdkDart.path : executable.path;
+}
+
+List<int> _zombieChildren() {
+  final zombies = <int>[];
+
+  for (final entry in Directory("/proc").listSync()) {
+    final processId = int.tryParse(
+      entry.uri.pathSegments.lastWhere(
+        (segment) => segment.isNotEmpty,
+        orElse: () => "",
+      ),
+    );
+    if (processId == null) {
+      continue;
+    }
+
+    try {
+      final stat = File("/proc/$processId/stat").readAsStringSync();
+      final closeParen = stat.lastIndexOf(")");
+      final fields = stat.substring(closeParen + 2).split(" ");
+      if (fields[0] == "Z" && int.parse(fields[1]) == pid) {
+        zombies.add(processId);
+      }
+    } on FileSystemException {
+      // The process exited while /proc was being scanned.
+    }
+  }
+
+  return zombies;
+}


### PR DESCRIPTION
`ExitCodeHandler::TerminateExitCodeThread()` forks a short-lived child to
wake the exit-handler thread from `wait()`. If that thread observes
`running_ == false` before entering `wait()`, it exits without reaping the
wakeup child. In a container, that child can be adopted by a Dart process
running as PID 1 and remain as a zombie.

Retain the wakeup PID and call `waitpid()` after the exit-handler thread has
terminated. `ECHILD` is accepted because it means the handler thread already
reaped the process. Apply the equivalent change on Linux and macOS.

Add a Linux regression test that:

- makes the test process a child subreaper;
- invokes an activated executable through `dart pub global run`;
- verifies that no zombie child is adopted after the intermediate Dart VM
  exits.

Validation:

- Before the patch, the regression test reproduced the zombie on its first
  invocation using a source-built Dart 3.12.2 SDK.
- Before the patch, the container harness reproduced
  `dart:dartdev_aot <defunct>` under container PID 1.
- After the patch, the official standalone regression test passes.
- After the patch, the exact fatal-dartdoc container harness completed 30
  iterations without a zombie on Dart 3.12.2 and a source build from `main`.
- The focused standalone process suite passed 33 tests. The existing
  `process_child_test` could not create its process stream in the local
  restricted sandbox and failed independently of this change.

Fixes #61624.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
