### PR TITLE
[io] Make SecureSocket buffer size configurable

### DIFF
--- a/runtime/bin/secure_socket_filter.cc
+++ b/runtime/bin/secure_socket_filter.cc
@@ -40,10 +40,6 @@ void SSLFilter::Cleanup() {
   trust_evaluate_reply_port_ = ILLEGAL_PORT;
 }
 
-const intptr_t SSLFilter::kInternalBIOSize = 10 * KB;
-const intptr_t SSLFilter::kApproximateSize =
-    sizeof(SSLFilter) + (2 * SSLFilter::kInternalBIOSize);
-
 static SSLFilter* GetFilter(Dart_NativeArguments args) {
   SSLFilter* filter = nullptr;
   Dart_Handle dart_this = ThrowIfError(Dart_GetNativeArgument(args, 0));
@@ -73,23 +69,23 @@ static Dart_Handle SetFilter(Dart_NativeArguments args, SSLFilter* filter) {
       reinterpret_cast<intptr_t>(filter));
   RETURN_IF_ERROR(err);
   Dart_NewFinalizableHandle(dart_this, reinterpret_cast<void*>(filter),
-                            SSLFilter::kApproximateSize, DeleteFilter);
+                            filter->ApproximateSize(), DeleteFilter);
   return Dart_Null();
 }
 
 void FUNCTION_NAME(SecureSocket_Init)(Dart_NativeArguments args) {
   Dart_Handle dart_this = ThrowIfError(Dart_GetNativeArgument(args, 0));
   SSLFilter* filter = new SSLFilter();
-  Dart_Handle err = SetFilter(args, filter);
+  Dart_Handle err = filter->Init(dart_this);
   if (Dart_IsError(err)) {
+    filter->Destroy();
     filter->Release();
     Dart_PropagateError(err);
   }
-  err = filter->Init(dart_this);
+  err = SetFilter(args, filter);
   if (Dart_IsError(err)) {
-    // The finalizer was set up by SetFilter. It will delete `filter` if there
-    // is an error.
     filter->Destroy();
+    filter->Release();
     Dart_PropagateError(err);
   }
 }
