### PR TITLE
Add `JSFunction.length` and `.name`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@
   (`ListOfNullableBoolToJSArray`). These make it easier and more efficient to
   convert between JS and Dart arrays of primitives.
 
+- Added `JSFunction.length` and `.name` getters.
+
 [#61353]: https://github.com/dart-lang/sdk/issues/61353
 [#62699]: https://github.com/dart-lang/sdk/issues/62699
 

--- a/sdk/lib/js_interop/js_interop.dart
+++ b/sdk/lib/js_interop/js_interop.dart
@@ -245,7 +245,17 @@ external JSObjectType _createObjectLiteral();
 /// JavaScript side.
 @JS('Function')
 extension type JSFunction<T extends Function>._(JSFunctionType _jsFunction)
-    implements JSObject, JSFunctionType {}
+    implements JSObject, JSFunctionType {
+  /// The number of arguments declared for this function.
+  @Since('3.14')
+  external int get length;
+
+  /// The name used when declaring this function.
+  ///
+  /// Anonymous functions' names are empty strings.
+  @Since('3.14')
+  external String get name;
+}
 
 /// A JavaScript function created from a Dart function.
 ///

--- a/tests/lib/js/static_interop_test/js_types_test.dart
+++ b/tests/lib/js/static_interop_test/js_types_test.dart
@@ -230,7 +230,7 @@ void syncTests() {
     globalThis.obj = {
       'foo': 'bar',
     };
-    globalThis.fun = function(a, b) {
+    globalThis.fun = function fun(a, b) {
       return globalThis.edf(a, b);
     }
     globalThis.nullAny = null;
@@ -253,6 +253,8 @@ void syncTests() {
   // [JSFunction]
   Expect.isTrue(fun is JSFunction);
   Expect.isTrue(confuse(fun) is JSFunction);
+  Expect.equals(2, fun.length);
+  Expect.equals('fun', fun.name);
 
   // [JSExportedDartFunction] <-> [Function]
   final dartFunction = (JSString a, JSString b) {


### PR DESCRIPTION
These are basic information fields. `JSFunction.length` in particular is useful for distinguishing different inputs in overloaded JS APIs.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
