### PR TITLE
[vm] Fix temp dir cleanup fallback on Windows

### DIFF
--- a/runtime/bin/utils_win.cc
+++ b/runtime/bin/utils_win.cc
@@ -347,12 +347,15 @@ void DeleteTempDirDetached(const wchar_t* temp_dir_w) {
     len--;
   }
 
+  // `rmdir /s /q` leaves errorlevel 0 when it fails to delete in-use files,
+  // so success is detected by checking that the directory is gone.
   const wchar_t* cmd_fmt =
-      L"cmd.exe /c (for /l %%i in (1,1,10) do (rmdir /s /q \"%s\" 2>&1 && "
-      L"exit /b 0 || timeout /t 1 /nobreak)) > NUL 2>&1";
-  size_t cmd_len = wcslen(cmd_fmt) + wcslen(clean_dir.get()) + 100;
+      L"cmd.exe /c (for /l %%i in (1,1,10) do (rmdir /s /q \"%s\" 2>&1 & "
+      L"if not exist \"%s\" (exit /b 0) else (timeout /t 1 /nobreak))) "
+      L"> NUL 2>&1";
+  size_t cmd_len = wcslen(cmd_fmt) + 2 * wcslen(clean_dir.get()) + 100;
   wchar_t* cmd_line = new wchar_t[cmd_len];
-  swprintf(cmd_line, cmd_len, cmd_fmt, clean_dir.get());
+  swprintf(cmd_line, cmd_len, cmd_fmt, clean_dir.get(), clean_dir.get());
 
   STARTUPINFOW si;
   ZeroMemory(&si, sizeof(si));
@@ -360,10 +363,12 @@ void DeleteTempDirDetached(const wchar_t* temp_dir_w) {
   PROCESS_INFORMATION pi;
   ZeroMemory(&pi, sizeof(pi));
 
-  if (CreateProcessW(
-          nullptr, cmd_line, nullptr, nullptr, FALSE,
-          CREATE_NO_WINDOW | DETACHED_PROCESS | CREATE_BREAKAWAY_FROM_JOB,
-          nullptr, nullptr, &si, &pi)) {
+  // CREATE_NO_WINDOW is ignored when combined with DETACHED_PROCESS. Without
+  // a console to inherit, each timeout.exe would open a visible console
+  // window.
+  if (CreateProcessW(nullptr, cmd_line, nullptr, nullptr, FALSE,
+                     CREATE_NO_WINDOW | CREATE_BREAKAWAY_FROM_JOB, nullptr,
+                     nullptr, &si, &pi)) {
     CloseHandle(pi.hProcess);
     CloseHandle(pi.hThread);
   }


### PR DESCRIPTION
Fixes two defects in the cmd.exe retry loop that `DeleteTempDirDetached()` spawns (#63933).

First, the loop flashed console windows. `CREATE_NO_WINDOW` is ignored when combined with `DETACHED_PROCESS`, so cmd.exe ran with no console at all, and each `timeout.exe` in the loop allocated a visible console window, stealing focus once per second. 
Dropping `DETACHED_PROCESS` gives cmd.exe its own hidden console. The hidden console is a new one, not the parent's, so the cleanup stays isolated from the parent's console.

Second, `rmdir /s /q` leaves errorlevel 0 when it fails to delete an in-use file, so the retry loop mistook that failure for success and exited without retrying. The loop now checks that the directory is gone instead of trusting rmdir's exit status.

Verified on Windows against a temp dir holding a locked file. The loop keeps retrying with no visible window and deletes the dir once the handle is released.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
