### PR TITLE
[dds] Apply the DevTools server Origin check to all api/* methods

### DIFF
--- a/pkg/dds/lib/src/devtools/handler.dart
+++ b/pkg/dds/lib/src/devtools/handler.dart
@@ -176,24 +176,28 @@ FutureOr<Handler> defaultHandler({
       return devtoolsAssetHandler(request);
     }
 
-    // Host header check for all api/* requests to prevent DNS rebinding.
     if (originCheckEnabled) {
+      // Host header check for all api/* requests to prevent DNS rebinding.
       final hostHeader = request.headers[HttpHeaders.hostHeader];
       if (hostHeader == null || !isAllowedHost(hostHeader)) {
         return Response.forbidden('forbidden host');
+      }
+
+      // Origin header check for all api/* requests to prevent CSRF. Browsers
+      // set Origin on cross-origin fetch/XHR/EventSource requests, so this
+      // rejects requests from a page the DevTools server never granted trust
+      // to, even though such a request's Host header legitimately matches
+      // this server (Host reflects the request's destination, not the page
+      // that issued it, so the check above does not protect against this).
+      final origin = request.headers['Origin'];
+      if (origin != null && !isAllowedOrigin(origin)) {
+        return Response.forbidden('forbidden origin');
       }
     }
 
     final method = request.url.pathSegments[1];
 
-    // Origin check specifically for api/sse to prevent CSRF.
     if (method == 'sse') {
-      if (originCheckEnabled) {
-        final origin = request.headers['Origin'];
-        if (origin != null && !isAllowedOrigin(origin)) {
-          return Response.forbidden('forbidden origin');
-        }
-      }
       return devToolsApiHandler.handler(request);
     }
 

--- a/pkg/dds/test/devtools_server/security_test.dart
+++ b/pkg/dds/test/devtools_server/security_test.dart
@@ -52,6 +52,22 @@ void main() {
         expect(response.statusCode, HttpStatus.forbidden);
         await response.drain();
       });
+
+      // Regression test: the Origin check used to be applied only to
+      // `/api/sse`. Every other `api/*` method (ping, and the ServerApi
+      // endpoints that perform side effects, such as the deeplink handlers
+      // that spawn a `flutter`/`xcodebuild` process for a caller-supplied
+      // path) relied solely on the Host header check, which does not stop a
+      // same-machine cross-origin request: Host reflects the request's
+      // destination, not the page that issued it, so it is always this
+      // server's own host/port regardless of who sent the request.
+      test('forbids GET request with bad Origin Header to /api/ping', () async {
+        final request = await client.getUrl(serverUri.resolve('api/ping'));
+        request.headers.set('Origin', 'http://evil.example.com');
+        final response = await request.close();
+        expect(response.statusCode, HttpStatus.forbidden);
+        await response.drain();
+      });
     });
 
     group('Disable Origin Check', () {
@@ -86,6 +102,14 @@ void main() {
 
       test('allows bad Origin Header to /api/sse', () async {
         final request = await client.getUrl(serverUri.resolve('api/sse'));
+        request.headers.set('Origin', 'http://evil.example.com');
+        final response = await request.close();
+        expect(response.statusCode, isNot(HttpStatus.forbidden));
+        await response.drain();
+      });
+
+      test('allows bad Origin Header to /api/ping', () async {
+        final request = await client.getUrl(serverUri.resolve('api/ping'));
         request.headers.set('Origin', 'http://evil.example.com');
         final response = await request.close();
         expect(response.statusCode, isNot(HttpStatus.forbidden));


### PR DESCRIPTION
`devtoolsHandler` in `pkg/dds/lib/src/devtools/handler.dart` only checks the Origin header for `/api/sse`. Every other `api/*` method, including `ping` and the `ServerApi`-dispatched endpoints (the deeplink handlers that spawn a `flutter`/`xcodebuild` process for a caller-supplied path, plus storage, preferences, and app size), relies on the Host header check alone.

The Host check does not stop a plain cross-origin request. Host reflects the request's destination, which is always this server's own host and port regardless of who sent the request. Origin is the header that reflects the caller, and it was only checked for `sse`:

```dart
final method = request.url.pathSegments[1];

// Origin check specifically for api/sse to prevent CSRF.
if (method == 'sse') {
  if (originCheckEnabled) {
    final origin = request.headers['Origin'];
    if (origin != null && !isAllowedOrigin(origin)) {
      return Response.forbidden('forbidden origin');
    }
  }
  return devToolsApiHandler.handler(request);
}
```

With the Origin check scoped to `sse` only, any webpage open in the same browser as a running devtools server can trigger the other endpoints with a background `fetch()`, no token or user interaction required.

This is reachable in the standalone `dart devtools` server (`DevToolsServer.serveDevTools`), which has no secret path segment guarding these routes. That protection is specific to DDS-embedded DevTools, gated behind `enableAuthCodes` (default `true`), and is unaffected by this change since its auth-code middleware runs before any of this code.

I verified this live with a local harness built against this source, `dds` as a path dependency and `devtools_shared` overridden to a local checkout. An unauthenticated cross-origin GET to `/api/androidBuildVariants` with an attacker Origin header reached `DeeplinkManager` and spawned the flutter binary with the caller-supplied `rootPath` before this change, and is rejected with 403 after it. A control request with a spoofed Host header, mimicking DNS rebinding, was correctly rejected in both cases, confirming the Host check itself was never the gap.

The fix moves the Origin check up next to the Host check so it runs for every `api/*` method:

```dart
if (originCheckEnabled) {
  final hostHeader = request.headers[HttpHeaders.hostHeader];
  if (hostHeader == null || !isAllowedHost(hostHeader)) {
    return Response.forbidden('forbidden host');
  }

  final origin = request.headers['Origin'];
  if (origin != null && !isAllowedOrigin(origin)) {
    return Response.forbidden('forbidden origin');
  }
}
```

Added a regression test on `/api/ping` in both groups of `security_test.dart`, alongside the existing Host/Origin coverage for `sse` from the prior "Harden Host and Origin checks across VM Service, DDS, DevTools, and DTD" change. That change touched this same file and added the sse-only check; this closes the api/* method class it did not extend the check to.

`dart analyze` and `dart format --set-exit-if-changed` are clean on both touched files.

---

- [x] I've reviewed the contributor guide and applied the relevant portions to this PR.
