### PR TITLE
Update use_key_in_widget_constructors to check the super constructor

### DIFF
--- a/pkg/linter/CHANGELOG.md
+++ b/pkg/linter/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - new lint: `future_sync_value`
 - new _(experimental)_ lint: `unnecessary_this_alias`
+- update `use_key_in_widget_constructors` to no longer report classes whose
+  superclass constructor has no `Key` parameter to forward.
 
 # 3.13.0
 

--- a/pkg/linter/lib/src/rules/use_key_in_widget_constructors.dart
+++ b/pkg/linter/lib/src/rules/use_key_in_widget_constructors.dart
@@ -47,6 +47,12 @@ class _Visitor(final AnalysisRule rule) extends SimpleAstVisitor<void> {
         !classElement.metadata.hasVisibleForTesting &&
         classElement.extendsWidget &&
         classElement.constructors.where((e) => e.isOriginDeclaration).isEmpty) {
+      var superConstructor = classElement.superUnnamedConstructor;
+      if (superConstructor != null && !superConstructor.definesKeyParameter) {
+        // The super constructor has no `Key` parameter to forward, so there is
+        // nothing for this class to declare.
+        return;
+      }
       rule.reportAtToken(node.namePart.typeName);
     }
   }
@@ -91,6 +97,20 @@ class _Visitor(final AnalysisRule rule) extends SimpleAstVisitor<void> {
     if (!classElement.extendsWidget) return;
     if (_hasKeySuperParameterInitializerArg(parameters)) return;
     if (!initializers.any((initializer) => initializer.isMissingKey)) {
+      var hasExplicitSuperOrRedirect = initializers.any(
+        (initializer) =>
+            initializer is SuperConstructorInvocation ||
+            initializer is RedirectingConstructorInvocation,
+      );
+      if (!hasExplicitSuperOrRedirect) {
+        // The super constructor is invoked implicitly. If it has no `Key`
+        // parameter to forward, there is nothing for this constructor to
+        // declare.
+        var superConstructor = classElement.superUnnamedConstructor;
+        if (superConstructor != null && !superConstructor.definesKeyParameter) {
+          return;
+        }
+      }
       rule.reportAtSourceRange(errorNode.sourceRange);
     }
   }
@@ -115,6 +135,13 @@ extension on ConstructorInitializer {
     ) => !element.definesKeyParameter || argumentList.containsKeyArgument,
     _ => false,
   };
+}
+
+extension on ClassElement {
+  /// The unnamed constructor of this class's superclass, or `null` if there is
+  /// none.
+  ConstructorElement? get superUnnamedConstructor =>
+      supertype?.element.unnamedConstructor;
 }
 
 extension on ConstructorElement {

--- a/pkg/linter/test/rules/use_key_in_widget_constructors_test.dart
+++ b/pkg/linter/test/rules/use_key_in_widget_constructors_test.dart
@@ -66,6 +66,21 @@ class MyWidget extends StatelessWidget {
 ''');
   }
 
+  test_constructor_implicitSuper_superWithoutKey() async {
+    await assertDiagnosticsFromMarkup(r'''
+import 'package:flutter/widgets.dart';
+
+abstract class ParentWidget extends StatelessWidget {
+  final int? i;
+  [!ParentWidget!]({this.i});
+}
+
+abstract class MyWidget extends ParentWidget {
+  MyWidget();
+}
+''');
+  }
+
   test_constructor_new_withoutKey() async {
     await assertDiagnosticsFromMarkup(r'''
 import 'package:flutter/widgets.dart';
@@ -189,6 +204,65 @@ class W extends StatelessWidget {
 import 'package:flutter/widgets.dart';
 
 abstract class [!NoConstructorWidget!] extends StatefulWidget {}
+''');
+  }
+
+  test_missingConstructor_privateSuperWithoutKey() async {
+    await assertNoDiagnostics(r'''
+import 'package:flutter/widgets.dart';
+
+abstract class _Foo extends StatelessWidget {
+  const _Foo();
+}
+
+abstract class Bar extends _Foo {}
+''');
+  }
+
+  test_missingConstructor_superWithKey() async {
+    await assertDiagnosticsFromMarkup(r'''
+import 'package:flutter/widgets.dart';
+
+abstract class ParentWidget extends StatelessWidget {
+  ParentWidget({Key? key}) : super(key: key);
+}
+
+abstract class [!MyWidget!] extends ParentWidget {}
+''');
+  }
+
+  test_missingConstructor_superWithoutKey() async {
+    await assertDiagnosticsFromMarkup(r'''
+import 'package:flutter/widgets.dart';
+
+abstract class [!ParentWidget!] extends StatelessWidget {}
+
+abstract class MyWidget extends ParentWidget {}
+''');
+  }
+
+  test_missingConstructor_superWithoutKey_withField() async {
+    await assertDiagnosticsFromMarkup(r'''
+import 'package:flutter/widgets.dart';
+
+abstract class ParentWidget extends StatelessWidget {
+  final int? i;
+  [!ParentWidget!]({this.i});
+}
+
+abstract class MyWidget extends ParentWidget {}
+''');
+  }
+
+  test_missingConstructor_superWithStringKey() async {
+    await assertDiagnosticsFromMarkup(r'''
+import 'package:flutter/widgets.dart';
+
+abstract class ParentWidget extends StatelessWidget {
+  [!ParentWidget!]({String key = 'abc'});
+}
+
+abstract class MyWidget extends ParentWidget {}
 ''');
   }
 


### PR DESCRIPTION
The rule reported a widget subclass even when the superclass constructor has no Key parameter to forward:

    class ParentWidget extends StatelessWidget {
      ParentWidget({this.i});
    }

    class MyWidget extends ParentWidget {}

An explicit super call already skips this case via definesKeyParameter, so MyWidget() : super(); was accepted while the same class without a constructor was reported. This applies the existing check to the missing-constructor and implicit-super paths, fixing all three cases in the issue including the String key one.

This also stops reporting a public widget extending a private keyless widget, matching what an explicit super() call already does today; there's a test pinning that behavior.

- [x] I've reviewed the contributor guide and applied the relevant portions to this submission.

Closes https://github.com/dart-lang/sdk/issues/58727