### PR TITLE
Add a `WrappedPromiseError` type to `dart:js_interop`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@
   wrapping them. Only Dart errors are wrapped in a JS `Error`.
   For more details, see SDK issue [#61353][].
 
+- Added `WrappedPromiseError` to represent the error type produced by
+  `FutureOfJSAnyToJSPromise.toJS` and `FutureOfVoidToJSPromise.toJS` when they
+  wrap a Dart error.
+
 - Added extension methods `JSArray<JSNumber>.toDartDoubleList` and
   `JSArray<JSNumber>.toDartIntList` (`JSArrayOfJSNumberToList`);
   `List<num>.toJS` (`ListOfNumberToJSArray`);

--- a/sdk/lib/js_interop/js_interop.dart
+++ b/sdk/lib/js_interop/js_interop.dart
@@ -1326,11 +1326,7 @@ JSAny _convertError(Object error, StackTrace stackTrace) {
 extension FutureOfJSAnyToJSPromise<T extends JSAny?> on Future<T> {
   /// A [JSPromise] that either resolves with the result of the completed
   /// [Future] or rejects with its error if it is a JS value and otherwise
-  /// rejects with a JS `Error` that wraps its Dart error value.
-  ///
-  /// The rejected object contains the original error as a [JSBoxedDartObject]
-  /// in the property `error` and the original stack trace as a [String] in the
-  /// property `stack`.
+  /// rejects with a [WrappedPromiseerror] that wraps its Dart error value.
   JSPromise<T> get toJS {
     return JSPromise<T>(
       (JSFunction resolve, JSFunction reject) {
@@ -1354,11 +1350,8 @@ extension FutureOfJSAnyToJSPromise<T extends JSAny?> on Future<T> {
 /// a value.
 extension FutureOfVoidToJSPromise on Future<void> {
   /// A [JSPromise] that either resolves once this [Future] completes or rejects
-  /// with an object that contains its error.
-  ///
-  /// The rejected object contains the original error as a [JSBoxedDartObject]
-  /// in the property `error` and the original stack trace as a [String] in the
-  /// property `stack`.
+  /// with its error if it is a JS value and otherwise rejects with a
+  /// [WrappedPromiseerror] that wraps its Dart error value.
   JSPromise get toJS {
     return JSPromise(
       (JSFunction resolve, JSFunction reject) {
@@ -1373,6 +1366,38 @@ extension FutureOfVoidToJSPromise on Future<void> {
       }.toJS,
     );
   }
+}
+
+@JS('Object.getOwnPropertyNames')
+external JSArray<JSString> _getOwnPropertyNames(JSObject object);
+
+/// The type of error produced when [FutureOfJSAnyToJSPromise.toJS] or
+/// [FutureOfVoidToJSPromise.toJS] catches a Dart exception.
+@Since('3.14')
+extension type WrappedPromiseError._(JSObject _) implements JSObject {
+  /// The Dart error that was originally thrown.
+  external JSBoxedDartObject get error;
+
+  /// The Dart stack trace, serialized to a string.
+  external String get stack;
+
+  /// Returns whether [value] matches the expected structure of a
+  /// [WrappedPromiseError].
+  static bool isA(JSAny? value) {
+    if (!value.isA<JSObject>()) return false;
+    var object = value as JSObject;
+    return _getOwnPropertyNames(object).length == 3 &&
+        object.has('error') &&
+        object.has('message') &&
+        object['stack'].isA<JSString>();
+  }
+
+  /// If [value] matches the expected structure of a [WrappedPromiseError],
+  /// returns it, and returns null otherwise.
+  ///
+  /// This is intended for use with pattern matching.
+  static WrappedPromiseError? asA(JSAny? value) =>
+      isA(value) ? value as WrappedPromiseError : null;
 }
 
 /// Conversions from [JSArrayBuffer] to [ByteBuffer].

--- a/tests/lib/js/static_interop_test/js_types_test.dart
+++ b/tests/lib/js/static_interop_test/js_types_test.dart
@@ -1145,13 +1145,11 @@ Future<void> asyncTests() async {
       await Future<JSAny?>(() => throw Exception()).toJS.toDart;
       Expect.fail('Expected future to throw.');
     } catch (e) {
-      Expect.isTrue(e is JSObject);
-      final jsError = e as JSObject;
+      Expect.isTrue(WrappedPromiseError.isA(e as JSObject));
+      final jsError = WrappedPromiseError.asA(e)!;
       Expect.isTrue(jsError.instanceof(globalContext['Error'] as JSFunction));
-      Expect.isTrue(
-        (jsError['error'] as JSBoxedDartObject).toDart is Exception,
-      );
-      StackTrace.fromString((jsError['stack'] as JSString).toDart);
+      Expect.isTrue(jsError.error.toDart is Exception);
+      StackTrace.fromString(jsError.stack);
     }
     var error = await asyncExpectThrows<JSAny>(
       Future<JSAny?>(() => throw JSError('oh no')).toJS.toDart,
@@ -1215,13 +1213,11 @@ Future<void> asyncTests() async {
       await f;
       Expect.fail('Expected future to throw.');
     } catch (e) {
-      Expect.isTrue(e is JSObject);
-      final jsError = e as JSObject;
+      Expect.isTrue(WrappedPromiseError.isA(e as JSObject));
+      final jsError = WrappedPromiseError.asA(e)!;
       Expect.isTrue(jsError.instanceof(globalContext['Error'] as JSFunction));
-      Expect.isTrue(
-        (jsError['error'] as JSBoxedDartObject).toDart is Exception,
-      );
-      StackTrace.fromString((jsError['stack'] as JSString).toDart);
+      Expect.isTrue(jsError.error.toDart is Exception);
+      StackTrace.fromString(jsError.stack);
     }
     var error = await asyncExpectThrows<JSAny>(
       Future<void>(() => throw JSError('oh no')).toJS.toDart as Future<void>,


### PR DESCRIPTION
This exposes an explicit type for the object shape that's already used when a `Future` converted to a `Promise` emits an error.

See #63403

- Thanks for your contribution! Please replace this text with a description of what this PR is changing or adding and why, list any relevant issues, and review the contribution guidelines below.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.