### PR TITLE
[vm] Fix use-after-free of --delete_temp_dir_on_shutdown

### DIFF
--- a/runtime/bin/main_impl.cc
+++ b/runtime/bin/main_impl.cc
@@ -1438,6 +1438,14 @@ void main(int argc, char** argv) {
 #endif
   }
 
+  // --delete_temp_dir_on_shutdown would otherwise point into argv, whose
+  // strings main() frees before returning. Own a copy instead, kept for the
+  // lifetime of the process.
+  if (Options::delete_temp_dir_on_shutdown() != nullptr) {
+    Options::set_delete_temp_dir_on_shutdown(
+        Utils::StrDup(Options::delete_temp_dir_on_shutdown()));
+  }
+
   // If we need to write an app-jit snapshot, a depfile, or delete a temp dir,
   // then add an exit hook.
   if ((Options::gen_snapshot_kind() == kAppJIT) ||
@@ -1567,6 +1575,8 @@ void main(int argc, char** argv) {
   free(app_script_uri);
   asset_resolution_base.reset();
 
+  DeleteTempDirOnShutdown();
+
   // Free copied argument strings if converted.
   if (argv_converted) {
     for (int i = 0; i < argc; i++) {
@@ -1577,7 +1587,6 @@ void main(int argc, char** argv) {
   // Free environment if any.
   Options::Cleanup();
 
-  DeleteTempDirOnShutdown();
   Platform::Exit(global_exit_code);
 }
 


### PR DESCRIPTION
Fixes the use-after-free behind #63933, where `dart run` deletes its working directory on Windows. 

String options store a pointer into `argv`, and on Windows `main()` frees the `argv` copies before DeleteTempDirOnShutdown() reads that pointer. Once the freed block has been reused the read yields something else, and the recursive delete targets whatever that names. Other platforms never free `argv`, so this is Windows only.

Two changes:

- Take ownership of the string right after parsing, so the value no longer depends on the lifetime of `argv`
- Move the `DeleteTempDirOnShutdown()` call above the free, so the read does not sit after the cleanup.

Verified on Windows with a package that has a code asset (a `webcrypto` dependency is enough). Before the fix, repeated `dart run` invocations wiped the project directory. With the fix, they no longer do.

I didn't add a test. A meaningful one looks like a bigger change than the fix itself. Let me know if you'd like one here.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
