### PR TITLE
create temp directory with 0700 in Directory::CreateTemp

### DIFF
--- a/runtime/bin/directory_fuchsia.cc
+++ b/runtime/bin/directory_fuchsia.cc
@@ -338,7 +338,8 @@ const char* Directory::CreateTemp(Namespace* namespc, const char* prefix) {
       return nullptr;
     }
     NamespaceScope ns(namespc, path.AsString());
-    const int result = NO_RETRY_EXPECTED(mkdirat(ns.fd(), ns.path(), 0777));
+    // Only the owner may access the directory, matching mkdtemp().
+    const int result = NO_RETRY_EXPECTED(mkdirat(ns.fd(), ns.path(), 0700));
     if (result == 0) {
       return path.AsScopedString();
     } else if (errno == EEXIST) {

--- a/runtime/bin/directory_linux.cc
+++ b/runtime/bin/directory_linux.cc
@@ -501,7 +501,8 @@ const char* Directory::CreateTemp(Namespace* namespc, const char* prefix) {
       return nullptr;
     }
     NamespaceScope ns(namespc, path.AsString());
-    const int result = NO_RETRY_EXPECTED(mkdirat(ns.fd(), ns.path(), 0777));
+    // Only the owner may access the directory, matching mkdtemp().
+    const int result = NO_RETRY_EXPECTED(mkdirat(ns.fd(), ns.path(), 0700));
     if (result == 0) {
       return path.AsScopedString();
     } else if (errno == EEXIST) {


### PR DESCRIPTION
Directory.createTemp() on Linux, Android and Fuchsia hand-rolls mkdtemp() but creates the directory with mkdirat(..., 0777), so the temp directory ends up world-readable and traversable (0755 under the usual umask, and 0777 when the process runs with umask 0). The macOS path uses the real mkdtemp(), which fixes the mode to 0700. This passes 0700 at both CreateTemp sites so every POSIX platform gives the owner-only directory callers expect from a temp dir; regular Directory.create() keeps 0777 so the process umask still applies there.

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>