@@ -363,23 +359,21 @@ Dart_Handle SSLFilter::InitializeBuffers(Dart_Handle dart_this) {
   RETURN_IF_ERROR(buffers_string);
   Dart_Handle dart_buffers_object = Dart_GetField(dart_this, buffers_string);
   RETURN_IF_ERROR(dart_buffers_object);
-  Dart_Handle secure_filter_impl_type = Dart_InstanceGetType(dart_this);
-  RETURN_IF_ERROR(secure_filter_impl_type);
-  Dart_Handle size_string = DartUtils::NewString("SIZE");
+  Dart_Handle size_string = DartUtils::NewString("bufferSize");
   RETURN_IF_ERROR(size_string);
-  Dart_Handle dart_buffer_size =
-      Dart_GetField(secure_filter_impl_type, size_string);
+  Dart_Handle dart_buffer_size = Dart_GetField(dart_this, size_string);
   RETURN_IF_ERROR(dart_buffer_size);
 
   int64_t buffer_size = 0;
   Dart_Handle err = Dart_IntegerToInt64(dart_buffer_size, &buffer_size);
   RETURN_IF_ERROR(err);
 
-  Dart_Handle encrypted_size_string = DartUtils::NewString("ENCRYPTED_SIZE");
+  Dart_Handle encrypted_size_string =
+      DartUtils::NewString("encryptedBufferSize");
   RETURN_IF_ERROR(encrypted_size_string);
 
   Dart_Handle dart_encrypted_buffer_size =
-      Dart_GetField(secure_filter_impl_type, encrypted_size_string);
+      Dart_GetField(dart_this, encrypted_size_string);
   RETURN_IF_ERROR(dart_encrypted_buffer_size);
 
   int64_t encrypted_buffer_size = 0;
@@ -389,7 +383,7 @@ Dart_Handle SSLFilter::InitializeBuffers(Dart_Handle dart_this) {
   if (buffer_size <= 0 || buffer_size > 1 * MB) {
     FATAL("Invalid buffer size in _ExternalBuffer");
   }
-  if (encrypted_buffer_size <= 0 || encrypted_buffer_size > 1 * MB) {
+  if (encrypted_buffer_size <= 0 || encrypted_buffer_size > 1 * MB + 2 * KB) {
     FATAL("Invalid encrypted buffer size in _ExternalBuffer");
   }
   buffer_size_ = static_cast<int>(buffer_size);
@@ -501,8 +495,8 @@ void SSLFilter::Connect(const char* hostname,
   int status;
   int error;
   BIO* ssl_side;
-  status = BIO_new_bio_pair(&ssl_side, kInternalBIOSize, &socket_side_,
-                            kInternalBIOSize);
+  status = BIO_new_bio_pair(&ssl_side, encrypted_buffer_size_, &socket_side_,
+                            encrypted_buffer_size_);
   SecureSocketUtils::CheckStatusSSL(status, "TlsException", "BIO_new_bio_pair",
                                     ssl_);
 

--- a/runtime/bin/secure_socket_filter.h
+++ b/runtime/bin/secure_socket_filter.h
@@ -53,7 +53,6 @@ class SSLFilter : public ReferenceCounted<SSLFilter> {
     kFirstEncrypted = kReadEncrypted
   };
 
-  static const intptr_t kApproximateSize;
   static constexpr int kSSLFilterNativeFieldIndex = 0;
 
   SSLFilter()
@@ -65,13 +64,21 @@ class SSLFilter : public ReferenceCounted<SSLFilter> {
         handshake_complete_(nullptr),
         bad_certificate_callback_(nullptr),
         in_handshake_(false),
-        hostname_(nullptr) {}
+        hostname_(nullptr) {
+    for (int i = 0; i < kNumBuffers; ++i) {
+      buffers_[i] = nullptr;
+      dart_buffer_objects_[i] = nullptr;
+    }
+  }
 
   ~SSLFilter();
 
   char* hostname() const { return hostname_; }
   bool is_server() const { return is_server_; }
   bool is_client() const { return !is_server_; }
+  intptr_t ApproximateSize() const {
+    return sizeof(SSLFilter) + (2 * encrypted_buffer_size_);
+  }
 
   Dart_Handle Init(Dart_Handle dart_this);
   void Connect(const char* hostname,
@@ -118,7 +125,6 @@ class SSLFilter : public ReferenceCounted<SSLFilter> {
   static Dart_Port TrustEvaluateReplyPort();
 
  private:
-  static const intptr_t kInternalBIOSize;
   static bool library_initialized_;
   static Mutex* mutex_;  // To protect library initialization.
   static Dart_Port trust_evaluate_reply_port_;

--- a/sdk/lib/_internal/js_dev_runtime/patch/io_patch.dart
+++ b/sdk/lib/_internal/js_dev_runtime/patch/io_patch.dart
@@ -667,7 +667,7 @@ class RawDatagramSocket {
 @patch
 class _SecureFilter {
   @patch
-  factory _SecureFilter._() {
+  factory _SecureFilter._(int bufferSize) {
     throw UnsupportedError("_SecureFilter._SecureFilter");
   }
 }

--- a/sdk/lib/_internal/js_runtime/lib/io_patch.dart
+++ b/sdk/lib/_internal/js_runtime/lib/io_patch.dart
@@ -663,7 +663,7 @@ class RawDatagramSocket {
 @patch
 class _SecureFilter {
   @patch
-  factory _SecureFilter._() {
+  factory _SecureFilter._(int bufferSize) {
     throw UnsupportedError("_SecureFilter._SecureFilter");
   }
 }

--- a/sdk/lib/_internal/vm/bin/secure_socket_patch.dart
+++ b/sdk/lib/_internal/vm/bin/secure_socket_patch.dart
@@ -13,7 +13,7 @@ class SecureSocket {
 @patch
 class _SecureFilter {
   @patch
-  factory _SecureFilter._() => _SecureFilterImpl._();
+  factory _SecureFilter._(int bufferSize) => _SecureFilterImpl._(bufferSize);
 }
 
 @patch
@@ -62,19 +62,24 @@ class _SecureSocket extends _Socket implements SecureSocket {
 @pragma("vm:entry-point")
 base class _SecureFilterImpl extends NativeFieldWrapperClass1
     implements _SecureFilter {
+  static const int _encryptedBufferOverhead = 2 * 1024;
+
   // Performance is improved if a full buffer of plaintext fits
   // in the encrypted buffer, when encrypted.
-  // SIZE and ENCRYPTED_SIZE are referenced from C++.
+  // bufferSize and encryptedBufferSize are referenced from C++.
   @pragma("vm:entry-point")
-  static final int SIZE = 8 * 1024;
+  final int bufferSize;
   @pragma("vm:entry-point")
-  static final int ENCRYPTED_SIZE = 10 * 1024;
+  final int encryptedBufferSize;
 
-  _SecureFilterImpl._() {
+  _SecureFilterImpl._(this.bufferSize)
+    : encryptedBufferSize = bufferSize + _encryptedBufferOverhead {
     buffers = <_ExternalBuffer>[
       for (int i = 0; i < _RawSecureSocket.bufferCount; ++i)
         _ExternalBuffer(
-          _RawSecureSocket._isBufferEncrypted(i) ? ENCRYPTED_SIZE : SIZE,
+          _RawSecureSocket._isBufferEncrypted(i)
+              ? encryptedBufferSize
+              : bufferSize,
         ),
     ];
   }
@@ -216,7 +221,11 @@ class SecurityContext {
 
 base class _SecurityContext extends NativeFieldWrapperClass1
     implements SecurityContext {
+  static const int _minSecureSocketBufferSize = 8 * 1024;
+  static const int _maxSecureSocketBufferSize = 1024 * 1024;
+
   bool _allowLegacyUnsafeRenegotiation = false;
+  int _secureSocketBufferSize = _minSecureSocketBufferSize;
 
   _SecurityContext(bool withTrustedRoots) {
     _createNativeContext();
@@ -224,6 +233,18 @@ base class _SecurityContext extends NativeFieldWrapperClass1
       _trustBuiltinRoots();
     }
   }
+
+  set secureSocketBufferSize(int size) {
+    RangeError.checkValueInInterval(
+      size,
+      _minSecureSocketBufferSize,
+      _maxSecureSocketBufferSize,
+      'secureSocketBufferSize',
+    );
+    _secureSocketBufferSize = size;
+  }
+
+  int get secureSocketBufferSize => _secureSocketBufferSize;
 
   set allowLegacyUnsafeRenegotiation(bool allow) {
     _allowLegacyUnsafeRenegotiation = allow;

--- a/sdk/lib/_internal/wasm/common/io_patch.dart
+++ b/sdk/lib/_internal/wasm/common/io_patch.dart
@@ -663,7 +663,7 @@ class RawDatagramSocket {
 @patch
 class _SecureFilter {
   @patch
-  factory _SecureFilter._() {
+  factory _SecureFilter._(int bufferSize) {
     throw UnsupportedError("_SecureFilter._SecureFilter");
   }
 }

--- a/sdk/lib/io/secure_socket.dart
+++ b/sdk/lib/io/secure_socket.dart
@@ -589,7 +589,7 @@ class _RawSecureSocket extends Stream<RawSocketEvent>
   bool _filterPending = false;
   bool _filterActive = false;
 
-  _SecureFilter? _secureFilter = _SecureFilter._();
+  _SecureFilter? _secureFilter;
   String? _selectedProtocol;
 
   static Future<_RawSecureSocket> connect(
@@ -654,7 +654,8 @@ class _RawSecureSocket extends Stream<RawSocketEvent>
       ..onCancel = _onSubscriptionStateChange;
     // Throw an ArgumentError if any field is invalid.  After this, all
     // errors will be reported through the future or the stream.
-    final secureFilter = _secureFilter!;
+    final secureFilter = _SecureFilter._(context.secureSocketBufferSize);
+    _secureFilter = secureFilter;
     secureFilter.init();
     secureFilter.registerHandshakeCompleteCallback(
       _secureHandshakeCompleteHandler,
@@ -1419,7 +1420,7 @@ class _ExternalBuffer {
 }
 
 abstract class _SecureFilter {
-  external factory _SecureFilter._();
+  external factory _SecureFilter._(int bufferSize);
 
   void connect(
     String hostName,

--- a/sdk/lib/io/security_context.dart
+++ b/sdk/lib/io/security_context.dart
@@ -208,6 +208,20 @@ abstract final class SecurityContext {
   /// The default value is [TlsProtocolVersion.tls1_2].
   abstract TlsProtocolVersion minimumTlsProtocolVersion;
 
+  /// The size, in bytes, of each plaintext buffer allocated for a secure socket
+  /// that uses this context.
+  ///
+  /// Increasing the value can improve throughput for large transfers at the
+  /// cost of additional memory per connection. The corresponding encrypted
+  /// buffers include additional space for TLS overhead.
+  ///
+  /// If the value is changed, it will only affect new connections. Existing
+  /// connections will retain their current buffer sizes.
+  ///
+  /// The value must be between 8 KiB and 1 MiB, inclusive. The default is
+  /// 8 KiB.
+  abstract int secureSocketBufferSize;
+
   /// Encodes a set of supported protocols for ALPN/NPN usage.
   ///
   /// The [protocols] list is expected to contain protocols in descending order

--- a/tests/standalone/io/secure_socket_buffer_size_test.dart
+++ b/tests/standalone/io/secure_socket_buffer_size_test.dart
@@ -1,0 +1,80 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+//
+// OtherResources=certificates/server_chain.pem
+// OtherResources=certificates/server_key.pem
+// OtherResources=certificates/trusted_certs.pem
+
+import "dart:io";
+import "dart:typed_data";
+
+import "package:expect/expect.dart";
+
+String localFile(String path) => Platform.script.resolve(path).toFilePath();
+
+SecurityContext clientContext({int? secureSocketBufferSize}) {
+  final context = SecurityContext();
+  if (secureSocketBufferSize != null) {
+    context.secureSocketBufferSize = secureSocketBufferSize;
+  }
+  return context
+    ..setTrustedCertificates(localFile('certificates/trusted_certs.pem'));
+}
+
+Future<int> initialWrite(
+  SecureServerSocket server,
+  SecurityContext context,
+) async {
+  final socket = await RawSecureSocket.connect(
+    InternetAddress.loopbackIPv4,
+    server.port,
+    context: context,
+  );
+  final written = socket.write(Uint8List(32 * 1024));
+  await socket.close();
+  return written;
+}
+
+void testInvalidSizes() {
+  final context = SecurityContext();
+  Expect.equals(8 * 1024, context.secureSocketBufferSize);
+  Expect.throwsRangeError(() => context.secureSocketBufferSize = 8 * 1024 - 1);
+  Expect.throwsRangeError(
+    () => context.secureSocketBufferSize = 1024 * 1024 + 1,
+  );
+  context.secureSocketBufferSize = 64 * 1024;
+  Expect.equals(64 * 1024, context.secureSocketBufferSize);
+}
+
+Future<void> main() async {
+  testInvalidSizes();
+
+  final serverContext = SecurityContext()
+    ..secureSocketBufferSize = 64 * 1024
+    ..useCertificateChain(localFile('certificates/server_chain.pem'))
+    ..usePrivateKey(
+      localFile('certificates/server_key.pem'),
+      password: 'dartdart',
+    );
+  final server = await SecureServerSocket.bind(
+    InternetAddress.loopbackIPv4,
+    0,
+    serverContext,
+  );
+  server.listen((socket) async {
+    await socket.drain<void>();
+    await socket.close();
+  });
+
+  Expect.equals(8 * 1024 - 1, await initialWrite(server, clientContext()));
+  Expect.equals(
+    32 * 1024,
+    await initialWrite(
+      server,
+      clientContext(secureSocketBufferSize: 64 * 1024),
+    ),
+  );
+
+  await server.close();
+}


### PR DESCRIPTION
Fixes #64086

## What this changes

This adds `SecurityContext.secureSocketBufferSize`, an opt-in per-context setting controlling the plaintext buffers allocated for newly created secure sockets.

- The default remains 8 KiB.
- Valid values range from 8 KiB through 1 MiB.
- Changing the property affects only connections created afterward.
- Existing connections retain their original buffer sizes.
- Encrypted circular buffers retain the existing 2 KiB TLS allowance.
- The native BoringSSL BIO pair uses the corresponding encrypted buffer size.

The Dart circular buffers and native BIO must be resized together. Increasing only the Dart-side buffer would otherwise move the bottleneck into the fixed 10 KiB BIO.

## Background

SecureSocket currently uses:

- 8 KiB plaintext circular buffers;
- 10 KiB encrypted circular buffers;
- a 10 KiB native BIO pair.

Large application writes are therefore divided across repeated asynchronous `IOService.sslProcessFilter` dispatches. This is particularly expensive for long-lived, high-throughput TLS connections.

The new setting allows applications to choose the throughput/memory tradeoff without changing existing defaults.

## Native lifecycle changes

The native finalizer is now registered after filter initialization. This allows its external allocation estimate to use the configured BIO size.

Native buffer pointers are initialized to null so cleanup remains safe if initialization fails before every buffer has been allocated.

## Compatibility

This is an additive API on the final `SecurityContext` class.

The default plaintext, encrypted, and BIO sizes are unchanged, so applications that do not set `secureSocketBufferSize` retain their current allocation and runtime behavior. There is no TLS protocol or wire-format change.

Larger values allocate additional memory per secure connection, which is documented on the property.

## Performance

Measured using a Windows x64 release SDK built from `35d2cf87af7`.

The loopback test transferred 256 MiB in repeated 1 MiB writes after a 16 MiB warm-up. Both endpoints used the same configured buffer size.

| Buffer size | Round 1 | Round 2 |
|---|---:|---:|
| 8 KiB | 99.6 MiB/s | 104.3 MiB/s |
| 64 KiB | 231.7 MiB/s | 236.5 MiB/s |

The 64 KiB configuration was approximately 2.3 times faster in this local measurement. The exact improvement will depend on workload and platform.

## Tests

- Built the complete Windows x64 release SDK:

  `python tools/build.py --mode release create_sdk`

- Added `standalone/io/secure_socket_buffer_size_test.dart`, covering:

  - the unchanged 8 KiB default;
  - lower and upper range validation;
  - property updates;
  - default initial `RawSecureSocket.write` capacity;
  - increased initial write capacity with a 64 KiB configuration.

- Passed the new test and relevant SecureSocket coverage, including:

  - raw secure sockets;
  - socket-to-TLS upgrades;
  - standard secure sockets;
  - secure server sockets under all short-read/write variants;
  - ALPN;
  - minimum TLS protocol version.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.