### PR TITLE
Fix DartPad language server shutdown race

### DIFF
--- a/pkg/dartpad_worker/lib/src/tools/language_server.dart
+++ b/pkg/dartpad_worker/lib/src/tools/language_server.dart
@@ -65,8 +65,10 @@ class LanguageServer {
   }
 
   Future<void> close() async {
-    await _input.sink.close();
+    // Shutdown can still emit messages, so keep the channel open until it
+    // completes.
     await _server.shutdown();
+    await _input.sink.close();
     if (!_closed.isCompleted) {
       _closed.complete();
     }


### PR DESCRIPTION
This changes the DartPad language server shutdown order so the LSP communication channel remains open while the analysis server shuts down.

Closing the input first completes the channel's closed future and allows the output stream to close. The subsequent server shutdown may still emit analyzer notifications, causing Cannot add event after closing in the worker.

The server is now shut down before the input stream is closed.

Testing:
- Dart formatting completed with no changes.
- Rebuilt the DartPad worker and repeatedly disposed and recreated workspaces while language-server analysis was active; the worker error no longer occurred.

Fixes #64067

- [x] I've reviewed the contributor guide and applied the relevant portions to this PR.