### PR TITLE
[vm] Cache the null instance on the Zone to avoid a TLS lookup per handle

### DIFF
--- a/runtime/vm/object.h
+++ b/runtime/vm/object.h
@@ -34,6 +34,7 @@
 #include "vm/json_stream.h"
 #include "vm/os.h"
 #include "vm/raw_object.h"
+#include "vm/zone.h"
 #include "vm/regexp/regexp-flags.h"
 #include "vm/report.h"
 #include "vm/roots.h"
@@ -132,7 +133,8 @@ class BaseTextBuffer;
         HandleImpl(Thread::Current()->zone(), object::null(), kClassId));      \
   }                                                                            \
   DART_NOINLINE static object& Handle(Zone* zone) {                            \
-    return static_cast<object&>(HandleImpl(zone, object::null(), kClassId));   \
+    return static_cast<object&>(                                               \
+        HandleImpl(zone, NullForZone(zone), kClassId));                        \
   }                                                                            \
   DART_NOINLINE static object& Handle(object##Ptr ptr) {                       \
     return static_cast<object&>(                                               \
@@ -147,7 +149,7 @@ class BaseTextBuffer;
   }                                                                            \
   DART_NOINLINE static object& ZoneHandle(Zone* zone) {                        \
     return static_cast<object&>(                                               \
-        ZoneHandleImpl(zone, object::null(), kClassId));                       \
+        ZoneHandleImpl(zone, NullForZone(zone), kClassId));                    \
   }                                                                            \
   DART_NOINLINE static object& ZoneHandle(object##Ptr ptr) {                   \
     return static_cast<object&>(                                               \
@@ -482,7 +484,7 @@ class KNOWN_VTABLE_DISCRIMINATOR Object {
     return HandleImpl(Thread::Current()->zone(), Roots::null_obj(), kObjectCid);
   }
   static Object& Handle(Zone* zone) {
-    return HandleImpl(zone, Roots::null_obj(), kObjectCid);
+    return HandleImpl(zone, NullForZone(zone), kObjectCid);
   }
   static Object& Handle(ObjectPtr ptr) {
     return HandleImpl(Thread::Current()->zone(), ptr, kObjectCid);
@@ -495,7 +497,7 @@ class KNOWN_VTABLE_DISCRIMINATOR Object {
                           kObjectCid);
   }
   static Object& ZoneHandle(Zone* zone) {
-    return ZoneHandleImpl(zone, Roots::null_obj(), kObjectCid);
+    return ZoneHandleImpl(zone, NullForZone(zone), kObjectCid);
   }
   static Object& ZoneHandle(ObjectPtr ptr) {
     return ZoneHandleImpl(Thread::Current()->zone(), ptr, kObjectCid);
@@ -702,6 +704,15 @@ class KNOWN_VTABLE_DISCRIMINATOR Object {
 
   inline void setPtr(ObjectPtr value, intptr_t default_cid);
   void CheckHandle() const;
+  // Never stale: a Zone never outlives the group entry that filled it.
+  static ObjectPtr NullForZone(Zone* zone) {
+    ObjectPtr cached = zone->null_obj();
+    if (cached == nullptr) {
+      cached = Roots::null_obj();
+      zone->set_null_obj(cached);
+    }
+    return cached;
+  }
   DART_NOINLINE static Object& HandleImpl(Zone* zone,
                                           ObjectPtr ptr,
                                           intptr_t default_cid) {

--- a/runtime/vm/zone.cc
+++ b/runtime/vm/zone.cc
@@ -175,6 +175,7 @@ void Zone::Reset() {
   size_ = 0;
   small_segment_capacity_ = 0;
   previous_ = nullptr;
+  null_obj_ = nullptr;
   handles_.Reset();
 }
 

--- a/runtime/vm/zone.h
+++ b/runtime/vm/zone.h
@@ -10,6 +10,7 @@
 #include "platform/utils.h"
 #include "vm/allocation.h"
 #include "vm/handles.h"
+#include "vm/tagged_pointer.h"
 #include "vm/memory_region.h"
 #include "vm/thread_state.h"
 
@@ -88,6 +89,10 @@ class Zone {
 
   // Structure for managing handles allocation.
   VMHandles* handles() { return &handles_; }
+
+  // Cached so handle allocation does not need a thread-local lookup.
+  ObjectPtr null_obj() const { return null_obj_; }
+  void set_null_obj(ObjectPtr value) { null_obj_ = value; }
 
   void VisitObjectPointers(ObjectPointerVisitor* visitor);
 
@@ -187,6 +192,7 @@ class Zone {
 
   // Structure for managing handles allocation.
   VMHandles handles_;
+  ObjectPtr null_obj_ = nullptr;
 
   // This buffer is used for allocation before any segments.
   // This would act as the initial stack allocated chunk so that we don't


### PR DESCRIPTION
`Roots` became a `thread_local` in `e98e6a1198c`, so `Object::null()` costs a thread-local read and every VM handle is initialised to null. Paths allocating many handles pay it per handle, and that read is a call on Darwin and in ELF shared libraries.

`Handle(Zone*)` is the largest group of readers, needs only the null, has no `Thread` in hand, and is `DART_NOINLINE`, so there is nothing to share a lookup with. This caches the null on the `Zone`, filled on first use and cleared in `Zone::Reset()`.

On arm64 macOS, against a path entering the runtime type checker once per iteration (#61970's record subtype check): 1.4% to 1.8% faster at three and four record fields, `_tlv_get_addr` down from 5.99% to 4.07% of samples, controls that stay out of the runtime unchanged, snapshot output byte identical.

Not GC-visited: safe only because the null instance never moves, which `Thread::object_null_` already assumes. Slightly unsure, since if that guarantee is weaker than I think then the existing field is wrong too.

Measured and discussed in more detail in #64103, including the cross-platform numbers and two approaches that did not work.

Ran locally on arm64 macOS against the parent commit: `vm` 4166 pass / 14 fail against 4165 / 15, `language` + `corelib` 7120 / 10 on both, no new failure names in either. The one difference is `vm/dart/thread_priority_macos_test`, which fails on the parent under the parallel suite and passes in isolation.

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>