### PR TITLE
[tools] Fix Result equality operator

### DIFF
--- a/tools/diff_results.dart
+++ b/tools/diff_results.dart
@@ -302,21 +302,14 @@ class Result {
         result == other.result;
   }
 
-  bool equals(Object other) {
-    if (other is Result) {
-      if (name != other.name) return false;
-      if (builderName != other.builderName) return false;
-    }
-    return false;
-  }
-
   @override
   int get hashCode => name.hashCode ^ builderName.hashCode;
 
   @override
   bool operator ==(Object other) {
-    // TODO: implement ==
-    return super == other;
+    if (identical(this, other)) return true;
+    if (other is! Result) return false;
+    return name == other.name && builderName == other.builderName;
   }
 }
 

--- a/tools/diff_results.dart
+++ b/tools/diff_results.dart
@@ -302,15 +302,6 @@ class Result {
         result == other.result;
   }
 
-  @override
-  int get hashCode => name.hashCode ^ builderName.hashCode;
-
-  @override
-  bool operator ==(Object other) {
-    if (identical(this, other)) return true;
-    if (other is! Result) return false;
-    return name == other.name && builderName == other.builderName;
-  }
 }
 
 String currentDate() {


### PR DESCRIPTION
Fixes an issue in `tools/diff_results.dart` where the `Result` class overrode `hashCode` but failed to implement `operator ==`, which violates Dart's equality contract. 

Also removes an unused, buggy `equals()` method that always returned `false`.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>