### PR TITLE
[dart2js] Fix SizeEstimator crash with merge-fragments-threshold + minify

### DIFF
--- a/pkg/compiler/lib/src/js/size_estimator.dart
+++ b/pkg/compiler/lib/src/js/size_estimator.dart
@@ -10,6 +10,8 @@ import 'package:js_ast/src/characters.dart' as char_codes;
 // ignore: implementation_imports
 import 'package:js_ast/src/precedence.dart';
 
+import '../common/codegen.dart' show ModularName;
+import '../js/js.dart' as js;
 import '../js_backend/deferred_holder_expression.dart';
 import '../js_backend/string_reference.dart';
 import '../js_backend/type_reference.dart';
@@ -20,6 +22,29 @@ int estimateSize(Node node) {
   var estimator = SizeEstimator();
   estimator.visit(node);
   return estimator.charCount;
+}
+
+/// Whether [name].name can be read without throwing.
+///
+/// Some [Name] nodes report [Name.isFinalized] before the underlying text is
+/// available. For example, a [ModularName] can be assigned a [Name.value] that
+/// is not yet finalized, [CompoundName.isFinalized] can be true when a part is
+/// such a [ModularName], and [DeferredHolderParameter.name] is only set during
+/// holder finalization after pre-fragment size estimation.
+bool _hasReadableNameText(Name name) {
+  if (!name.isFinalized) return false;
+  if (name is ModularName) {
+    return _hasReadableNameText(name.value);
+  }
+  if (name is js.AstContainer) {
+    final container = name as js.AstContainer;
+    for (final node in container.containedNodes) {
+      if (node is Name && !_hasReadableNameText(node)) {
+        return false;
+      }
+    }
+  }
+  return true;
 }
 
 /// [SizeEstimator] is a [NodeVisitor] designed to produce a consistent size
