### PR TITLE
fix unsigned readlink return in File::LinkTarget on macos

### DIFF
--- a/runtime/bin/file_macos.cc
+++ b/runtime/bin/file_macos.cc
@@ -624,7 +624,7 @@ const char* File::LinkTarget(Namespace* namespc,
   // target. The link might have changed before the readlink call.
   const int kBufferSize = 1024;
   char target[kBufferSize];
-  size_t target_size =
+  const ssize_t target_size =
       TEMP_FAILURE_RETRY(readlink(pathname, target, kBufferSize));
   if (target_size <= 0) {
     return nullptr;
@@ -633,7 +633,7 @@ const char* File::LinkTarget(Namespace* namespc,
     dest = DartUtils::ScopedCString(target_size + 1);
   } else {
     ASSERT(dest_size > 0);
-    if (static_cast<size_t>(dest_size) <= target_size) {
+    if (dest_size <= target_size) {
       return nullptr;
     }
   }


### PR DESCRIPTION
File::LinkTarget on macOS stored the readlink() result in a `size_t`, so the `target_size <= 0` check only rejected an empty read and let a -1 error return slip through as SIZE_MAX. If the symlink is removed or replaced between the lstat/S_ISLNK check and readlink (a race on a link reached through Link.target()), the following `ScopedCString(target_size + 1)` wraps to a zero-length allocation and memmove copies SIZE_MAX bytes. The Linux and Fuchsia versions store it in a signed type so their identical check catches the failure. This switches the macOS variable to `ssize_t` (readlink's actual return type) and drops the now-redundant `static_cast<size_t>` on the dest_size comparison.

This continues #63789: that PR was force-pushed while closed, which leaves it un-reopenable on GitHub, so this recreates the same change cleanly on top of current main.