@@ -75,6 +100,11 @@ class SizeEstimator implements NodeVisitor<void> {
   }
 
   String literalStringToString(LiteralString node) {
+    if (node is LiteralStringFromName &&
+        !_hasReadableNameText(node.name)) {
+      // LiteralStringFromName may report isFinalized before name text is readable.
+      return nameSizeEstimate;
+    }
     if (node.isFinalized) {
       return node.value;
     } else {

--- a/pkg/compiler/test/js/size_estimator_unfinalized_name_test.dart
+++ b/pkg/compiler/test/js/size_estimator_unfinalized_name_test.dart
@@ -1,0 +1,96 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:compiler/src/js/size_estimator.dart';
+import 'package:compiler/src/js_backend/namer.dart';
+import 'package:expect/expect.dart';
+import 'package:js_ast/js_ast.dart';
+
+/// Regression tests for size estimation during fragment merging.
+///
+/// With `--merge-fragments-threshold` and `--minify`, [SizeEstimator] can run
+/// before all [Name] nodes have readable text. These tests construct unfinalized
+/// [ModularName], [_PrefixedName], and [CompoundName] shapes directly. Without
+/// the `_hasReadableNameText` guard in [SizeEstimator.literalStringToString],
+/// [estimateSize] throws:
+///
+///     Null check operator used on a null value
+///
+/// Stock dart2js end-to-end compiles (including the deferred `many_parts`
+/// fixture) do not hit this path; production crashes required a large minified
+/// deferred program (threshold=80).
+void main() {
+  literalStringFromNameWithTransitivelyUnfinalizedModularName();
+  literalStringFromNameWithPrefixedNameAndUnfinalizedBase();
+  literalStringFromNameWithCompoundName();
+  literalStringFromNameWithReadableModularName();
+}
+
+/// `###:null` — placeholder name estimate plus object-literal punctuation.
+const int _placeholderPropertySize = 8;
+
+Property _propertyWithLiteralName(Name name) {
+  return Property(LiteralStringFromName(name), LiteralNull());
+}
+
+void literalStringFromNameWithTransitivelyUnfinalizedModularName() {
+  final tokenName = TokenName(TokenScope(), 'testKey');
+  final modularName = ModularName(ModularNameKind.asName, data: 'foo');
+  modularName.value = tokenName;
+
+  Expect.isTrue(modularName.isFinalized);
+  Expect.isFalse(tokenName.isFinalized);
+
+  final property = _propertyWithLiteralName(modularName);
+  Expect.isTrue((property.name as LiteralStringFromName).isFinalized);
+
+  // Before the fix this threw: Null check operator used on a null value.
+  Expect.equals(_placeholderPropertySize, estimateSize(property));
+
+  tokenName.finalize();
+  Expect.equals(6, estimateSize(property)); // `a:null`
+}
+
+void literalStringFromNameWithPrefixedNameAndUnfinalizedBase() {
+  final tokenName = TokenName(TokenScope(), 'holderKey');
+  final prefixedName = GetterName(StringBackedName('h'), tokenName);
+  final modularName = ModularName(ModularNameKind.asName, data: 'foo');
+  modularName.value = prefixedName;
+
+  Expect.isTrue(modularName.isFinalized);
+  Expect.isFalse(prefixedName.isFinalized);
+  Expect.isFalse(tokenName.isFinalized);
+
+  // Same shape as the production crash: ModularName -> _PrefixedName -> leaf.
+  Expect.equals(
+    _placeholderPropertySize,
+    estimateSize(_propertyWithLiteralName(modularName)),
+  );
+
+  tokenName.finalize();
+  Expect.equals(8, estimateSize(_propertyWithLiteralName(modularName))); // `ha:null`
+}
+
+void literalStringFromNameWithCompoundName() {
+  final tokenName = TokenName(TokenScope(), 'partKey');
+  final modularName = ModularName(ModularNameKind.asName, data: 'part');
+  modularName.value = tokenName;
+  final compound = CompoundName([modularName, StringBackedName('suffix')]);
+
+  Expect.isTrue(compound.isFinalized);
+  Expect.isFalse(tokenName.isFinalized);
+
+  final property = _propertyWithLiteralName(compound);
+  Expect.equals(_placeholderPropertySize, estimateSize(property));
+
+  tokenName.finalize();
+  Expect.equals(12, estimateSize(property)); // `asuffix:null`
+}
+
+void literalStringFromNameWithReadableModularName() {
+  final modularName = ModularName(ModularNameKind.asName, data: 'foo');
+  modularName.value = StringBackedName('bar');
+
+  Expect.equals(8, estimateSize(_propertyWithLiteralName(modularName))); // `bar:null`
+}


### PR DESCRIPTION
## Summary

Fixes #64150.

Fixes an internal dart2js crash when building with **`--merge-fragments-threshold` and `--minify` together**.

With fragment merging enabled, `SizeEstimator` runs during `FragmentEmitter.emitPreFragment` (`estimateSize: true`) **before** holder/minified names are fully readable. `LiteralStringFromName` can report `isFinalized == true` while the underlying `Name` still throws on `.name` (e.g. `ModularName` whose `value` is an unfinalized `TokenName`, or `_PrefixedName` / `CompoundName` shapes with the same issue).

The fix guards `literalStringToString` and uses the existing placeholder estimate (`###`) unless name text is transitively readable via `_hasReadableNameText()`.

**Why not fix `ModularName.isFinalized`?** That flag means "value assigned", not "text readable". Changing it would break single-assignment semantics and miss `_PrefixedName` / `CompoundName` cases. `SizeEstimator` is the correct layer because it runs before finalization during fragment merge.

**Why SDK CI missed this:**

1. **Split coverage:** dart2js bots exercise the triggers separately — `dart2js-hostasserts-minified-fragments-linux-d8` uses `--merge-fragments-threshold=3` without `--minify`, while `dart2js-minified-linux-d8` uses `--minify` without fragment merging. The crash requires **both**.

2. **No minimal in-repo repro yet:** SDK fixtures (including deferred `many_parts` with both flags) do not trigger the crash on stock dart2js. We have only reproduced it while compiling a **large production deferred web application** outside the SDK tree. We have not yet isolated which program characteristics are required beyond scale/complexity; the unit test targets the failure mechanism directly.

## Observed crash

```
The compiler crashed: Null check operator used on a null value
#0      DeferredHolderParameter.name (package:compiler/src/js_backend/deferred_holder_expression.dart:210)
#1      _PrefixedName.name (package:compiler/src/js_backend/namer_names.dart:90)
#2      ModularName.name (package:compiler/src/common/codegen.dart:2143)
#3      LiteralStringFromName.value (package:js_ast/src/nodes.dart:1490)
#4      SizeEstimator.literalStringToString (package:compiler/src/js/size_estimator.dart:79)
#5      SizeEstimator.visitLiteralString (package:compiler/src/js/size_estimator.dart:1086)
...
#N      FragmentEmitter.emitPreFragment (estimateSize: true)
```

Compile flags involved: `--merge-fragments-threshold=80 --minify -O3 --csp`

## External validation (optional context)

Reproduced while building a large deferred web app (Workiva doc_plat_client — not available upstream) with the flags above. On Dart 3.13.2, stock dart2js crashes; this patch completes successfully (~897s tag-like release build).

Reviewers do not need access to that application. It confirms real-world impact but is not part of the review contract — the in-tree unit test is the regression guard. We have not fully characterized which program shapes trigger the bug; happy to help add SDK CI coverage if reviewers have a preferred approach.

## Fix

- Add `_hasReadableNameText()` (checks `ModularName` recursion and `AstContainer` parts for `CompoundName`)
- Guard `literalStringToString` before reading unfinalized name text
- Unit regression for unfinalized `ModularName`, `_PrefixedName`, and `CompoundName` shapes

## Test plan

- [x] Added `pkg/compiler/test/js/size_estimator_unfinalized_name_test.dart` — unit tests with exact size assertions
- [x] External validation on Dart 3.13.2: stock SDK crashes, patched compiler succeeds (large deferred web app; see above)
- [ ] SDK CI (automatic): compiler unit tests, including `js_size_estimator_test.dart` goldens unchanged

---

- [x] I've reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>