### PR TITLE
[io] Use custom socket BIO for SecureSocket

### DIFF
--- a/runtime/bin/io_impl_sources.gni
+++ b/runtime/bin/io_impl_sources.gni
@@ -98,4 +98,7 @@ io_impl_sources = [
   "typed_data_utils.h",
 ]
 
-io_impl_tests = [ "secure_socket_utils_test.cc" ]
+io_impl_tests = [
+  "secure_socket_filter_test.cc",
+  "secure_socket_utils_test.cc",
+]

--- a/runtime/bin/io_natives.cc
+++ b/runtime/bin/io_natives.cc
@@ -118,15 +118,17 @@ namespace bin {
   V(ProcessInfo_CurrentRSS, 0)                                                 \
   V(ProcessInfo_MaxRSS, 0)                                                     \
   V(RawSocketOption_GetOptionValue, 1)                                         \
-  V(SecureSocket_Connect, 7)                                                   \
+  V(SecureSocket_Connect, 10)                                                  \
   V(SecureSocket_Destroy, 1)                                                   \
-  V(SecureSocket_FilterPointer, 1)                                             \
   V(SecureSocket_GetSelectedProtocol, 1)                                       \
+  V(SecureSocket_GrowBuffer, 6)                                                \
   V(SecureSocket_Handshake, 2)                                                 \
   V(SecureSocket_MarkAsTrusted, 3)                                             \
   V(SecureSocket_NewX509CertificateWrapper, 1)                                 \
   V(SecureSocket_Init, 1)                                                      \
   V(SecureSocket_PeerCertificate, 1)                                           \
+  V(SecureSocket_Process, 2)                                                   \
+  V(SecureSocket_QueuePrefetchedData, 3)                                       \
   V(SecureSocket_RegisterBadCertificateCallback, 2)                            \
   V(SecureSocket_RegisterKeyLogPort, 2)                                        \
   V(SecureSocket_RegisterHandshakeCompleteCallback, 2)                         \

--- a/runtime/bin/io_service.cc
+++ b/runtime/bin/io_service.cc
@@ -10,8 +10,6 @@
 #include "bin/directory.h"
 #include "bin/file.h"
 #include "bin/io_buffer.h"
-#include "bin/secure_socket_filter.h"
-#include "bin/security_context.h"
 #include "bin/socket.h"
 #include "bin/utils.h"
 

--- a/runtime/bin/io_service.h
+++ b/runtime/bin/io_service.h
@@ -61,8 +61,7 @@ namespace bin {
   V(Directory, ListStart, 39)                                                  \
   V(Directory, ListNext, 40)                                                   \
   V(Directory, ListStop, 41)                                                   \
-  V(Directory, Rename, 42)                                                     \
-  V(SSLFilter, ProcessFilter, 43)
+  V(Directory, Rename, 42)
 
 #define DECLARE_REQUEST(type, method, id) k##type##method##Request = id,
 

--- a/runtime/bin/io_service_no_ssl.h
+++ b/runtime/bin/io_service_no_ssl.h
@@ -18,8 +18,8 @@ namespace dart {
 namespace bin {
 
 // This list must be kept in sync with the list in sdk/lib/io/io_service.dart
-// In this modified version, though, the request 43 for SSLFilter::ProcessFilter
-// is removed, for use in contexts in which secure sockets are not enabled.
+// Secure sockets use a synchronous custom BIO and do not dispatch filter work
+// through the IO service.
 #define IO_SERVICE_REQUEST_LIST(V)                                             \
   V(File, Exists, 0)                                                           \
   V(File, Create, 1)                                                           \

--- a/runtime/bin/secure_socket_filter.cc
+++ b/runtime/bin/secure_socket_filter.cc
@@ -6,6 +6,8 @@
 
 #include "bin/secure_socket_filter.h"
 
+#include <errno.h>
+
 #include <openssl/bio.h>
 #include <openssl/ssl.h>
 #include <openssl/x509.h>
@@ -14,12 +16,59 @@
 #include "bin/lockers.h"
 #include "bin/secure_socket_utils.h"
 #include "bin/security_context.h"
+#include "bin/socket.h"
 #include "bin/socket_base.h"
+#include "bin/utils.h"
 #include "platform/syslog.h"
-#include "platform/text_buffer.h"
 
 namespace dart {
 namespace bin {
+
+static int GetLastSocketError(intptr_t fd) {
+#if defined(DART_HOST_OS_WINDOWS)
+  OSError os_error;
+  SocketBase::GetError(fd, &os_error);
+  return os_error.code();
+#else
+  static_cast<void>(fd);
+  return errno;
+#endif
+}
+
+// Determines whether an OS socket error (or return status) indicates a
+// non-fatal, retriable condition for BoringSSL custom socket BIO.
+//
+// BoringSSL custom BIO contract:
+// - Returning -1 (read) or 0 (write) WITHOUT setting BIO_set_retry_read/write
+//   causes BoringSSL to treat the condition as a fatal SSL_ERROR_SYSCALL (5),
+//   which invalidates the TLS session and corrupts the state machine.
+// - On Windows, non-blocking asynchronous I/O (Handle::Read / Handle::Write)
+//   returns -1 with last_error == NOERROR (0) when an overlapped operation
+//   is pending or no packet has completed yet.
+// - Furthermore, socket resets/closures (WSAECONNRESET, ERROR_OPERATION_ABORTED,
+//   etc.) must be flagged as retriable so that Dart EventHandler's stream
+//   events (RawSocketEvent.readClosed / closed) can deliver the termination
+//   gracefully instead of triggering an unhandled native SYSCALL exception.
+static bool IsRetrySocketError(int error) {
+  if (error == 0) {
+    // Windows non-blocking pending I/O: Handle::Read returns -1 with last_error
+    // == 0 when no data is ready, and Handle::Write returns -1 with last_error
+    // == 0 when a write is in progress.
+    return true;
+  }
+#if defined(DART_HOST_OS_WINDOWS)
+  return error == WSAEWOULDBLOCK || error == WSAEBADF ||
+         error == WSAENOTSOCK || error == ERROR_INVALID_HANDLE ||
+         error == WSAECONNRESET || error == WSAECONNABORTED ||
+         error == WSAESHUTDOWN || error == WSAENOTCONN ||
+         error == ERROR_NETNAME_DELETED || error == ERROR_OPERATION_ABORTED ||
+         error == ERROR_CONNECTION_ABORTED;
+#else
+  return error == EAGAIN || error == EWOULDBLOCK || error == EBADF ||
+         error == ECONNRESET || error == EPIPE || error == ENOTCONN ||
+         error == ECONNABORTED;
+#endif
+}
 
 bool SSLFilter::library_initialized_ = false;
 // To protect library initialization.
@@ -27,6 +76,7 @@ Mutex* SSLFilter::mutex_ = nullptr;
 int SSLFilter::filter_ssl_index;
 int SSLFilter::ssl_cert_context_index;
 Dart_Port SSLFilter::trust_evaluate_reply_port_ = ILLEGAL_PORT;
+BIO_METHOD* SSLFilter::socket_bio_method_ = nullptr;
 
 void SSLFilter::Init() {
   ASSERT(SSLFilter::mutex_ == nullptr);
@@ -35,14 +85,54 @@ void SSLFilter::Init() {
 
 void SSLFilter::Cleanup() {
   ASSERT(SSLFilter::mutex_ != nullptr);
+  if (socket_bio_method_ != nullptr) {
+    BIO_meth_free(socket_bio_method_);
+    socket_bio_method_ = nullptr;
+  }
   delete SSLFilter::mutex_;
   SSLFilter::mutex_ = nullptr;
   trust_evaluate_reply_port_ = ILLEGAL_PORT;
 }
 
-const intptr_t SSLFilter::kInternalBIOSize = 10 * KB;
 const intptr_t SSLFilter::kApproximateSize =
-    sizeof(SSLFilter) + (2 * SSLFilter::kInternalBIOSize);
+    sizeof(SSLFilter) + SSLFilter::kMaxPrefetchedData;
+
+SSLFilterBuffer::SSLFilterBuffer(int size)
+    : data_(new uint8_t[size]), size_(size) {
+  ASSERT(size >= 2);
+  ASSERT(data_ != nullptr);
+  memset(data_, 0, size_);
+}
+
+SSLFilterBuffer::~SSLFilterBuffer() {
+  delete[] data_;
+}
+
+static void ReleaseFilterBuffer(void* isolate_data, void* peer) {
+  static_cast<SSLFilterBuffer*>(peer)->Release();
+}
+
+static Dart_Handle NewUnhandledInternalError(const char* message) {
+  return Dart_NewUnhandledExceptionError(DartUtils::NewInternalError(message));
+}
+
+static Dart_Handle NewUnhandledArgumentError(const char* message) {
+  return Dart_NewUnhandledExceptionError(
+      DartUtils::NewDartArgumentError(message));
+}
+
+static Dart_Handle WrapFilterBuffer(SSLFilterBuffer* buffer) {
+  // The allocation's initial reference belongs to SSLFilter. Reserve a second
+  // reference for the ExternalUint8List before installing its finalizer.
+  buffer->Retain();
+  Dart_Handle data = Dart_NewExternalTypedDataWithFinalizer(
+      Dart_TypedData_kUint8, buffer->data(), buffer->size(), buffer,
+      buffer->size() + sizeof(SSLFilterBuffer), ReleaseFilterBuffer);
+  if (Dart_IsError(data)) {
+    buffer->Release();
+  }
+  return data;
+}
 
 static SSLFilter* GetFilter(Dart_NativeArguments args) {
   SSLFilter* filter = nullptr;
@@ -118,9 +208,17 @@ void FUNCTION_NAME(SecureSocket_Connect)(Dart_NativeArguments args) {
   // The protocols_handle is guaranteed to be a valid Uint8List.
   // It will have the correct length encoding of the protocols array.
   ASSERT(!Dart_IsNull(protocols_handle));
+  Dart_Handle native_socket = ThrowIfError(Dart_GetNativeArgument(args, 7));
+  Dart_Handle transport_read = ThrowIfError(Dart_GetNativeArgument(args, 8));
+  Dart_Handle transport_write = ThrowIfError(Dart_GetNativeArgument(args, 9));
+  Socket* socket = nullptr;
+  if (!Dart_IsNull(native_socket)) {
+    socket = Socket::GetSocketIdNativeField(native_socket);
+  }
   GetFilter(args)->Connect(host_name, context, is_server,
                            request_client_certificate,
-                           require_client_certificate, protocols_handle);
+                           require_client_certificate, protocols_handle, socket,
+                           transport_read, transport_write);
 }
 
 void FUNCTION_NAME(SecureSocket_Destroy)(Dart_NativeArguments args) {
@@ -144,8 +242,20 @@ void FUNCTION_NAME(SecureSocket_Handshake)(Dart_NativeArguments args) {
 
   Dart_Port port_id;
   ThrowIfError(Dart_SendPortGetId(port, &port_id));
-  int result = GetFilter(args)->Handshake(port_id);
-  Dart_SetReturnValue(args, Dart_NewInteger(result));
+  SSLFilter* filter = GetFilter(args);
+  int status = filter->Handshake(port_id);
+  Dart_Handle result = Dart_NewList(5);
+  ThrowIfError(result);
+  ThrowIfError(Dart_ListSetAt(result, 0, Dart_NewInteger(status)));
+  ThrowIfError(
+      Dart_ListSetAt(result, 1, Dart_NewBoolean(filter->HasPrefetchedData())));
+  ThrowIfError(Dart_ListSetAt(
+      result, 2, Dart_NewBoolean(filter->HasPendingSocketWrite())));
+  ThrowIfError(Dart_ListSetAt(result, 3,
+                              Dart_NewInteger(filter->TakeSocketReadBytes())));
+  ThrowIfError(Dart_ListSetAt(result, 4,
+                              Dart_NewInteger(filter->TakeSocketWriteBytes())));
+  Dart_SetReturnValue(args, result);
 }
 
 void FUNCTION_NAME(SecureSocket_MarkAsTrusted)(Dart_NativeArguments args) {
@@ -205,83 +315,342 @@ void FUNCTION_NAME(SecureSocket_PeerCertificate)(Dart_NativeArguments args) {
   Dart_SetReturnValue(args, cert);
 }
 
-void FUNCTION_NAME(SecureSocket_FilterPointer)(Dart_NativeArguments args) {
+void FUNCTION_NAME(SecureSocket_QueuePrefetchedData)(
+    Dart_NativeArguments args) {
   SSLFilter* filter = GetFilter(args);
-  // This filter pointer is passed to the IO Service thread. The IO Service
-  // thread must Release() the pointer when it is done with it.
-  filter->Retain();
-  intptr_t filter_pointer = reinterpret_cast<intptr_t>(filter);
-  Dart_SetReturnValue(args, Dart_NewInteger(filter_pointer));
+  Dart_Handle data = ThrowIfError(Dart_GetNativeArgument(args, 1));
+  intptr_t offset = DartUtils::GetNativeIntptrArgument(args, 2);
+  Dart_SetIntegerReturnValue(args, filter->QueuePrefetchedData(data, offset));
 }
 
-/**
- * Pushes data through the SSL filter, reading and writing from circular
- * buffers shared with Dart.
- *
- * The Dart _SecureFilterImpl class contains 4 ExternalByteArrays used to
- * pass encrypted and plaintext data to and from the C++ SSLFilter object.
- *
- * ProcessFilter is called with a CObject array containing the pointer to
- * the SSLFilter, encoded as an int, and the start and end positions of the
- * valid data in the four circular buffers.  The function only reads from
- * the valid data area of the input buffers, and only writes to the free
- * area of the output buffers.  The function returns the new start and end
- * positions in the buffers, but it only updates start for input buffers, and
- * end for output buffers.  Therefore, the Dart thread can simultaneously
- * write to the free space and end pointer of input buffers, and read from
- * the data space of output buffers, and modify the start pointer.
- *
- * When ProcessFilter returns, the Dart thread is responsible for combining
- * the updated pointers from Dart and C++, to make the new valid state of
- * the circular buffer.
- */
-CObject* SSLFilter::ProcessFilterRequest(const CObjectArray& request) {
-  CObjectIntptr filter_object(request[0]);
-  SSLFilter* filter = reinterpret_cast<SSLFilter*>(filter_object.Value());
-  RefCntReleaseScope<SSLFilter> rs(filter);
-
-  bool in_handshake = CObjectBool(request[1]).Value();
-  int starts[SSLFilter::kNumBuffers];
-  int ends[SSLFilter::kNumBuffers];
-  for (int i = 0; i < SSLFilter::kNumBuffers; ++i) {
-    starts[i] = CObjectInt32(request[2 * i + 2]).Value();
-    ends[i] = CObjectInt32(request[2 * i + 3]).Value();
+void FUNCTION_NAME(SecureSocket_Process)(Dart_NativeArguments args) {
+  SSLFilter* filter = GetFilter(args);
+  Dart_Handle positions = ThrowIfError(Dart_GetNativeArgument(args, 1));
+  intptr_t length = 0;
+  ThrowIfError(Dart_ListLength(positions, &length));
+  if (length != SSLFilter::kNumBuffers * 3) {
+    Dart_ThrowException(DartUtils::NewInternalError(
+        "Invalid SecureSocket buffer position list"));
   }
 
-  if (filter->ProcessAllBuffers(starts, ends, in_handshake)) {
-    CObjectArray* result =
-        new CObjectArray(CObject::NewArray(SSLFilter::kNumBuffers * 2));
-    for (int i = 0; i < SSLFilter::kNumBuffers; ++i) {
-      result->SetAt(2 * i, new CObjectInt32(CObject::NewInt32(starts[i])));
-      result->SetAt(2 * i + 1, new CObjectInt32(CObject::NewInt32(ends[i])));
+  int starts[SSLFilter::kNumBuffers];
+  int ends[SSLFilter::kNumBuffers];
+  int sizes[SSLFilter::kNumBuffers];
+  for (int i = 0; i < SSLFilter::kNumBuffers; ++i) {
+    starts[i] = DartUtils::GetIntegerValue(
+        ThrowIfError(Dart_ListGetAt(positions, 3 * i)));
+    ends[i] = DartUtils::GetIntegerValue(
+        ThrowIfError(Dart_ListGetAt(positions, 3 * i + 1)));
+    sizes[i] = DartUtils::GetIntegerValue(
+        ThrowIfError(Dart_ListGetAt(positions, 3 * i + 2)));
+  }
+
+  if (!filter->ProcessAllBuffers(starts, ends, sizes)) {
+    filter->ThrowFilterError();
+  }
+
+  Dart_Handle result = Dart_NewList(SSLFilter::kNumBuffers * 2 + 6);
+  ThrowIfError(result);
+  for (int i = 0; i < SSLFilter::kNumBuffers; ++i) {
+    ThrowIfError(Dart_ListSetAt(result, 2 * i, Dart_NewInteger(starts[i])));
+    ThrowIfError(Dart_ListSetAt(result, 2 * i + 1, Dart_NewInteger(ends[i])));
+  }
+  ThrowIfError(Dart_ListSetAt(result, SSLFilter::kNumBuffers * 2,
+                              Dart_NewBoolean(filter->WantsWrite())));
+  ThrowIfError(Dart_ListSetAt(result, SSLFilter::kNumBuffers * 2 + 1,
+                              Dart_NewBoolean(filter->HasPrefetchedData())));
+  ThrowIfError(
+      Dart_ListSetAt(result, SSLFilter::kNumBuffers * 2 + 2,
+                     Dart_NewBoolean(filter->HasPendingSocketWrite())));
+  ThrowIfError(Dart_ListSetAt(result, SSLFilter::kNumBuffers * 2 + 3,
+                              Dart_NewInteger(filter->TakeSocketReadBytes())));
+  ThrowIfError(Dart_ListSetAt(result, SSLFilter::kNumBuffers * 2 + 4,
+                              Dart_NewInteger(filter->TakeSocketWriteBytes())));
+  ThrowIfError(
+      Dart_ListSetAt(result, SSLFilter::kNumBuffers * 2 + 5,
+                     Dart_NewBoolean(filter->HasPendingPlaintext())));
+  Dart_SetReturnValue(args, result);
+}
+
+void FUNCTION_NAME(SecureSocket_GrowBuffer)(Dart_NativeArguments args) {
+  SSLFilter* filter = GetFilter(args);
+  int buffer_index =
+      static_cast<int>(DartUtils::GetNativeIntptrArgument(args, 1));
+  int start = static_cast<int>(DartUtils::GetNativeIntptrArgument(args, 2));
+  int end = static_cast<int>(DartUtils::GetNativeIntptrArgument(args, 3));
+  int old_size = static_cast<int>(DartUtils::GetNativeIntptrArgument(args, 4));
+  int new_size = static_cast<int>(DartUtils::GetNativeIntptrArgument(args, 5));
+  Dart_SetReturnValue(args, ThrowIfError(filter->GrowBuffer(
+                                buffer_index, start, end, old_size, new_size)));
+}
+
+void SSLFilter::ThrowFilterError() {
+  if (last_ssl_error_ == SSL_ERROR_SYSCALL && last_os_error_ != 0) {
+    OSError os_error;
+    os_error.SetCodeAndMessage(OSError::kSystem, last_os_error_);
+    Dart_Handle dart_os_error = DartUtils::NewDartOSError(&os_error);
+    Dart_Handle exception = DartUtils::NewDartIOException(
+        "TlsException", "SecureSocket filter error", dart_os_error);
+    Dart_ThrowException(exception);
+    UNREACHABLE();
+  }
+  SecureSocketUtils::ThrowIOException(
+      last_ssl_error_ == SSL_ERROR_SSL ? 0 : last_ssl_status_, "TlsException",
+      "SecureSocket filter error", ssl_);
+}
+
+bool SSLFilter::HasPendingSocketWrite() const {
+#if defined(DART_HOST_OS_WINDOWS)
+  return socket_fd_ != Socket::kClosedFd &&
+         SocketBase::HasPendingWrite(socket_fd_);
+#else
+  return false;
+#endif
+}
+
+intptr_t SSLFilter::QueuePrefetchedData(Dart_Handle data, intptr_t offset) {
+  if (HasPrefetchedData()) {
+    return 0;
+  }
+  if (prefetched_data_ != nullptr) {
+    delete[] prefetched_data_;
+    prefetched_data_ = nullptr;
+  }
+  prefetched_data_offset_ = 0;
+  prefetched_data_length_ = 0;
+
+  intptr_t data_length = 0;
+  ThrowIfError(Dart_ListLength(data, &data_length));
+  intptr_t length = BoundedPrefetchedDataLength(data_length, offset);
+  if (length < 0) {
+    Dart_ThrowException(
+        DartUtils::NewDartArgumentError("Invalid prefetched data offset"));
+  }
+  if (length == 0) {
+    prefetched_data_has_tail_ = false;
+    return 0;
+  }
+
+  prefetched_data_ = new uint8_t[length];
+  ASSERT(prefetched_data_ != nullptr);
+  Dart_Handle result =
+      Dart_ListGetAsBytes(data, offset, prefetched_data_, length);
+  if (Dart_IsError(result)) {
+    delete[] prefetched_data_;
+    prefetched_data_ = nullptr;
+    prefetched_data_has_tail_ = false;
+    Dart_PropagateError(result);
+  }
+  prefetched_data_length_ = length;
+  prefetched_data_has_tail_ =
+      PrefetchedDataHasTail(data_length, offset, length);
+  return length;
+}
+
+int SSLFilter::SocketBIORead(BIO* bio, char* output, int length) {
+  BIO_clear_retry_flags(bio);
+  SSLFilter* filter = static_cast<SSLFilter*>(BIO_get_data(bio));
+  if (filter == nullptr || length <= 0) {
+    return -1;
+  }
+
+  if (filter->HasPrefetchedData()) {
+    intptr_t available =
+        filter->prefetched_data_length_ - filter->prefetched_data_offset_;
+    intptr_t to_read = available < length ? available : length;
+    memmove(output, filter->prefetched_data_ + filter->prefetched_data_offset_,
+            to_read);
+    filter->prefetched_data_offset_ += to_read;
+    if (!filter->HasPrefetchedData()) {
+      delete[] filter->prefetched_data_;
+      filter->prefetched_data_ = nullptr;
+      filter->prefetched_data_offset_ = 0;
+      filter->prefetched_data_length_ = 0;
     }
-    return result;
+    return static_cast<int>(to_read);
+  }
+
+  // The current bounded chunk is empty, but Dart still owns earlier transport
+  // bytes which have not been queued yet. Do not allow newer socket bytes to
+  // overtake that tail. Returning WANT_READ gives Dart a chance to queue the
+  // next chunk before BoringSSL reads again.
+  if (filter->prefetched_data_has_tail_) {
+    BIO_set_retry_read(bio);
+    return -1;
+  }
+
+  if (filter->socket_fd_ != Socket::kClosedFd) {
+    const intptr_t fd = filter->socket_fd_;
+    intptr_t requested = length;
+    if (Socket::short_socket_read()) {
+      requested = (requested + 1) / 2;
+    }
+    intptr_t read = SocketBase::Read(fd, output, requested, SocketBase::kAsync);
+    if (read > 0) {
+      filter->socket_read_bytes_ += read;
+      return static_cast<int>(read);
+    }
+    if (read == 0) {
+      BIO_set_retry_read(bio);
+      return -1;
+    }
+    const int socket_error = GetLastSocketError(fd);
+    if (IsRetrySocketError(socket_error)) {
+      BIO_set_retry_read(bio);
+      return -1;
+    }
+    filter->last_os_error_ = socket_error;
+    return -1;
+  }
+
+  if (filter->transport_read_ == nullptr) {
+    return -1;
+  }
+  Dart_Handle read_length = Dart_NewInteger(length);
+  if (Dart_IsError(read_length)) {
+    filter->SetCallbackError(read_length);
+    return -1;
+  }
+  Dart_Handle result = Dart_InvokeClosure(
+      Dart_HandleFromPersistent(filter->transport_read_), 1, &read_length);
+  if (Dart_IsError(result)) {
+    filter->SetCallbackError(result);
+    return -1;
+  }
+  if (Dart_IsNull(result)) {
+    BIO_set_retry_read(bio);
+    return -1;
+  }
+  intptr_t result_length = 0;
+  Dart_Handle status = Dart_ListLength(result, &result_length);
+  if (Dart_IsError(status)) {
+    filter->SetCallbackError(status);
+    return -1;
+  }
+  if (result_length < 0 || result_length > length) {
+    filter->SetCallbackError(NewUnhandledArgumentError(
+        "RawSocket.read returned an invalid byte count"));
+    return -1;
+  }
+  if (result_length == 0) {
+    BIO_set_retry_read(bio);
+    return -1;
+  }
+  status = Dart_ListGetAsBytes(result, 0, reinterpret_cast<uint8_t*>(output),
+                               result_length);
+  if (Dart_IsError(status)) {
+    filter->SetCallbackError(status);
+    return -1;
+  }
+  return static_cast<int>(result_length);
+}
+
+int SSLFilter::SocketBIOWrite(BIO* bio,
+                              const char* input,
+                              size_t length,
+                              size_t* written) {
+  BIO_clear_retry_flags(bio);
+  SSLFilter* filter = static_cast<SSLFilter*>(BIO_get_data(bio));
+  if (filter == nullptr) {
+    return 0;
+  }
+
+  intptr_t requested = length > static_cast<size_t>(INTPTR_MAX)
+                           ? INTPTR_MAX
+                           : static_cast<intptr_t>(length);
+  intptr_t result = 0;
+  if (filter->socket_fd_ != Socket::kClosedFd) {
+    const intptr_t fd = filter->socket_fd_;
+    if (Socket::short_socket_write()) {
+      requested = (requested + 1) / 2;
+    }
+    result = SocketBase::Write(fd, input, requested, SocketBase::kAsync);
+    if (result > 0) {
+      filter->socket_write_bytes_ += result;
+    } else if (result == 0) {
+      BIO_set_retry_write(bio);
+    } else {
+      const int socket_error = GetLastSocketError(fd);
+      if (IsRetrySocketError(socket_error)) {
+        BIO_set_retry_write(bio);
+      } else {
+        filter->last_os_error_ = socket_error;
+      }
+    }
   } else {
-    int32_t error_code = static_cast<int32_t>(ERR_peek_error());
-    TextBuffer error_string(SecureSocketUtils::SSL_ERROR_MESSAGE_BUFFER_SIZE);
-    SecureSocketUtils::FetchErrorString(filter->ssl_, &error_string);
-    CObjectArray* result = new CObjectArray(CObject::NewArray(2));
-    result->SetAt(0, new CObjectInt32(CObject::NewInt32(error_code)));
-    result->SetAt(1,
-                  new CObjectString(CObject::NewString(error_string.buffer())));
-    return result;
+    if (filter->transport_write_ == nullptr) {
+      return 0;
+    }
+    Dart_Handle data = DartUtils::MakeUint8Array(input, requested);
+    if (Dart_IsError(data)) {
+      filter->SetCallbackError(data);
+      return 0;
+    }
+    Dart_Handle write_result = Dart_InvokeClosure(
+        Dart_HandleFromPersistent(filter->transport_write_), 1, &data);
+    if (Dart_IsError(write_result)) {
+      filter->SetCallbackError(write_result);
+      return 0;
+    }
+    int64_t dart_result = 0;
+    Dart_Handle status = Dart_IntegerToInt64(write_result, &dart_result);
+    if (Dart_IsError(status)) {
+      filter->SetCallbackError(status);
+      return 0;
+    }
+    if (dart_result < 0 || dart_result > requested) {
+      filter->SetCallbackError(NewUnhandledArgumentError(
+          "RawSocket.write returned an invalid byte count"));
+      return 0;
+    }
+    result = static_cast<intptr_t>(dart_result);
+  }
+  if (result > 0) {
+    *written = static_cast<size_t>(result);
+    return 1;
+  }
+  if (result == 0) {
+    BIO_set_retry_write(bio);
+  }
+  return 0;
+}
+
+long SSLFilter::SocketBIOControl(BIO* bio,
+                                 int command,
+                                 long argument,
+                                 void* pointer) {
+  SSLFilter* filter = static_cast<SSLFilter*>(BIO_get_data(bio));
+  switch (command) {
+    case BIO_CTRL_EOF:
+      return 0;
+    case BIO_CTRL_PENDING:
+      return filter != nullptr && filter->HasPrefetchedData()
+                 ? filter->prefetched_data_length_ -
+                       filter->prefetched_data_offset_
+                 : 0;
+    case BIO_CTRL_WPENDING:
+      return 0;
+    case BIO_CTRL_FLUSH:
+      return 1;
+    default:
+      return 0;
   }
 }
 
 bool SSLFilter::ProcessAllBuffers(int starts[kNumBuffers],
                                   int ends[kNumBuffers],
-                                  bool in_handshake) {
+                                  int sizes[kNumBuffers]) {
   for (int i = 0; i < kNumBuffers; ++i) {
-    if (in_handshake && (i == kReadPlaintext || i == kWritePlaintext)) continue;
     int start = starts[i];
     int end = ends[i];
-    int size = IsBufferEncrypted(i) ? encrypted_buffer_size_ : buffer_size_;
-    if (start < 0 || end < 0 || start >= size || end >= size) {
-      FATAL("Out-of-bounds internal buffer access in dart:io SecureSocket");
+    int size = sizes[i];
+    if (buffers_[i] == nullptr || size != buffers_[i]->size() ||
+        !IsValidBufferRange(start, end, size)) {
+      Dart_ThrowException(DartUtils::NewInternalError(
+          "Out-of-bounds internal buffer access in dart:io SecureSocket"));
     }
     switch (i) {
       case kReadPlaintext:
-      case kWriteEncrypted:
         // Write data to the circular buffer's free space.  If the buffer
         // is full, neither if statement is executed and nothing happens.
         if (start <= end) {
@@ -290,43 +659,34 @@ bool SSLFilter::ProcessAllBuffers(int starts[kNumBuffers],
           // Then, since the last free byte is at position start - 2,
           // the interval is [end, size - 1).
           int buffer_end = (start == 0) ? size - 1 : size;
-          int bytes = (i == kReadPlaintext)
-                          ? ProcessReadPlaintextBuffer(end, buffer_end)
-                          : ProcessWriteEncryptedBuffer(end, buffer_end);
+          int bytes = ProcessReadPlaintextBuffer(end, buffer_end);
           if (bytes < 0) return false;
           end += bytes;
           ASSERT(end <= size);
           if (end == size) end = 0;
         }
         if (start > end + 1) {
-          int bytes = (i == kReadPlaintext)
-                          ? ProcessReadPlaintextBuffer(end, start - 1)
-                          : ProcessWriteEncryptedBuffer(end, start - 1);
+          int bytes = ProcessReadPlaintextBuffer(end, start - 1);
           if (bytes < 0) return false;
           end += bytes;
           ASSERT(end < start);
         }
         ends[i] = end;
         break;
-      case kReadEncrypted:
       case kWritePlaintext:
         // Read/Write data from circular buffer.  If the buffer is empty,
         // neither if statement's condition is true.
         if (end < start) {
           // Data may be split into two segments.  In this case,
           // the first is [start, size).
-          int bytes = (i == kReadEncrypted)
-                          ? ProcessReadEncryptedBuffer(start, size)
-                          : ProcessWritePlaintextBuffer(start, size);
+          int bytes = ProcessWritePlaintextBuffer(start, size);
           if (bytes < 0) return false;
           start += bytes;
           ASSERT(start <= size);
           if (start == size) start = 0;
         }
         if (start < end) {
-          int bytes = (i == kReadEncrypted)
-                          ? ProcessReadEncryptedBuffer(start, end)
-                          : ProcessWritePlaintextBuffer(start, end);
+          int bytes = ProcessWritePlaintextBuffer(start, end);
           if (bytes < 0) return false;
           start += bytes;
           ASSERT(start <= end);
@@ -340,16 +700,58 @@ bool SSLFilter::ProcessAllBuffers(int starts[kNumBuffers],
   return true;
 }
 
+Dart_Handle SSLFilter::GrowBuffer(int buffer_index,
+                                  int start,
+                                  int end,
+                                  int old_size,
+                                  int new_size) {
+  if (buffer_index < 0 || buffer_index >= kNumBuffers) {
+    return NewUnhandledInternalError("Invalid SecureSocket buffer index");
+  }
+
+  SSLFilterBuffer* old_buffer = buffers_[buffer_index];
+  if (old_buffer == nullptr || old_size != old_buffer->size() ||
+      new_size <= old_size || new_size > max_buffer_size_ ||
+      !IsValidBufferRange(start, end, old_size)) {
+    return NewUnhandledInternalError(
+        "Invalid SecureSocket buffer growth request");
+  }
+
+  int used = start > end ? old_size + end - start : end - start;
+  if (used < 0 || used >= new_size) {
+    return NewUnhandledInternalError(
+        "Invalid SecureSocket buffer contents during growth");
+  }
+
+  SSLFilterBuffer* new_buffer = new SSLFilterBuffer(new_size);
+  int first_length = old_size - start;
+  if (first_length > used) first_length = used;
+  if (first_length > 0) {
+    memmove(new_buffer->data(), old_buffer->data() + start, first_length);
+  }
+  int second_length = used - first_length;
+  if (second_length > 0) {
+    memmove(new_buffer->data() + first_length, old_buffer->data(),
+            second_length);
+  }
+
+  Dart_Handle data = WrapFilterBuffer(new_buffer);
+  if (Dart_IsError(data)) {
+    new_buffer->Release();
+    return data;
+  }
+
+  // Commit only after both the native allocation and its Dart wrapper exist.
+  // The old ExternalUint8List owns the remaining reference to old_buffer.
+  buffers_[buffer_index] = new_buffer;
+  old_buffer->Release();
+  return data;
+}
+
 Dart_Handle SSLFilter::Init(Dart_Handle dart_this) {
   if (!library_initialized_) {
     InitializeLibrary();
   }
-  ASSERT(string_start_ == nullptr);
-  string_start_ = Dart_NewPersistentHandle(DartUtils::NewString("start"));
-  ASSERT(string_start_ != nullptr);
-  ASSERT(string_length_ == nullptr);
-  string_length_ = Dart_NewPersistentHandle(DartUtils::NewString("length"));
-  ASSERT(string_length_ != nullptr);
   ASSERT(bad_certificate_callback_ == nullptr);
   bad_certificate_callback_ = Dart_NewPersistentHandle(Dart_Null());
   ASSERT(bad_certificate_callback_ != nullptr);
@@ -375,58 +777,52 @@ Dart_Handle SSLFilter::InitializeBuffers(Dart_Handle dart_this) {
   Dart_Handle err = Dart_IntegerToInt64(dart_buffer_size, &buffer_size);
   RETURN_IF_ERROR(err);
 
-  Dart_Handle encrypted_size_string = DartUtils::NewString("ENCRYPTED_SIZE");
-  RETURN_IF_ERROR(encrypted_size_string);
-
-  Dart_Handle dart_encrypted_buffer_size =
-      Dart_GetField(secure_filter_impl_type, encrypted_size_string);
-  RETURN_IF_ERROR(dart_encrypted_buffer_size);
-
-  int64_t encrypted_buffer_size = 0;
-  err = Dart_IntegerToInt64(dart_encrypted_buffer_size, &encrypted_buffer_size);
-  RETURN_IF_ERROR(err);
-
   if (buffer_size <= 0 || buffer_size > 1 * MB) {
     FATAL("Invalid buffer size in _ExternalBuffer");
   }
-  if (encrypted_buffer_size <= 0 || encrypted_buffer_size > 1 * MB) {
-    FATAL("Invalid encrypted buffer size in _ExternalBuffer");
-  }
-  buffer_size_ = static_cast<int>(buffer_size);
-  encrypted_buffer_size_ = static_cast<int>(encrypted_buffer_size);
+  max_buffer_size_ = static_cast<int>(buffer_size);
 
   Dart_Handle data_identifier = DartUtils::NewString("data");
   RETURN_IF_ERROR(data_identifier);
 
-  for (int i = 0; i < kNumBuffers; i++) {
-    int size = IsBufferEncrypted(i) ? encrypted_buffer_size_ : buffer_size_;
-    buffers_[i] = new uint8_t[size];
-    ASSERT(buffers_[i] != nullptr);
-    memset(buffers_[i], 0, size);
-    dart_buffer_objects_[i] = nullptr;
-  }
+  Dart_Handle current_size_identifier = DartUtils::NewString("size");
+  RETURN_IF_ERROR(current_size_identifier);
 
   Dart_Handle result = Dart_Null();
   for (int i = 0; i < kNumBuffers; ++i) {
-    int size = IsBufferEncrypted(i) ? encrypted_buffer_size_ : buffer_size_;
-    result = Dart_ListGetAt(dart_buffers_object, i);
-    if (Dart_IsError(result)) {
+    Dart_Handle dart_buffer = Dart_ListGetAt(dart_buffers_object, i);
+    if (Dart_IsError(dart_buffer)) {
+      result = dart_buffer;
       break;
     }
 
-    dart_buffer_objects_[i] = Dart_NewPersistentHandle(result);
-    ASSERT(dart_buffer_objects_[i] != nullptr);
-    Dart_Handle data =
-        Dart_NewExternalTypedData(Dart_TypedData_kUint8, buffers_[i], size);
-    if (Dart_IsError(data)) {
-      result = data;
+    Dart_Handle dart_current_size =
+        Dart_GetField(dart_buffer, current_size_identifier);
+    if (Dart_IsError(dart_current_size)) {
+      result = dart_current_size;
       break;
     }
-    result = Dart_HandleFromPersistent(dart_buffer_objects_[i]);
+    int64_t current_size = 0;
+    result = Dart_IntegerToInt64(dart_current_size, &current_size);
     if (Dart_IsError(result)) {
       break;
     }
-    result = Dart_SetField(result, data_identifier, data);
+    if (current_size < 2 || current_size > max_buffer_size_) {
+      result =
+          NewUnhandledInternalError("Invalid initial SecureSocket buffer size");
+      break;
+    }
+
+    SSLFilterBuffer* buffer =
+        new SSLFilterBuffer(static_cast<int>(current_size));
+    Dart_Handle data = WrapFilterBuffer(buffer);
+    if (Dart_IsError(data)) {
+      buffer->Release();
+      result = data;
+      break;
+    }
+    buffers_[i] = buffer;
+    result = Dart_SetField(dart_buffer, data_identifier, data);
     if (Dart_IsError(result)) {
       break;
     }
@@ -466,6 +862,16 @@ void SSLFilter::InitializeLibrary() {
   MutexLocker locker(mutex_);
   if (!library_initialized_) {
     SSL_library_init();
+    const int socket_bio_type = BIO_get_new_index();
+    RELEASE_ASSERT(socket_bio_type >= 0);
+    socket_bio_method_ = BIO_meth_new(socket_bio_type, nullptr);
+    RELEASE_ASSERT(socket_bio_method_ != nullptr);
+    RELEASE_ASSERT(
+        BIO_meth_set_read(socket_bio_method_, SSLFilter::SocketBIORead));
+    RELEASE_ASSERT(
+        BIO_meth_set_write_ex(socket_bio_method_, SSLFilter::SocketBIOWrite));
+    RELEASE_ASSERT(
+        BIO_meth_set_ctrl(socket_bio_method_, SSLFilter::SocketBIOControl));
     filter_ssl_index =
         SSL_get_ex_new_index(0, nullptr, nullptr, nullptr, nullptr);
     ASSERT(filter_ssl_index >= 0);
@@ -492,25 +898,54 @@ void SSLFilter::Connect(const char* hostname,
                         bool is_server,
                         bool request_client_certificate,
                         bool require_client_certificate,
-                        Dart_Handle protocols_handle) {
+                        Dart_Handle protocols_handle,
+                        Socket* socket,
+                        Dart_Handle transport_read,
+                        Dart_Handle transport_write) {
   is_server_ = is_server;
-  if (in_handshake_) {
+  if (ssl_ != nullptr) {
     FATAL("Connect called twice on the same _SecureFilter.");
   }
 
   int status;
-  int error;
-  BIO* ssl_side;
-  status = BIO_new_bio_pair(&ssl_side, kInternalBIOSize, &socket_side_,
-                            kInternalBIOSize);
-  SecureSocketUtils::CheckStatusSSL(status, "TlsException", "BIO_new_bio_pair",
-                                    ssl_);
+  ASSERT(socket_ == nullptr);
+  ASSERT(socket_fd_ == Socket::kClosedFd);
+  ASSERT(transport_read_ == nullptr);
+  ASSERT(transport_write_ == nullptr);
+  if (socket != nullptr) {
+    socket_ = socket;
+    socket_->Retain();
+    socket_fd_ = socket->fd();
+    Socket::RetainFd(socket_fd_);
+  } else {
+    if (!Dart_IsClosure(transport_read) || !Dart_IsClosure(transport_write)) {
+      Dart_ThrowException(DartUtils::NewDartArgumentError(
+          "SecureSocket transport callbacks must be closures"));
+    }
+    transport_read_ = Dart_NewPersistentHandle(transport_read);
+    transport_write_ = Dart_NewPersistentHandle(transport_write);
+    ASSERT(transport_read_ != nullptr);
+    ASSERT(transport_write_ != nullptr);
+  }
+
+  BIO* socket_bio = BIO_new(socket_bio_method_);
+  if (socket_bio == nullptr) {
+    SecureSocketUtils::ThrowIOException(0, "TlsException",
+                                        "Failed to create socket BIO", ssl_);
+  }
+  BIO_set_data(socket_bio, this);
+  BIO_set_init(socket_bio, 1);
 
   ASSERT(context != nullptr);
   ASSERT(context->context() != nullptr);
   ssl_ = SSL_new(context->context());
-  SSL_set_bio(ssl_, ssl_side, ssl_side);
-  SSL_set_mode(ssl_, SSL_MODE_AUTO_RETRY);  // TODO(whesse): Is this right?
+  if (ssl_ == nullptr) {
+    BIO_free(socket_bio);
+    SecureSocketUtils::ThrowIOException(
+        0, "TlsException", "Failed to create TLS connection", nullptr);
+  }
+  SSL_set_bio(ssl_, socket_bio, socket_bio);
+  SSL_set_mode(ssl_, SSL_MODE_AUTO_RETRY | SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER);
   SSL_set_ex_data(ssl_, filter_ssl_index, this);
 
   if (context->allow_tls_renegotiation()) {
@@ -552,36 +987,12 @@ void SSLFilter::Connect(const char* hostname,
     SecureSocketUtils::CheckStatusSSL(
         status, "TlsException", "Set hostname for certificate checking", ssl_);
   }
-  // Make the connection:
   if (is_server_) {
-    status = SSL_accept(ssl_);
-    if (SSL_LOG_STATUS) {
-      Syslog::Print("SSL_accept status: %d\n", status);
-    }
-    if (status != 1) {
-      // TODO(whesse): expect a needs-data error here.  Handle other errors.
-      error = SSL_get_error(ssl_, status);
-      if (SSL_LOG_STATUS) {
-        Syslog::Print("SSL_accept error: %d\n", error);
-      }
-    }
+    SSL_set_accept_state(ssl_);
   } else {
-    status = SSL_connect(ssl_);
-    if (SSL_LOG_STATUS) {
-      Syslog::Print("SSL_connect status: %d\n", status);
-    }
-    if (status != 1) {
-      // TODO(whesse): expect a needs-data error here.  Handle other errors.
-      error = SSL_get_error(ssl_, status);
-      if (SSL_LOG_STATUS) {
-        Syslog::Print("SSL_connect error: %d\n", error);
-      }
-    }
+    SSL_set_connect_state(ssl_);
   }
-  // We don't expect certificate evaluation on first attempt,
-  // we expect requests for more bytes, therefore we could get away
-  // with passing illegal port.
-  Handshake(ILLEGAL_PORT);
+  in_handshake_ = true;
 }
 
 void SSLFilter::MarkAsTrusted(Dart_NativeArguments args) {
@@ -598,6 +1009,14 @@ void SSLFilter::MarkAsTrusted(Dart_NativeArguments args) {
 }
 
 int SSLFilter::Handshake(Dart_Port reply_port) {
+  if (ssl_ == nullptr) {
+    SecureSocketUtils::ThrowIOException(
+        0, "HandshakeException",
+        "TLS handshake started before the connection was initialized",
+        nullptr);
+    return SSL_ERROR_SSL;
+  }
+
   // Set reply port to be used by CertificateVerificationCallback
   // invoked by SSL_do_handshake: this is where results of
   // certificate evaluation will be communicated to.
@@ -606,19 +1025,19 @@ int SSLFilter::Handshake(Dart_Port reply_port) {
   // Try and push handshake along.
   int status = SSL_do_handshake(ssl_);
   int error = SSL_get_error(ssl_, status);
-  if (error == SSL_ERROR_WANT_CERTIFICATE_VERIFY) {
-    return SSL_ERROR_WANT_CERTIFICATE_VERIFY;
-  }
   if (callback_error != nullptr) {
-    // The SSL_do_handshake will try performing a handshake and might call one
-    // or both of:
+    // The SSL_do_handshake will try performing a handshake and might call:
     //   SSLCertContext::KeyLogCallback
     //   SSLCertContext::CertificateCallback
+    //   the Dart RawSocket transport callbacks
     //
     // If either of those functions fail, and this.callback_error has not
     // already been set, then they will set this.callback_error to an error
     // handle i.e. only the first error will be captured and propagated.
     Dart_PropagateError(callback_error);
+  }
+  if (error == SSL_ERROR_WANT_CERTIFICATE_VERIFY) {
+    return SSL_ERROR_WANT_CERTIFICATE_VERIFY;
   }
   if (SSL_want_write(ssl_) || SSL_want_read(ssl_)) {
     in_handshake_ = true;
@@ -669,17 +1088,28 @@ void SSLFilter::FreeResources() {
     SSL_free(ssl_);
     ssl_ = nullptr;
   }
-  if (socket_side_ != nullptr) {
-    BIO_free(socket_side_);
-    socket_side_ = nullptr;
+  if (socket_fd_ != Socket::kClosedFd) {
+    Socket::ReleaseFd(socket_fd_);
+    socket_fd_ = Socket::kClosedFd;
   }
+  if (socket_ != nullptr) {
+    socket_->Release();
+    socket_ = nullptr;
+  }
+  if (prefetched_data_ != nullptr) {
+    delete[] prefetched_data_;
+    prefetched_data_ = nullptr;
+  }
+  prefetched_data_offset_ = 0;
+  prefetched_data_length_ = 0;
+  prefetched_data_has_tail_ = false;
   if (hostname_ != nullptr) {
     free(hostname_);
     hostname_ = nullptr;
   }
   for (int i = 0; i < kNumBuffers; ++i) {
     if (buffers_[i] != nullptr) {
-      delete[] buffers_[i];
+      buffers_[i]->Release();
       buffers_[i] = nullptr;
     }
   }
@@ -690,20 +1120,6 @@ SSLFilter::~SSLFilter() {
 }
 
 void SSLFilter::Destroy() {
-  for (int i = 0; i < kNumBuffers; ++i) {
-    if (dart_buffer_objects_[i] != nullptr) {
-      Dart_DeletePersistentHandle(dart_buffer_objects_[i]);
-      dart_buffer_objects_[i] = nullptr;
-    }
-  }
-  if (string_start_ != nullptr) {
-    Dart_DeletePersistentHandle(string_start_);
-    string_start_ = nullptr;
-  }
-  if (string_length_ != nullptr) {
-    Dart_DeletePersistentHandle(string_length_);
-    string_length_ = nullptr;
-  }
   if (handshake_complete_ != nullptr) {
     Dart_DeletePersistentHandle(handshake_complete_);
     handshake_complete_ = nullptr;
@@ -711,6 +1127,14 @@ void SSLFilter::Destroy() {
   if (bad_certificate_callback_ != nullptr) {
     Dart_DeletePersistentHandle(bad_certificate_callback_);
     bad_certificate_callback_ = nullptr;
+  }
+  if (transport_read_ != nullptr) {
+    Dart_DeletePersistentHandle(transport_read_);
+    transport_read_ = nullptr;
+  }
+  if (transport_write_ != nullptr) {
+    Dart_DeletePersistentHandle(transport_write_);
+    transport_write_ = nullptr;
   }
   FreeResources();
 }
@@ -724,10 +1148,14 @@ int SSLFilter::ProcessReadPlaintextBuffer(int start, int end) {
                   length);
   }
   if (length > 0) {
+    last_os_error_ = 0;
     bytes_processed = SSL_read(
-        ssl_, reinterpret_cast<char*>((buffers_[kReadPlaintext] + start)),
+        ssl_, reinterpret_cast<char*>(buffers_[kReadPlaintext]->data() + start),
         length);
-    if (bytes_processed < 0) {
+    if (callback_error != nullptr) {
+      Dart_PropagateError(callback_error);
+    }
+    if (bytes_processed <= 0) {
       int error = SSL_get_error(ssl_, bytes_processed);
       if (SSL_LOG_DATA) {
         Syslog::Print("SSL_read returned error %d\n", error);
@@ -735,6 +1163,8 @@ int SSLFilter::ProcessReadPlaintextBuffer(int start, int end) {
       switch (error) {
         case SSL_ERROR_SYSCALL:
         case SSL_ERROR_SSL:
+          last_ssl_status_ = bytes_processed;
+          last_ssl_error_ = error;
           return -1;
         default:
           break;
@@ -755,71 +1185,30 @@ int SSLFilter::ProcessWritePlaintextBuffer(int start, int end) {
     Syslog::Print("Entering ProcessWritePlaintextBuffer with %d bytes\n",
                   length);
   }
+  last_os_error_ = 0;
   int bytes_processed =
-      SSL_write(ssl_, buffers_[kWritePlaintext] + start, length);
-  if (bytes_processed < 0) {
+      SSL_write(ssl_, buffers_[kWritePlaintext]->data() + start, length);
+  if (callback_error != nullptr) {
+    Dart_PropagateError(callback_error);
+  }
+  if (bytes_processed <= 0) {
+    int error = SSL_get_error(ssl_, bytes_processed);
     if (SSL_LOG_DATA) {
-      Syslog::Print("SSL_write returned error %d\n", bytes_processed);
+      Syslog::Print("SSL_write returned error %d\n", error);
     }
-    return 0;
+    switch (error) {
+      case SSL_ERROR_SYSCALL:
+      case SSL_ERROR_SSL:
+        last_ssl_status_ = bytes_processed;
+        last_ssl_error_ = error;
+        return -1;
+      default:
+        return 0;
+    }
   }
   if (SSL_LOG_DATA) {
     Syslog::Print("Leaving ProcessWritePlaintextBuffer wrote %d bytes\n",
                   bytes_processed);
-  }
-  return bytes_processed;
-}
-
-/* Read encrypted data from the circular buffer to the filter */
-int SSLFilter::ProcessReadEncryptedBuffer(int start, int end) {
-  int length = end - start;
-  if (SSL_LOG_DATA) {
-    Syslog::Print("Entering ProcessReadEncryptedBuffer with %d bytes\n",
-                  length);
-  }
-  int bytes_processed = 0;
-  if (length > 0) {
-    bytes_processed =
-        BIO_write(socket_side_, buffers_[kReadEncrypted] + start, length);
-    if (bytes_processed <= 0) {
-      bool retry = BIO_should_retry(socket_side_) != 0;
-      if (!retry) {
-        if (SSL_LOG_DATA) {
-          Syslog::Print("BIO_write failed in ReadEncryptedBuffer\n");
-        }
-      }
-      bytes_processed = 0;
-    }
-  }
-  if (SSL_LOG_DATA) {
-    Syslog::Print("Leaving ProcessReadEncryptedBuffer read %d bytes\n",
-                  bytes_processed);
-  }
-  return bytes_processed;
-}
-
-int SSLFilter::ProcessWriteEncryptedBuffer(int start, int end) {
-  int length = end - start;
-  int bytes_processed = 0;
-  if (SSL_LOG_DATA) {
-    Syslog::Print("Entering ProcessWriteEncryptedBuffer with %d bytes\n",
-                  length);
-  }
-  if (length > 0) {
-    bytes_processed =
-        BIO_read(socket_side_, buffers_[kWriteEncrypted] + start, length);
-    if (bytes_processed < 0) {
-      if (SSL_LOG_DATA) {
-        Syslog::Print("WriteEncrypted BIO_read returned error %d\n",
-                      bytes_processed);
-      }
-      return 0;
-    } else {
-      if (SSL_LOG_DATA) {
-        Syslog::Print("WriteEncrypted  BIO_read wrote %d bytes\n",
-                      bytes_processed);
-      }
-    }
   }
   return bytes_processed;
 }

--- a/runtime/bin/secure_socket_filter.h
+++ b/runtime/bin/secure_socket_filter.h
@@ -38,20 +38,40 @@ class X509TrustState {
   DISALLOW_COPY_AND_ASSIGN(X509TrustState);
 };
 
+// Owns one immutable generation of a plaintext ring's backing storage. The
+// SSLFilter and the Dart ExternalUint8List each retain a reference, so a
+// replaced generation remains valid until neither side can access it.
+class SSLFilterBuffer : public ReferenceCounted<SSLFilterBuffer> {
+ public:
+  explicit SSLFilterBuffer(int size);
+  ~SSLFilterBuffer() override;
+
+  uint8_t* data() const { return data_; }
+  int size() const { return size_; }
+
+ private:
+  uint8_t* const data_;
+  const int size_;
+
+  DISALLOW_COPY_AND_ASSIGN(SSLFilterBuffer);
+};
+
+// Owns the BoringSSL connection and two shared plaintext rings. Its custom BIO
+// uses a retained native socket when available and falls back to Dart RawSocket
+// callbacks for other implementations. It never owns a ciphertext queue. All
+// TLS operations are serialized by the Dart isolate.
 class SSLFilter : public ReferenceCounted<SSLFilter> {
  public:
   static void Init();
   static void Cleanup();
 
   // These enums must agree with those in sdk/lib/io/secure_socket.dart.
-  enum BufferIndex {
-    kReadPlaintext,
-    kWritePlaintext,
-    kReadEncrypted,
-    kWriteEncrypted,
-    kNumBuffers,
-    kFirstEncrypted = kReadEncrypted
-  };
+  enum BufferIndex { kReadPlaintext, kWritePlaintext, kNumBuffers };
+
+  // TLS upgrades may provide bytes which were read before the socket was
+  // handed to SecureSocket. Keep only a small, bounded chunk in native memory
+  // while those bytes are drained. Normal socket traffic bypasses this queue.
+  static constexpr intptr_t kMaxPrefetchedData = 16 * KB;
 
   static const intptr_t kApproximateSize;
   static constexpr int kSSLFilterNativeFieldIndex = 0;
@@ -59,27 +79,44 @@ class SSLFilter : public ReferenceCounted<SSLFilter> {
   SSLFilter()
       : callback_error(nullptr),
         ssl_(nullptr),
-        socket_side_(nullptr),
-        string_start_(nullptr),
-        string_length_(nullptr),
+        socket_(nullptr),
+        socket_fd_(Socket::kClosedFd),
+        transport_read_(nullptr),
+        transport_write_(nullptr),
+        prefetched_data_(nullptr),
+        prefetched_data_offset_(0),
+        prefetched_data_length_(0),
+        prefetched_data_has_tail_(false),
+        socket_read_bytes_(0),
+        socket_write_bytes_(0),
+        max_buffer_size_(0),
+        last_ssl_status_(0),
+        last_ssl_error_(SSL_ERROR_NONE),
+        last_os_error_(0),
         handshake_complete_(nullptr),
         bad_certificate_callback_(nullptr),
         in_handshake_(false),
-        hostname_(nullptr) {}
+        hostname_(nullptr) {
+    for (int i = 0; i < kNumBuffers; ++i) {
+      buffers_[i] = nullptr;
+    }
+  }
 
   ~SSLFilter();
 
   char* hostname() const { return hostname_; }
   bool is_server() const { return is_server_; }
   bool is_client() const { return !is_server_; }
-
   Dart_Handle Init(Dart_Handle dart_this);
   void Connect(const char* hostname,
                SSLCertContext* context,
                bool is_server,
                bool request_client_certificate,
                bool require_client_certificate,
-               Dart_Handle protocols_handle);
+               Dart_Handle protocols_handle,
+               class Socket* socket,
+               Dart_Handle transport_read,
+               Dart_Handle transport_write);
   void Destroy();
   void FreeResources();
   void MarkAsTrusted(Dart_NativeArguments args);
@@ -94,16 +131,58 @@ class SSLFilter : public ReferenceCounted<SSLFilter> {
   }
   int ProcessReadPlaintextBuffer(int start, int end);
   int ProcessWritePlaintextBuffer(int start, int end);
-  int ProcessReadEncryptedBuffer(int start, int end);
-  int ProcessWriteEncryptedBuffer(int start, int end);
   bool ProcessAllBuffers(int starts[kNumBuffers],
                          int ends[kNumBuffers],
-                         bool in_handshake);
+                         int sizes[kNumBuffers]);
+  Dart_Handle GrowBuffer(int buffer_index,
+                         int start,
+                         int end,
+                         int old_size,
+                         int new_size);
+  intptr_t QueuePrefetchedData(Dart_Handle data, intptr_t offset);
+  bool HasPrefetchedData() const {
+    return prefetched_data_offset_ < prefetched_data_length_;
+  }
+  bool HasPendingPlaintext() const {
+    return ssl_ != nullptr && SSL_pending(ssl_) > 0;
+  }
+  bool WantsWrite() const { return ssl_ != nullptr && SSL_want_write(ssl_); }
+  bool HasPendingSocketWrite() const;
+  intptr_t TakeSocketReadBytes() {
+    const intptr_t result = socket_read_bytes_;
+    socket_read_bytes_ = 0;
+    return result;
+  }
+  intptr_t TakeSocketWriteBytes() {
+    const intptr_t result = socket_write_bytes_;
+    socket_write_bytes_ = 0;
+    return result;
+  }
+  void ThrowFilterError();
+  static bool IsValidBufferRange(int start, int end, int size) {
+    return start >= 0 && end >= 0 && start < size && end < size;
+  }
+  static intptr_t BoundedPrefetchedDataLength(intptr_t data_length,
+                                              intptr_t offset) {
+    if (data_length < 0 || offset < 0 || offset > data_length) return -1;
+    const intptr_t remaining = data_length - offset;
+    return remaining > kMaxPrefetchedData ? kMaxPrefetchedData : remaining;
+  }
+  static bool PrefetchedDataHasTail(intptr_t data_length,
+                                    intptr_t offset,
+                                    intptr_t chunk_length) {
+    if (data_length < 0 || offset < 0 || offset > data_length ||
+        chunk_length < 0 || chunk_length > data_length - offset) {
+      return false;
+    }
+    return chunk_length < data_length - offset;
+  }
   Dart_Handle PeerCertificate();
   static void InitializeLibrary();
   Dart_Handle callback_error;
-
-  static CObject* ProcessFilterRequest(const CObjectArray& request);
+  void SetCallbackError(Dart_Handle error) {
+    if (callback_error == nullptr) callback_error = error;
+  }
 
   // The index of the external data field in _ssl that points to the SSLFilter.
   static int filter_ssl_index;
@@ -118,23 +197,49 @@ class SSLFilter : public ReferenceCounted<SSLFilter> {
   static Dart_Port TrustEvaluateReplyPort();
 
  private:
-  static const intptr_t kInternalBIOSize;
   static bool library_initialized_;
   static Mutex* mutex_;  // To protect library initialization.
   static Dart_Port trust_evaluate_reply_port_;
+  static BIO_METHOD* socket_bio_method_;
+
+  static int SocketBIORead(BIO* bio, char* output, int length);
+  static int SocketBIOWrite(BIO* bio,
+                            const char* input,
+                            size_t length,
+                            size_t* written);
+  static long SocketBIOControl(BIO* bio,
+                               int command,
+                               long argument,
+                               void* pointer);
 
   SSL* ssl_;
-  BIO* socket_side_;
+  // The native socket and its underlying fd/handle are retained until SSL
+  // (and therefore its BIO) has been freed. socket_fd_ is cached at Connect
+  // time and protected via Socket::RetainFd / Socket::ReleaseFd to avoid
+  // Use-After-Free on platforms where fd is a heap Handle* (Windows/Fuchsia).
+  // For non-native RawSocket implementations the two persistent closures
+  // provide the transport instead.
+  class Socket* socket_;
+  intptr_t socket_fd_;
+  Dart_PersistentHandle transport_read_;
+  Dart_PersistentHandle transport_write_;
+  uint8_t* prefetched_data_;
+  intptr_t prefetched_data_offset_;
+  intptr_t prefetched_data_length_;
+  // Prevents the BIO from reading the socket between bounded chunks from the
+  // same Dart bufferedData value.
+  bool prefetched_data_has_tail_;
+  intptr_t socket_read_bytes_;
+  intptr_t socket_write_bytes_;
   // Currently only one(root) certificate is evaluated via
   // TrustEvaluate mechanism.
   std::unique_ptr<X509TrustState> certificate_trust_state_;
 
-  uint8_t* buffers_[kNumBuffers];
-  int buffer_size_;
-  int encrypted_buffer_size_;
-  Dart_PersistentHandle string_start_;
-  Dart_PersistentHandle string_length_;
-  Dart_PersistentHandle dart_buffer_objects_[kNumBuffers];
+  SSLFilterBuffer* buffers_[kNumBuffers];
+  int max_buffer_size_;
+  int last_ssl_status_;
+  int last_ssl_error_;
+  int last_os_error_;
   Dart_PersistentHandle handshake_complete_;
   Dart_PersistentHandle bad_certificate_callback_;
   bool in_handshake_;
@@ -144,9 +249,6 @@ class SSLFilter : public ReferenceCounted<SSLFilter> {
   Dart_Port reply_port_ = ILLEGAL_PORT;
   Dart_Port key_log_port_ = ILLEGAL_PORT;
 
-  static bool IsBufferEncrypted(int i) {
-    return static_cast<BufferIndex>(i) >= kFirstEncrypted;
-  }
   Dart_Handle InitializeBuffers(Dart_Handle dart_this);
   void InitializePlatformData();
 

--- a/runtime/bin/secure_socket_filter_test.cc
+++ b/runtime/bin/secure_socket_filter_test.cc
@@ -1,0 +1,52 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+#if !defined(DART_IO_SECURE_SOCKET_DISABLED)
+
+#include "bin/secure_socket_filter.h"
+
+#include "vm/unit_test.h"
+
+namespace dart {
+namespace bin {
+
+VM_UNIT_TEST_CASE(SSLFilter_BufferRangesAreBoundsChecked) {
+  EXPECT(SSLFilter::IsValidBufferRange(0, 0, 1));
+  EXPECT(SSLFilter::IsValidBufferRange(7, 0, 8));
+  EXPECT(!SSLFilter::IsValidBufferRange(-1, 0, 8));
+  EXPECT(!SSLFilter::IsValidBufferRange(0, -1, 8));
+  EXPECT(!SSLFilter::IsValidBufferRange(8, 0, 8));
+  EXPECT(!SSLFilter::IsValidBufferRange(0, 8, 8));
+  EXPECT(!SSLFilter::IsValidBufferRange(0, 0, 0));
+}
+
+VM_UNIT_TEST_CASE(SSLFilter_PrefetchedDataIsStrictlyBounded) {
+  EXPECT_EQ(0, SSLFilter::BoundedPrefetchedDataLength(0, 0));
+  EXPECT_EQ(1, SSLFilter::BoundedPrefetchedDataLength(1, 0));
+  EXPECT_EQ(1, SSLFilter::BoundedPrefetchedDataLength(10, 9));
+  EXPECT_EQ(SSLFilter::kMaxPrefetchedData,
+            SSLFilter::BoundedPrefetchedDataLength(
+                SSLFilter::kMaxPrefetchedData * 4, 0));
+  EXPECT_EQ(
+      SSLFilter::kMaxPrefetchedData,
+      SSLFilter::BoundedPrefetchedDataLength(SSLFilter::kMaxPrefetchedData * 4,
+                                             SSLFilter::kMaxPrefetchedData));
+  EXPECT_EQ(-1, SSLFilter::BoundedPrefetchedDataLength(1, -1));
+  EXPECT_EQ(-1, SSLFilter::BoundedPrefetchedDataLength(1, 2));
+  EXPECT_EQ(-1, SSLFilter::BoundedPrefetchedDataLength(-1, 0));
+
+  EXPECT(!SSLFilter::PrefetchedDataHasTail(0, 0, 0));
+  EXPECT(!SSLFilter::PrefetchedDataHasTail(1, 0, 1));
+  EXPECT(SSLFilter::PrefetchedDataHasTail(SSLFilter::kMaxPrefetchedData + 1, 0,
+                                          SSLFilter::kMaxPrefetchedData));
+  EXPECT(SSLFilter::PrefetchedDataHasTail(SSLFilter::kMaxPrefetchedData * 4,
+                                          SSLFilter::kMaxPrefetchedData,
+                                          SSLFilter::kMaxPrefetchedData));
+  EXPECT(!SSLFilter::PrefetchedDataHasTail(1, 2, 0));
+}
+
+}  // namespace bin
+}  // namespace dart
+
+#endif  // !defined(DART_IO_SECURE_SOCKET_DISABLED)

--- a/runtime/bin/secure_socket_unsupported.cc
+++ b/runtime/bin/secure_socket_unsupported.cc
@@ -53,6 +53,11 @@ void FUNCTION_NAME(SecureSocket_GetSelectedProtocol)(
       "Secure Sockets unsupported on this platform"));
 }
 
+void FUNCTION_NAME(SecureSocket_GrowBuffer)(Dart_NativeArguments args) {
+  Dart_ThrowException(DartUtils::NewDartArgumentError(
+      "Secure Sockets unsupported on this platform"));
+}
+
 void FUNCTION_NAME(SecureSocket_RegisterHandshakeCompleteCallback)(
     Dart_NativeArguments args) {
   Dart_ThrowException(DartUtils::NewDartArgumentError(
@@ -85,7 +90,13 @@ void FUNCTION_NAME(SecureSocket_PeerCertificate)(Dart_NativeArguments args) {
       "Secure Sockets unsupported on this platform"));
 }
 
-void FUNCTION_NAME(SecureSocket_FilterPointer)(Dart_NativeArguments args) {
+void FUNCTION_NAME(SecureSocket_Process)(Dart_NativeArguments args) {
+  Dart_ThrowException(DartUtils::NewDartArgumentError(
+      "Secure Sockets unsupported on this platform"));
+}
+
+void FUNCTION_NAME(SecureSocket_QueuePrefetchedData)(
+    Dart_NativeArguments args) {
   Dart_ThrowException(DartUtils::NewDartArgumentError(
       "Secure Sockets unsupported on this platform"));
 }
@@ -187,15 +198,6 @@ void FUNCTION_NAME(X509_EndValidity)(Dart_NativeArguments args) {
 void FUNCTION_NAME(X509_Pem)(Dart_NativeArguments args) {
   Dart_ThrowException(DartUtils::NewDartArgumentError(
       "Secure Sockets unsupported on this platform"));
-}
-
-class SSLFilter {
- public:
-  static CObject* ProcessFilterRequest(const CObjectArray& request);
-};
-
-CObject* SSLFilter::ProcessFilterRequest(const CObjectArray& request) {
-  return CObject::IllegalArgumentError();
 }
 
 }  // namespace bin

--- a/runtime/bin/socket.h
+++ b/runtime/bin/socket.h
@@ -58,6 +58,21 @@ class Socket : public ReferenceCounted<Socket> {
   // release handle but only SetClosedFd().
   void SetClosedFd();
 
+  // RetainFd and ReleaseFd manage the lifetime of the underlying descriptor
+  // or handle object associated with |fd|.
+  //
+  // On POSIX platforms, |fd| is an integer kernel file descriptor and these
+  // operations are no-ops.
+  //
+  // On Windows and Fuchsia, |fd| is a pointer to a reference-counted heap object
+  // (Handle* on Windows, IOHandle* on Fuchsia). If an external consumer (such
+  // as BoringSSL custom socket BIO) retains the raw fd across asynchronous
+  // operations while the Dart socket object might be closed or garbage-collected,
+  // RetainFd must be called to prevent Use-After-Free, and ReleaseFd must be
+  // called once the consumer is done with the descriptor.
+  static void RetainFd(intptr_t fd);
+  static void ReleaseFd(intptr_t fd);
+
   Dart_Port isolate_port() const { return isolate_port_; }
 
   Dart_Port port() const { return port_; }
@@ -107,10 +122,11 @@ class Socket : public ReferenceCounted<Socket> {
   static void set_short_socket_write(bool short_socket_write) {
     short_socket_write_ = short_socket_write;
   }
-
   static bool IsSignalSocketFlag(intptr_t flag) {
     return ((flag & (0x1 << kInternalSignalSocket)) != 0);
   }
+
+  static constexpr int kClosedFd = -1;
 
  private:
   ~Socket() {
@@ -118,8 +134,6 @@ class Socket : public ReferenceCounted<Socket> {
     free(udp_receive_buffer_);
     udp_receive_buffer_ = nullptr;
   }
-
-  static constexpr int kClosedFd = -1;
 
   static bool short_socket_read_;
   static bool short_socket_write_;

--- a/runtime/bin/socket_fuchsia.cc
+++ b/runtime/bin/socket_fuchsia.cc
@@ -62,6 +62,18 @@ void Socket::CloseFd() {
   SetClosedFd();
 }
 
+void Socket::RetainFd(intptr_t fd) {
+  if (fd != kClosedFd) {
+    reinterpret_cast<IOHandle*>(fd)->Retain();
+  }
+}
+
+void Socket::ReleaseFd(intptr_t fd) {
+  if (fd != kClosedFd) {
+    reinterpret_cast<IOHandle*>(fd)->Release();
+  }
+}
+
 static intptr_t Create(const RawAddr& addr) {
   LOG_INFO("Create: calling socket(SOCK_STREAM)\n");
   intptr_t fd = NO_RETRY_EXPECTED(socket(addr.ss.ss_family, SOCK_STREAM, 0));

--- a/runtime/bin/socket_linux.cc
+++ b/runtime/bin/socket_linux.cc
@@ -32,6 +32,14 @@ void Socket::SetClosedFd() {
   fd_ = kClosedFd;
 }
 
+void Socket::RetainFd(intptr_t fd) {
+  static_cast<void>(fd);
+}
+
+void Socket::ReleaseFd(intptr_t fd) {
+  static_cast<void>(fd);
+}
+
 static intptr_t Create(const RawAddr& addr) {
   intptr_t fd;
   intptr_t type = SOCK_STREAM | SOCK_NONBLOCK | SOCK_CLOEXEC;

--- a/runtime/bin/socket_macos.cc
+++ b/runtime/bin/socket_macos.cc
@@ -30,6 +30,14 @@ void Socket::SetClosedFd() {
   fd_ = kClosedFd;
 }
 
+void Socket::RetainFd(intptr_t fd) {
+  static_cast<void>(fd);
+}
+
+void Socket::ReleaseFd(intptr_t fd) {
+  static_cast<void>(fd);
+}
+
 static intptr_t Create(const RawAddr& addr) {
   intptr_t fd;
   fd = NO_RETRY_EXPECTED(socket(addr.ss.ss_family, SOCK_STREAM, 0));

--- a/runtime/bin/socket_win.cc
+++ b/runtime/bin/socket_win.cc
@@ -42,6 +42,18 @@ void Socket::SetClosedFd() {
   fd_ = kClosedFd;
 }
 
+void Socket::RetainFd(intptr_t fd) {
+  if (fd != kClosedFd) {
+    reinterpret_cast<Handle*>(fd)->Retain();
+  }
+}
+
+void Socket::ReleaseFd(intptr_t fd) {
+  if (fd != kClosedFd) {
+    reinterpret_cast<Handle*>(fd)->Release();
+  }
+}
+
 static intptr_t Create(const RawAddr& addr) {
   SOCKET s = socket(addr.ss.ss_family, SOCK_STREAM, 0);
   if (s == INVALID_SOCKET) {

--- a/sdk/lib/_internal/vm/bin/secure_socket_patch.dart
+++ b/sdk/lib/_internal/vm/bin/secure_socket_patch.dart
@@ -55,26 +55,27 @@ class _SecureSocket extends _Socket implements SecureSocket {
  * over an encrypted socket.  The filter also handles the handshaking
  * and certificate verification.
  *
- * The filter exposes its input and output buffers as Dart objects that
- * are backed by an external C array of bytes, so that both Dart code and
- * native code can access the same data.
+ * The filter exposes its plaintext input and output buffers as Dart objects
+ * backed by external C arrays. A non-buffering custom BIO sends encrypted bytes
+ * directly to a native socket, or through RawSocket callbacks for public
+ * implementations which do not expose a native transport.
  */
 @pragma("vm:entry-point")
 base class _SecureFilterImpl extends NativeFieldWrapperClass1
     implements _SecureFilter {
-  // Performance is improved if a full buffer of plaintext fits
-  // in the encrypted buffer, when encrypted.
-  // SIZE and ENCRYPTED_SIZE are referenced from C++.
+  // SIZE is the maximum backing allocation and is referenced from C++.
   @pragma("vm:entry-point")
-  static final int SIZE = 8 * 1024;
-  @pragma("vm:entry-point")
-  static final int ENCRYPTED_SIZE = 10 * 1024;
+  static final int SIZE = 16 * 1024 + 1;
+  static const int _initialSize = 1 * 1024 + 1;
 
   _SecureFilterImpl._() {
     buffers = <_ExternalBuffer>[
       for (int i = 0; i < _RawSecureSocket.bufferCount; ++i)
         _ExternalBuffer(
-          _RawSecureSocket._isBufferEncrypted(i) ? ENCRYPTED_SIZE : SIZE,
+          SIZE,
+          initialSize: _initialSize,
+          growBacking: (start, end, oldSize, newSize) =>
+              _growBuffer(i, start, end, oldSize, newSize),
         ),
     ];
   }
@@ -87,6 +88,9 @@ base class _SecureFilterImpl extends NativeFieldWrapperClass1
     bool requestClientCertificate,
     bool requireClientCertificate,
     Uint8List protocols,
+    Object? nativeSocket,
+    Uint8List? Function(int)? transportRead,
+    int Function(Uint8List)? transportWrite,
   );
 
   void destroy() {
@@ -98,7 +102,7 @@ base class _SecureFilterImpl extends NativeFieldWrapperClass1
   external void _destroy();
 
   @pragma("vm:external-name", "SecureSocket_Handshake")
-  external int _handshake(SendPort replyPort);
+  external List<Object?> _handshake(SendPort replyPort);
 
   @pragma("vm:external-name", "SecureSocket_MarkAsTrusted")
   external void _markAsTrusted(int certificatePtr, bool isTrusted);
@@ -108,8 +112,8 @@ base class _SecureFilterImpl extends NativeFieldWrapperClass1
     int certificatePtr,
   );
 
-  Future<bool> handshake() {
-    Completer<bool> evaluatorCompleter = Completer<bool>();
+  Future<List<Object?>> handshake() {
+    Completer<void> evaluatorCompleter = Completer<void>();
 
     ReceivePort rpEvaluateResponse = ReceivePort();
     rpEvaluateResponse.listen((data) {
@@ -136,30 +140,45 @@ base class _SecureFilterImpl extends NativeFieldWrapperClass1
         }
       }
       _markAsTrusted(certificatePtr, isTrusted);
-      evaluatorCompleter.complete(true);
+      evaluatorCompleter.complete();
       rpEvaluateResponse.close();
     });
 
     const int kSslErrorWantCertificateVerify = 16; // ssl.h:558
-    int handshakeResult;
+    List<Object?> handshakeResult;
     try {
       handshakeResult = _handshake(rpEvaluateResponse.sendPort);
     } catch (e, st) {
       rpEvaluateResponse.close();
       rethrow;
     }
-    if (handshakeResult == kSslErrorWantCertificateVerify) {
-      return evaluatorCompleter.future;
+    if (handshakeResult[0] == kSslErrorWantCertificateVerify) {
+      return evaluatorCompleter.future.then((_) => handshakeResult);
     } else {
       // Response is ready, no need for evaluate response receive port
       rpEvaluateResponse.close();
-      return Future<bool>.value(false);
+      return Future<List<Object?>>.value(handshakeResult);
     }
   }
 
   void rehandshake() => throw UnimplementedError();
 
   int processBuffer(int bufferIndex) => throw UnimplementedError();
+
+  @pragma("vm:external-name", "SecureSocket_Process")
+  external List<Object?> process(List<int> positions);
+
+  @pragma("vm:external-name", "SecureSocket_GrowBuffer")
+  external Uint8List _growBuffer(
+    int bufferIndex,
+    int start,
+    int end,
+    int oldSize,
+    int newSize,
+  );
+
+  @pragma("vm:external-name", "SecureSocket_QueuePrefetchedData")
+  external int queuePrefetchedData(List<int> data, int offset);
 
   @pragma("vm:external-name", "SecureSocket_GetSelectedProtocol")
   external String? selectedProtocol();
@@ -189,10 +208,6 @@ base class _SecureFilterImpl extends NativeFieldWrapperClass1
 
   @pragma("vm:external-name", "SecureSocket_RegisterKeyLogPort")
   external void registerKeyLogPort(SendPort port);
-
-  // This is a security issue, as it exposes a raw pointer to Dart code.
-  @pragma("vm:external-name", "SecureSocket_FilterPointer")
-  external int _pointer();
 
   @pragma("vm:entry-point")
   List<_ExternalBuffer>? buffers;

--- a/sdk/lib/_internal/vm/bin/socket_patch.dart
+++ b/sdk/lib/_internal/vm/bin/socket_patch.dart
@@ -2263,6 +2263,34 @@ class _RawServerSocket extends Stream<RawSocket>
 
   bool get _closedReadEventSent => _socket.closedReadEventSent;
 
+  Object get _nativeSocket => _socket;
+
+  void _syncNativeSocketState(bool wantsWrite, bool hasPendingWrite) {
+    if (!_socket.isClosing && !_socket.isClosed) {
+      _socket.available = _socket._nativeAvailable();
+    }
+    _socket.writeAvailable = !wantsWrite && !hasPendingWrite;
+  }
+
+  void _recordNativeSocketIO(int readBytes, int writeBytes) {
+    if (!const bool.fromEnvironment("dart.vm.product")) {
+      if (readBytes > 0) {
+        _SocketProfile.collectStatistic(
+          _socket.id,
+          _SocketProfileType.readBytes,
+          readBytes,
+        );
+      }
+      if (writeBytes > 0) {
+        _SocketProfile.collectStatistic(
+          _socket.id,
+          _SocketProfileType.writeBytes,
+          writeBytes,
+        );
+      }
+    }
+  }
+
   void set _owner(owner) {
     _socket.owner = owner;
   }
@@ -2476,6 +2504,34 @@ class _RawSocket extends Stream<RawSocketEvent>
   }
 
   bool get _closedReadEventSent => _socket.closedReadEventSent;
+
+  Object get _nativeSocket => _socket;
+
+  void _syncNativeSocketState(bool wantsWrite, bool hasPendingWrite) {
+    if (!_socket.isClosing && !_socket.isClosed) {
+      _socket.available = _socket._nativeAvailable();
+    }
+    _socket.writeAvailable = !wantsWrite && !hasPendingWrite;
+  }
+
+  void _recordNativeSocketIO(int readBytes, int writeBytes) {
+    if (!const bool.fromEnvironment("dart.vm.product")) {
+      if (readBytes > 0) {
+        _SocketProfile.collectStatistic(
+          _socket.id,
+          _SocketProfileType.readBytes,
+          readBytes,
+        );
+      }
+      if (writeBytes > 0) {
+        _SocketProfile.collectStatistic(
+          _socket.id,
+          _SocketProfileType.writeBytes,
+          writeBytes,
+        );
+      }
+    }
+  }
 
   void set _owner(owner) {
     _socket.owner = owner;

--- a/sdk/lib/io/io_service.dart
+++ b/sdk/lib/io/io_service.dart
@@ -49,7 +49,5 @@ class _IOService {
   static const int directoryListNext = 40;
   static const int directoryListStop = 41;
   static const int directoryRename = 42;
-  static const int sslProcessFilter = 43;
-
   external static Future<Object?> _dispatch(int request, List data);
 }

--- a/sdk/lib/io/secure_socket.dart
+++ b/sdk/lib/io/secure_socket.dart
@@ -519,22 +519,44 @@ abstract interface class X509Certificate {
 }
 
 class _FilterStatus {
-  bool progress = false; // The filter read or wrote data to the buffers.
-  bool readEmpty = true; // The read buffers and decryption filter are empty.
-  bool writeEmpty = true; // The write buffers and encryption filter are empty.
+  bool progress = false; // The filter made buffer or transport progress.
+  bool readEmpty = true; // The plaintext and prefetched input are empty.
+  bool writeEmpty = true; // The plaintext and TLS transport are empty.
   // These are set if a buffer changes state from empty or full.
   bool readPlaintextNoLongerEmpty = false;
   bool writePlaintextNoLongerFull = false;
-  bool readEncryptedNoLongerFull = false;
-  bool writeEncryptedNoLongerEmpty = false;
+  bool wantsWrite = false;
+  bool hasPendingSocketWrite = false;
+  bool hasPendingPlaintext = false;
 
   _FilterStatus();
+}
+
+class _DartRawSocketTransport {
+  final RawSocket socket;
+  bool _readClosed = false;
+  bool writePending = false;
+
+  _DartRawSocketTransport(this.socket);
+
+  Uint8List? read(int length) => _readClosed ? null : socket.read(length);
+
+  void closeRead() => _readClosed = true;
+
+  int write(Uint8List data) {
+    final written = socket.write(data);
+    if (Platform.isWindows && written > 0) writePending = true;
+    return written;
+  }
 }
 
 // Interface used by [RawSecureServerSocket] and [_RawSecureSocket] that exposes
 // members of [_NativeSocket].
 abstract interface class _RawSocketBase {
   bool get _closedReadEventSent;
+  Object? get _nativeSocket;
+  void _syncNativeSocketState(bool wantsWrite, bool hasPendingWrite);
+  void _recordNativeSocketIO(int readBytes, int writeBytes);
   void set _owner(owner);
 }
 
@@ -545,19 +567,20 @@ class _RawSecureSocket extends Stream<RawSocketEvent>
   static const int connectedStatus = 202;
   static const int closedStatus = 203;
 
+  // BoringSSL SSL_ERROR_* values returned by _SecureFilter.handshake.
+  static const int sslErrorWantWrite = 3;
+  static const int sslErrorWantCertificateVerify = 16;
+
   // Buffer identifiers.
   // These must agree with those in the native C++ implementation.
   static const int readPlaintextId = 0;
   static const int writePlaintextId = 1;
-  static const int readEncryptedId = 2;
-  static const int writeEncryptedId = 3;
-  static const int bufferCount = 4;
-
-  // Is a buffer identifier for an encrypted buffer?
-  static bool _isBufferEncrypted(int identifier) =>
-      identifier >= readEncryptedId;
+  static const int bufferCount = 2;
 
   final RawSocket _socket;
+  late final _RawSocketBase? _rawSocketBase;
+  late final Object? _nativeTransport;
+  late final _DartRawSocketTransport? _dartTransport;
   final Completer<_RawSecureSocket> _handshakeComplete =
       Completer<_RawSecureSocket>();
   final _controller = StreamController<RawSocketEvent>(sync: true);
@@ -578,6 +601,7 @@ class _RawSecureSocket extends Stream<RawSocketEvent>
   bool _readEventsEnabled = true;
   int _pauseCount = 0;
   bool _pendingReadEvent = false;
+  bool _pendingWriteEvent = false;
   bool _socketClosedRead = false; // The network socket is closed for reading.
   bool _socketClosedWrite = false; // The network socket is closed for writing.
   bool _closedRead = false; // The secure socket has fired an onClosed event.
@@ -588,6 +612,11 @@ class _RawSecureSocket extends Stream<RawSocketEvent>
   bool _connectPending = true;
   bool _filterPending = false;
   bool _filterActive = false;
+  bool _handshakePending = false;
+  bool _handshakeActive = false;
+  Completer<void>? _handshakeRun;
+  bool _hasNativePrefetchedData = false;
+  bool _secureFilterConnected = false;
 
   _SecureFilter? _secureFilter = _SecureFilter._();
   String? _selectedProtocol;
@@ -647,6 +676,13 @@ class _RawSecureSocket extends Stream<RawSocketEvent>
     this.keyLog,
     List<String>? supportedProtocols,
   ) {
+    _rawSocketBase = _socket is _RawSocketBase
+        ? _socket as _RawSocketBase
+        : null;
+    _nativeTransport = _rawSocketBase?._nativeSocket;
+    _dartTransport = _nativeTransport == null
+        ? _DartRawSocketTransport(_socket)
+        : null;
     _controller
       ..onListen = _onSubscriptionStateChange
       ..onPause = _onPauseStateChange
@@ -681,6 +717,7 @@ class _RawSecureSocket extends Stream<RawSocketEvent>
     }
     _socket.readEventsEnabled = true;
     _socket.writeEventsEnabled = false;
+    var closedReadEventSent = false;
     if (subscription == null) {
       // If a current subscription is provided use this otherwise
       // create a new one.
@@ -695,11 +732,7 @@ class _RawSecureSocket extends Stream<RawSocketEvent>
         _socket.close();
         throw ArgumentError("Subscription passed to TLS upgrade is paused");
       }
-      // If we are upgrading a socket that is already closed for read,
-      // report an error as if we received readClosed during the handshake.
-      if (_closedReadEventSent) {
-        _eventDispatcher(RawSocketEvent.readClosed);
-      }
+      closedReadEventSent = _closedReadEventSent;
       _socketSubscription
         ..onData(_eventDispatcher)
         ..onError(_reportError)
@@ -716,8 +749,26 @@ class _RawSecureSocket extends Stream<RawSocketEvent>
         requestClientCertificate || requireClientCertificate,
         requireClientCertificate,
         encodedProtocols,
+        _nativeTransport,
+        _dartTransport?.read,
+        _dartTransport?.write,
       );
-      _secureHandshake();
+      _secureFilterConnected = true;
+      if (closedReadEventSent) {
+        _markSocketClosedRead();
+      }
+      if (_socketClosedRead) {
+        if (_bufferedData == null || _bufferedData!.isEmpty) {
+          _reportError(
+            HandshakeException('Connection terminated during handshake'),
+            null,
+          );
+        } else {
+          _closeHandler();
+        }
+      } else {
+        _secureHandshake();
+      }
     } catch (e, s) {
       _reportError(e, s);
     }
@@ -758,11 +809,62 @@ class _RawSecureSocket extends Stream<RawSocketEvent>
 
   int get remotePort => _socket.remotePort;
 
-  bool get _closedReadEventSent =>
-      (_socket as _RawSocketBase)._closedReadEventSent;
+  static _RawSocketBase? _extractRawSocketBase(RawSocket socket) {
+    if (socket is _RawSocketBase) return socket as _RawSocketBase;
+    try {
+      final dynamic dynamicSocket = socket;
+      final dynamic target = dynamicSocket.socket;
+      if (target is RawSocket) {
+        return _extractRawSocketBase(target as RawSocket);
+      }
+    } catch (_) {}
+    return null;
+  }
+
+  bool get _closedReadEventSent {
+    if (_closedRead || _socketClosedRead) return true;
+    final base = _rawSocketBase ?? _extractRawSocketBase(_socket);
+    if (base != null) return base._closedReadEventSent;
+    try {
+      final dynamic dynamicSocket = _socket;
+      final dynamic closed = dynamicSocket._closedReadEventSent;
+      if (closed is bool) return closed;
+    } catch (_) {}
+    return false;
+  }
+
+  // A RawSecureSocket is itself a public RawSocket transport. Returning null
+  // keeps a second TLS layer on top of this one instead of bypassing it and
+  // attaching the inner BIO to the original native socket.
+  Object? get _nativeSocket => null;
+
+  void _syncNativeSocketState(bool wantsWrite, bool hasPendingWrite) {
+    // This implementation is exposed as a non-native transport to another
+    // SecureSocket. Its own native transport is synchronized below.
+  }
+
+  void _recordNativeSocketIO(int readBytes, int writeBytes) {
+    // A TLS layer using this object as a transport calls its public read/write
+    // methods, so the innermost native transport records the bytes once.
+  }
+
+  void _syncNativeTransportState(bool wantsWrite, bool hasPendingWrite) {
+    if (_nativeTransport == null) return;
+    _rawSocketBase!._syncNativeSocketState(wantsWrite, hasPendingWrite);
+  }
+
+  void _recordNativeTransportIO(int readBytes, int writeBytes) {
+    if (_nativeTransport == null) return;
+    _rawSocketBase!._recordNativeSocketIO(readBytes, writeBytes);
+  }
+
+  void _markSocketClosedRead() {
+    _socketClosedRead = true;
+    _dartTransport?.closeRead();
+  }
 
   void set _owner(owner) {
-    (_socket as _RawSocketBase)._owner = owner;
+    _rawSocketBase?._owner = owner;
   }
 
   int available() {
@@ -780,22 +882,34 @@ class _RawSecureSocket extends Stream<RawSocketEvent>
     if (!_closeCompleter.isCompleted) _closeCompleter.complete(this);
   }
 
+  void _destroyFilterIfInactive() {
+    if (_status != closedStatus ||
+        _filterActive ||
+        _handshakeActive ||
+        _secureFilter == null) {
+      return;
+    }
+    _secureFilter!.destroy();
+    _secureFilter = null;
+  }
+
   void _close() {
+    if (_status == closedStatus) {
+      _destroyFilterIfInactive();
+      return;
+    }
+    _status = closedStatus;
     _closedWrite = true;
     _closedRead = true;
     _socket.close().then(_completeCloseCompleter);
     _socketClosedWrite = true;
-    _socketClosedRead = true;
-    if (!_filterActive && _secureFilter != null) {
-      _secureFilter!.destroy();
-      _secureFilter = null;
-    }
+    _markSocketClosedRead();
+    _destroyFilterIfInactive();
     keyLogPort?.close();
     if (_socketSubscription != null) {
       _socketSubscription.cancel();
     }
     _controller.close();
-    _status = closedStatus;
   }
 
   void shutdown(SocketDirection direction) {
@@ -813,7 +927,7 @@ class _RawSecureSocket extends Stream<RawSocketEvent>
     if (direction == SocketDirection.receive ||
         direction == SocketDirection.both) {
       _closedRead = true;
-      _socketClosedRead = true;
+      _markSocketClosedRead();
       _socket.shutdown(SocketDirection.receive);
       if (_socketClosedWrite) {
         _close();
@@ -826,7 +940,7 @@ class _RawSecureSocket extends Stream<RawSocketEvent>
   void set writeEventsEnabled(bool value) {
     _writeEventsEnabled = value;
     if (value) {
-      Timer.run(() => _sendWriteEvent());
+      _scheduleWriteEvent();
     }
   }
 
@@ -834,7 +948,10 @@ class _RawSecureSocket extends Stream<RawSocketEvent>
 
   void set readEventsEnabled(bool value) {
     _readEventsEnabled = value;
-    _socket.readEventsEnabled = value;
+    _socket.readEventsEnabled =
+        value &&
+        _secureFilter != null &&
+        _secureFilter!.buffers![readPlaintextId].free > 0;
     _scheduleReadEvent();
   }
 
@@ -850,8 +967,18 @@ class _RawSecureSocket extends Stream<RawSocketEvent>
     if (_status != connectedStatus) {
       return null;
     }
-    var result = _secureFilter!.buffers![readPlaintextId].read(length);
-    _scheduleFilter();
+    // A public RawSocket implementation is invoked synchronously by the
+    // custom BIO. It may reenter this socket before the native filter call has
+    // returned. Keep the positions and backing allocation passed to native
+    // code immutable for the duration of that call.
+    if (_filterActive) return null;
+    final buffer = _secureFilter!.buffers![readPlaintextId];
+    var result = buffer.read(length);
+    if (_socketClosedRead && buffer.isEmpty) {
+      scheduleMicrotask(_scheduleFilter);
+    } else {
+      _scheduleFilter();
+    }
     return result;
   }
 
@@ -872,10 +999,20 @@ class _RawSecureSocket extends Stream<RawSocketEvent>
       );
     }
     if (_closedWrite) {
-      _controller.addError(SocketException("Writing to a closed socket"));
+      // A filter error closes the controller before an already scheduled
+      // write event can be delivered. Do not replace the original TLS error
+      // with StateError from adding to that closed controller.
+      if (!_controller.isClosed) {
+        _controller.addError(SocketException("Writing to a closed socket"));
+      }
       return 0;
     }
     if (_status != connectedStatus) return 0;
+    // Treat a write reentered from a custom BIO transport callback as
+    // backpressure. Growing or otherwise mutating this ring while SSL_write is
+    // using its current generation would invalidate native pointers and ring
+    // positions.
+    if (_filterActive) return 0;
     bytes ??= data.length - offset;
 
     int written = _secureFilter!.buffers![writePlaintextId].write(
@@ -935,13 +1072,21 @@ class _RawSecureSocket extends Stream<RawSocketEvent>
   }
 
   void _readHandler() {
-    _readSocket();
-    _scheduleFilter();
+    if (_status == handshakeStatus) {
+      _secureHandshake();
+    } else {
+      _scheduleFilter();
+    }
   }
 
   void _writeHandler() {
-    _writeSocket();
-    _scheduleFilter();
+    final dartTransport = _dartTransport;
+    if (dartTransport != null) dartTransport.writePending = false;
+    if (_status == handshakeStatus) {
+      _secureHandshake();
+    } else {
+      _scheduleFilter();
+    }
   }
 
   void _doneHandler() {
@@ -967,21 +1112,19 @@ class _RawSecureSocket extends Stream<RawSocketEvent>
   void _closeHandler() async {
     if (_status == connectedStatus) {
       if (_closedRead) return;
-      _socketClosedRead = true;
-      if (_filterStatus.readEmpty) {
-        _closedRead = true;
-        _controller.add(RawSocketEvent.readClosed);
-        if (_socketClosedWrite) {
-          _close();
-        }
-      } else {
-        await _scheduleFilter();
-      }
+      _markSocketClosedRead();
+      _socket.readEventsEnabled = false;
+      await _scheduleFilter();
+      _scheduleReadEvent();
     } else if (_status == handshakeStatus) {
-      _socketClosedRead = true;
-      // The other party might have disconnected, but if there still
-      // bytes available we can continue handshake.
-      if (_filterStatus.readEmpty) {
+      _markSocketClosedRead();
+      if (!_secureFilterConnected) return;
+      // Drain bytes delivered with the close event before declaring the
+      // handshake truncated.
+      await _secureHandshake();
+      if (_status == handshakeStatus &&
+          _bufferedData == null &&
+          !_hasNativePrefetchedData) {
         _reportError(
           HandshakeException('Connection terminated during handshake'),
           null,
@@ -990,20 +1133,79 @@ class _RawSecureSocket extends Stream<RawSocketEvent>
     }
   }
 
+  void _finishClosedRead() {
+    if (_status != connectedStatus || _closedRead || !_socketClosedRead) return;
+    _closedRead = true;
+    _filterStatus.readEmpty = true;
+    _controller.add(RawSocketEvent.readClosed);
+    if (_socketClosedWrite) {
+      _close();
+    }
+  }
+
   Future<void> _secureHandshake() async {
+    _handshakePending = true;
+    if (_handshakeActive) {
+      await _handshakeRun!.future;
+      return;
+    }
+    _handshakeActive = true;
+    final run = Completer<void>();
+    _handshakeRun = run;
     try {
-      bool needRetryHandshake = await _secureFilter!.handshake();
-      if (needRetryHandshake) {
-        // Some certificates have been evaluated, need to retry handshake.
-        await _secureHandshake();
-      } else {
-        _filterStatus.writeEmpty = false;
-        _readSocket();
-        _writeSocket();
-        await _scheduleFilter();
+      while (_status == handshakeStatus &&
+          _secureFilter != null &&
+          _handshakePending) {
+        _handshakePending = false;
+        _queuePrefetchedData();
+        final result = await _secureFilter!.handshake();
+        final error = result[0] as int;
+        final hasPrefetchedData = result[1] as bool;
+        final hasPendingWrite =
+            result[2] as bool || (_dartTransport?.writePending ?? false);
+        final readBytes = result[3] as int;
+        final writeBytes = result[4] as int;
+        _recordNativeTransportIO(readBytes, writeBytes);
+        _hasNativePrefetchedData = hasPrefetchedData;
+        _syncNativeTransportState(error == sslErrorWantWrite, hasPendingWrite);
+        if (!hasPendingWrite && (readBytes > 0 || writeBytes > 0)) {
+          // A positive partial socket operation is progress, but it is not
+          // guaranteed to produce another transport event. Retry until the
+          // BIO actually blocks.
+          _handshakePending = true;
+        }
+        if (error == sslErrorWantCertificateVerify) {
+          // Certificate evaluation completed while awaiting handshake().
+          _handshakePending = true;
+          continue;
+        }
+        if (!hasPrefetchedData && _bufferedData != null) {
+          // A bounded prefetched chunk was consumed. Queue the next one before
+          // waiting for another socket event.
+          _handshakePending = true;
+          continue;
+        }
+        if (_status == connectedStatus) {
+          _socket.writeEventsEnabled = false;
+          await _scheduleFilter();
+        } else {
+          _socket.readEventsEnabled = true;
+          _socket.writeEventsEnabled =
+              error == sslErrorWantWrite || hasPendingWrite;
+        }
+        if (_handshakePending) continue;
+        break;
       }
     } catch (e, stackTrace) {
       _reportError(e, stackTrace);
+    } finally {
+      _handshakeActive = false;
+      _handshakeRun = null;
+      try {
+        _destroyFilterIfInactive();
+      } finally {
+        run.complete();
+      }
     }
   }
 
@@ -1078,16 +1280,23 @@ class _RawSecureSocket extends Stream<RawSocketEvent>
         _filterActive = true;
         _filterPending = false;
 
-        _filterStatus = await _pushAllFilterStages();
-        _filterActive = false;
+        try {
+          _filterStatus = _pushAllFilterStages();
+        } finally {
+          _filterActive = false;
+        }
         if (_status == closedStatus) {
-          _secureFilter!.destroy();
-          _secureFilter = null;
+          _destroyFilterIfInactive();
           return;
         }
-        if (_readEventsEnabled) {
-          _socket.readEventsEnabled = true;
-        }
+        _socket.readEventsEnabled =
+            _readEventsEnabled &&
+            _secureFilter!.buffers![readPlaintextId].free > 0;
+        _socket.writeEventsEnabled =
+            _filterStatus.hasPendingSocketWrite ||
+            (_filterStatus.wantsWrite &&
+                (_secureFilter!.buffers![readPlaintextId].free > 0 ||
+                    !_secureFilter!.buffers![writePlaintextId].isEmpty));
         if (_filterStatus.writeEmpty && _closedWrite && !_socketClosedWrite) {
           // Checks for and handles all cases of partially closed sockets.
           shutdown(SocketDirection.send);
@@ -1095,83 +1304,56 @@ class _RawSecureSocket extends Stream<RawSocketEvent>
             return;
           }
         }
-        if (_filterStatus.readEmpty && _socketClosedRead && !_closedRead) {
-          if (_status == handshakeStatus) {
-            _secureFilter!.handshake();
-            if (_status == handshakeStatus) {
-              throw HandshakeException(
-                'Connection terminated during handshake',
-              );
-            }
-          }
-          _closeHandler();
+        if (_socketClosedRead && !_closedRead && _filterStatus.readEmpty) {
+          _finishClosedRead();
         }
         if (_status == closedStatus) {
           return;
         }
         if (_filterStatus.progress) {
           _filterPending = true;
-          if (_filterStatus.writeEncryptedNoLongerEmpty) {
-            _writeSocket();
-          }
           if (_filterStatus.writePlaintextNoLongerFull) {
-            _sendWriteEvent();
-          }
-          if (_filterStatus.readEncryptedNoLongerFull) {
-            _readSocket();
+            // Do not invoke user code before the current filter turn returns.
+            // _filterActive is cleared after the native call, so a synchronous
+            // write event here could start a nested filter turn.
+            _scheduleWriteEvent();
           }
           if (_filterStatus.readPlaintextNoLongerEmpty) {
             _scheduleReadEvent();
           }
-          if (_status == handshakeStatus) {
-            await _secureHandshake();
-          }
         }
       }
     } catch (e, st) {
-      _reportError(e, st);
+      // Preserve RawSecureSocket's asynchronous error delivery and avoid
+      // closing the stream reentrantly from write().
+      scheduleMicrotask(() => _reportError(e, st));
+    } finally {
+      // If _close() was invoked while _filterActive was true, the filter
+      // destruction was deferred. Ensure the native filter and its socket fd
+      // are cleaned up immediately when the filter turn completes.
+      _destroyFilterIfInactive();
     }
   }
 
-  List<int>? _readSocketOrBufferedData(int bytes) {
+  bool _queuePrefetchedData() {
     final bufferedData = _bufferedData;
-    if (bufferedData != null) {
-      if (bytes > bufferedData.length - _bufferedDataIndex) {
-        bytes = bufferedData.length - _bufferedDataIndex;
-      }
-      var result = bufferedData.sublist(
-        _bufferedDataIndex,
-        _bufferedDataIndex + bytes,
-      );
-      _bufferedDataIndex += bytes;
+    if (bufferedData == null) return false;
+    if (_bufferedDataIndex >= bufferedData.length) {
+      _bufferedData = null;
+      return false;
+    }
+    final queued = _secureFilter!.queuePrefetchedData(
+      bufferedData,
+      _bufferedDataIndex,
+    );
+    if (queued > 0) {
+      _bufferedDataIndex += queued;
       if (bufferedData.length == _bufferedDataIndex) {
         _bufferedData = null;
       }
-      return result;
-    } else if (!_socketClosedRead) {
-      return _socket.read(bytes);
-    } else {
-      return null;
+      return true;
     }
-  }
-
-  void _readSocket() {
-    if (_status == closedStatus) return;
-    var buffer = _secureFilter!.buffers![readEncryptedId];
-    if (buffer.writeFromSource(_readSocketOrBufferedData) > 0) {
-      _filterStatus.readEmpty = false;
-    } else {
-      _socket.readEventsEnabled = false;
-    }
-  }
-
-  void _writeSocket() {
-    if (_socketClosedWrite) return;
-    var buffer = _secureFilter!.buffers![writeEncryptedId];
-    if (buffer.readToSocket(_socket)) {
-      // Returns true if blocked
-      _socket.writeEventsEnabled = true;
-    }
+    return false;
   }
 
   // If a read event should be sent, add it to the controller.
@@ -1201,6 +1383,15 @@ class _RawSecureSocket extends Stream<RawSocketEvent>
   }
 
   // If a write event should be sent, add it to the controller.
+  void _scheduleWriteEvent() {
+    if (_pendingWriteEvent) return;
+    _pendingWriteEvent = true;
+    Timer.run(() {
+      _pendingWriteEvent = false;
+      _sendWriteEvent();
+    });
+  }
+
   _sendWriteEvent() {
     if (!_closedWrite &&
         _writeEventsEnabled &&
@@ -1212,51 +1403,47 @@ class _RawSecureSocket extends Stream<RawSocketEvent>
     }
   }
 
-  Future<_FilterStatus> _pushAllFilterStages() async {
-    bool wasInHandshake = _status != connectedStatus;
-    List args = List<dynamic>.filled(2 + bufferCount * 2, null);
-    args[0] = _secureFilter!._pointer();
-    args[1] = wasInHandshake;
+  _FilterStatus _pushAllFilterStages() {
+    final queuedPrefetchedData = _queuePrefetchedData();
     var bufs = _secureFilter!.buffers!;
+    final positions = List<int>.filled(bufferCount * 3, 0);
     for (var i = 0; i < bufferCount; ++i) {
-      args[2 * i + 2] = bufs[i].start;
-      args[2 * i + 3] = bufs[i].end;
+      positions[3 * i] = bufs[i].start;
+      positions[3 * i + 1] = bufs[i].end;
+      positions[3 * i + 2] = bufs[i].size;
     }
 
-    var response = (await _IOService._dispatch(
-      _IOService.sslProcessFilter,
-      args,
-    )) as List<Object?>;
-    if (response.length == 2) {
-      if (wasInHandshake) {
-        // If we're in handshake, throw a handshake error.
-        _reportError(
-          HandshakeException('${response[1]} error ${response[0]}'),
-          null,
-        );
-      } else {
-        // If we're connected, throw a TLS error.
-        _reportError(TlsException('${response[1]} error ${response[0]}'), null);
-      }
-    }
+    final response = _secureFilter!.process(positions);
     int start(int index) => response[2 * index] as int;
     int end(int index) => response[2 * index + 1] as int;
+    final wantsWrite = response[bufferCount * 2] as bool;
+    final hasPrefetchedData = response[bufferCount * 2 + 1] as bool;
+    final hasPendingWrite =
+        response[bufferCount * 2 + 2] as bool ||
+        (_dartTransport?.writePending ?? false);
+    final readBytes = response[bufferCount * 2 + 3] as int;
+    final writeBytes = response[bufferCount * 2 + 4] as int;
+    final hasPendingPlaintext = response[bufferCount * 2 + 5] as bool;
+    _recordNativeTransportIO(readBytes, writeBytes);
+    _hasNativePrefetchedData = hasPrefetchedData;
+    _syncNativeTransportState(wantsWrite, hasPendingWrite);
 
     _FilterStatus status = _FilterStatus();
-    // Compute writeEmpty as "write plaintext buffer and write encrypted
-    // buffer were empty when we started and are empty now".
+    status.wantsWrite = wantsWrite;
+    status.hasPendingSocketWrite = hasPendingWrite;
+    status.hasPendingPlaintext = hasPendingPlaintext;
     status.writeEmpty =
-        bufs[writePlaintextId].isEmpty &&
-        start(writeEncryptedId) == end(writeEncryptedId);
-    // If we were in handshake when this started, _writeEmpty may be false
-    // because the handshake wrote data after we checked.
-    if (wasInHandshake) status.writeEmpty = false;
-
-    // Compute readEmpty as "both read buffers were empty when we started
-    // and are empty now".
+        bufs[writePlaintextId].isEmpty && !wantsWrite && !hasPendingWrite;
     status.readEmpty =
-        bufs[readEncryptedId].isEmpty &&
-        start(readPlaintextId) == end(readPlaintextId);
+        start(readPlaintextId) == end(readPlaintextId) &&
+        _bufferedData == null &&
+        !hasPrefetchedData &&
+        !hasPendingPlaintext;
+    status.progress =
+        queuedPrefetchedData ||
+        (!hasPrefetchedData && _bufferedData != null) ||
+        readBytes > 0 ||
+        writeBytes > 0;
 
     _ExternalBuffer buffer = bufs[writePlaintextId];
     int new_start = start(writePlaintextId);
@@ -1265,46 +1452,31 @@ class _RawSecureSocket extends Stream<RawSocketEvent>
       if (buffer.free == 0) {
         status.writePlaintextNoLongerFull = true;
       }
-      buffer.start = new_start;
-    }
-    buffer = bufs[readEncryptedId];
-    new_start = start(readEncryptedId);
-    if (new_start != buffer.start) {
-      status.progress = true;
-      if (buffer.free == 0) {
-        status.readEncryptedNoLongerFull = true;
-      }
-      buffer.start = new_start;
-    }
-    buffer = bufs[writeEncryptedId];
-    int new_end = end(writeEncryptedId);
-    if (new_end != buffer.end) {
-      status.progress = true;
-      if (buffer.length == 0) {
-        status.writeEncryptedNoLongerEmpty = true;
-      }
-      buffer.end = new_end;
+      buffer.setStart(new_start);
     }
     buffer = bufs[readPlaintextId];
-    new_end = end(readPlaintextId);
+    int new_end = end(readPlaintextId);
     if (new_end != buffer.end) {
       status.progress = true;
       if (buffer.length == 0) {
         status.readPlaintextNoLongerEmpty = true;
       }
-      buffer.end = new_end;
+      buffer.setEnd(new_end);
+      if (buffer.free == 0 && buffer.grow()) {
+        status.progress = true;
+      }
     }
     return status;
   }
 }
 
-/// A circular buffer backed by an external byte array.  Accessed from
-/// both C++ and Dart code in an unsynchronized way, with one reading
-/// and one writing.  All updates to start and end are done by Dart code.
+/// A plaintext circular buffer backed by an external byte array. Native TLS
+/// processing is serialized on the isolate, and Dart applies the returned
+/// start/end positions after each native call.
 class _ExternalBuffer {
   // This will be an ExternalByteArray, backed by C allocated data.
   @pragma("vm:entry-point")
-  List<int>? data;
+  Uint8List? data;
 
   @pragma("vm:entry-point")
   int start;
@@ -1312,9 +1484,43 @@ class _ExternalBuffer {
   @pragma("vm:entry-point")
   int end;
 
-  final int size;
+  final int maxSize;
 
-  _ExternalBuffer(int size) : size = size, start = size ~/ 2, end = size ~/ 2;
+  @pragma("vm:entry-point")
+  int size;
+
+  final Uint8List Function(int start, int end, int oldSize, int newSize)
+  _growBacking;
+
+  _ExternalBuffer(
+    this.maxSize, {
+    required int initialSize,
+    required Uint8List Function(int start, int end, int oldSize, int newSize)
+    growBacking,
+  }) : assert(initialSize >= 2),
+       assert(initialSize <= maxSize),
+       size = initialSize,
+       _growBacking = growBacking,
+       start = 0,
+       end = 0;
+
+  void _resetIfEmpty() {
+    if (start == end) {
+      start = 0;
+      end = 0;
+    }
+  }
+
+  void setStart(int value) {
+    assert(value >= 0 && value < size);
+    start = value;
+    _resetIfEmpty();
+  }
+
+  void setEnd(int value) {
+    assert(value >= 0 && value < size);
+    end = value;
+  }
 
   void advanceStart(int bytes) {
     assert(start > end || start + bytes <= end);
@@ -1324,6 +1530,7 @@ class _ExternalBuffer {
       assert(start <= end);
       assert(start < size);
     }
+    _resetIfEmpty();
   }
 
   void advanceEnd(int bytes) {
@@ -1350,6 +1557,27 @@ class _ExternalBuffer {
     return size - end;
   }
 
+  bool grow([int requiredFree = 1]) {
+    if (requiredFree <= free) return false;
+    final requiredSize = min(maxSize, length + requiredFree + 1);
+    if (requiredSize <= size) return false;
+
+    // Start small for low-traffic connections, then move through a 4 KiB
+    // working ring before allocating one maximum-size TLS plaintext record.
+    final fourKiB = 4 * 1024 + 1;
+    final newSize = size < fourKiB ? fourKiB : maxSize;
+    final used = length;
+    final newData = _growBacking(start, end, size, newSize);
+    if (newData.length != newSize) {
+      throw StateError('Invalid SecureSocket backing buffer size');
+    }
+    data = newData;
+    size = newSize;
+    start = 0;
+    end = used;
+    return true;
+  }
+
   Uint8List? read(int? bytes) {
     if (bytes == null) {
       bytes = length;
@@ -1370,6 +1598,7 @@ class _ExternalBuffer {
   }
 
   int write(List<int> inputData, int offset, int bytes) {
+    grow(bytes);
     if (bytes > free) {
       bytes = free;
     }
@@ -1385,37 +1614,6 @@ class _ExternalBuffer {
     }
     return written;
   }
-
-  int writeFromSource(List<int>? getData(int requested)) {
-    int written = 0;
-    int toWrite = linearFree;
-    // Loop over zero, one, or two linear data ranges.
-    while (toWrite > 0) {
-      // Source returns at most toWrite bytes, and it returns null when empty.
-      var inputData = getData(toWrite);
-      if (inputData == null || inputData.length == 0) break;
-      var len = inputData.length;
-      data!.setRange(end, end + len, inputData);
-      advanceEnd(len);
-      written += len;
-      toWrite = linearFree;
-    }
-    return written;
-  }
-
-  bool readToSocket(RawSocket socket) {
-    // Loop over zero, one, or two linear data ranges.
-    while (true) {
-      var toWrite = linearLength;
-      if (toWrite == 0) return false;
-      int bytes = socket.write(data!, start, toWrite);
-      advanceStart(bytes);
-      if (bytes < toWrite) {
-        // The socket has blocked while we have data to write.
-        return true;
-      }
-    }
-  }
 }
 
 abstract class _SecureFilter {
@@ -1428,22 +1626,22 @@ abstract class _SecureFilter {
     bool requestClientCertificate,
     bool requireClientCertificate,
     Uint8List protocols,
+    Object? nativeSocket,
+    Uint8List? Function(int)? transportRead,
+    int Function(Uint8List)? transportWrite,
   );
   void destroy();
-  Future<bool> handshake();
+  Future<List<Object?>> handshake();
   String? selectedProtocol();
   void rehandshake();
   void init();
   X509Certificate? get peerCertificate;
   int processBuffer(int bufferIndex);
+  List<Object?> process(List<int> positions);
+  int queuePrefetchedData(List<int> data, int offset);
   void registerBadCertificateCallback(bool Function(X509Certificate) callback);
   void registerHandshakeCompleteCallback(Function handshakeCompleteHandler);
   void registerKeyLogPort(SendPort port);
-
-  // This call may cause a reference counted pointer in the native
-  // implementation to be retained. It should only be called when the resulting
-  // value is passed to the IO service through a call to dispatch().
-  int _pointer();
 
   List<_ExternalBuffer>? get buffers;
 }

--- a/tests/standalone/io/raw_secure_socket_ssl_read_error_test.dart
+++ b/tests/standalone/io/raw_secure_socket_ssl_read_error_test.dart
@@ -41,10 +41,11 @@ testSslReadError() async {
       serverContext,
       subscription: socket.listen((event) {}),
     );
-    secureSocket.write([1, 2, 3]);
     // Send content using the original unencrypted connection to provoke a
-    // TtsException in the client.
+    // TlsException in the client. This must precede the secure write now that
+    // SecureSocket processing writes synchronously through the socket BIO.
     socket.write([1, 2, 3]);
+    secureSocket.write([1, 2, 3]);
     secureSocket.close();
     serverSocket.close();
   });

--- a/tests/standalone/io/secure_client_server_test.dart
+++ b/tests/standalone/io/secure_client_server_test.dart
@@ -48,7 +48,11 @@ void checkServerCertificate(X509Certificate serverCert) {
   String serverCertString = serverCert.pem;
   String certFile = new File(localFile('certificates/server_chain.pem'))
       .readAsStringSync();
-  Expect.isTrue(certFile.contains(serverCertString));
+  Expect.isTrue(
+    certFile
+        .replaceAll('\r\n', '\n')
+        .contains(serverCertString.replaceAll('\r\n', '\n')),
+  );
 
   // Computed with:
   // openssl x509 -noout -sha1 -fingerprint -in certificates/server_chain.pem

--- a/tests/standalone/io/secure_server_client_certificate_test.dart
+++ b/tests/standalone/io/secure_server_client_certificate_test.dart
@@ -101,7 +101,9 @@ Future testClientCertificate({
         Expect.fail('Should not get data through');
       },
       onError: (e) {
-        Expect.isTrue(e is SocketException);
+        // The direct socket BIO can surface the peer's TLS alert before the
+        // transport reports its close.
+        Expect.isTrue(e is SocketException || e is TlsException);
       },
       onDone: () {
         clientDisconnected.complete();

--- a/tests/standalone/io/secure_socket_custom_bio_test.dart
+++ b/tests/standalone/io/secure_socket_custom_bio_test.dart
@@ -1,0 +1,1023 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+//
+// VMOptions=
+// VMOptions=--short_socket_read
+// VMOptions=--short_socket_write
+// VMOptions=--short_socket_read --short_socket_write
+// OtherResources=certificates/server_chain.pem
+// OtherResources=certificates/server_key.pem
+// OtherResources=certificates/trusted_certs.pem
+
+import "dart:async";
+import "dart:io";
+import "dart:typed_data";
+
+import "package:expect/expect.dart";
+
+String localFile(String path) => Platform.script.resolve(path).toFilePath();
+
+final SecurityContext serverContext = SecurityContext()
+  ..useCertificateChain(localFile('certificates/server_chain.pem'))
+  ..usePrivateKey(
+    localFile('certificates/server_key.pem'),
+    password: 'dartdart',
+  );
+
+final SecurityContext clientContext = SecurityContext()
+  ..setTrustedCertificates(localFile('certificates/trusted_certs.pem'));
+
+Uint8List makePayload(int length) {
+  final result = Uint8List(length);
+  for (var i = 0; i < result.length; i++) {
+    result[i] = (i * 31 + i ~/ 251) & 0xff;
+  }
+  return result;
+}
+
+int checksum(List<int> data) {
+  var result = 0;
+  for (final byte in data) {
+    result = (result + byte) & 0x7fffffff;
+  }
+  return result;
+}
+
+class DelegatingRawSocket extends Stream<RawSocketEvent> implements RawSocket {
+  final RawSocket socket;
+
+  DelegatingRawSocket(this.socket);
+
+  bool get readEventsEnabled => socket.readEventsEnabled;
+  set readEventsEnabled(bool value) => socket.readEventsEnabled = value;
+
+  bool get writeEventsEnabled => socket.writeEventsEnabled;
+  set writeEventsEnabled(bool value) => socket.writeEventsEnabled = value;
+
+  int available() => socket.available();
+  Uint8List? read([int? len]) => socket.read(len);
+  SocketMessage? readMessage([int? count]) => socket.readMessage(count);
+  int write(List<int> buffer, [int offset = 0, int? count]) =>
+      socket.write(buffer, offset, count);
+  int sendMessage(
+    List<SocketControlMessage> controlMessages,
+    List<int> data, [
+    int offset = 0,
+    int? count,
+  ]) => socket.sendMessage(controlMessages, data, offset, count);
+
+  int get port => socket.port;
+  int get remotePort => socket.remotePort;
+  InternetAddress get address => socket.address;
+  InternetAddress get remoteAddress => socket.remoteAddress;
+
+  Future<RawSocket> close() async {
+    await socket.close();
+    return this;
+  }
+
+  void shutdown(SocketDirection direction) => socket.shutdown(direction);
+  bool setOption(SocketOption option, bool enabled) =>
+      socket.setOption(option, enabled);
+  Uint8List getRawOption(RawSocketOption option) => socket.getRawOption(option);
+  void setRawOption(RawSocketOption option) => socket.setRawOption(option);
+
+  StreamSubscription<RawSocketEvent> listen(
+    void Function(RawSocketEvent)? onData, {
+    Function? onError,
+    void Function()? onDone,
+    bool? cancelOnError,
+  }) => socket.listen(
+    onData,
+    onError: onError,
+    onDone: onDone,
+    cancelOnError: cancelOnError,
+  );
+}
+
+class SynchronousErrorRawSocket extends DelegatingRawSocket {
+  Function? _onError;
+  bool _errorSent = false;
+
+  SynchronousErrorRawSocket(super.socket);
+
+  void _sendSynchronousError() {
+    if (_errorSent) return;
+    _errorSent = true;
+    final handler = _onError;
+    if (handler != null) {
+      Function.apply(handler, [
+        const SocketException('Synchronous transport failure'),
+        StackTrace.current,
+      ]);
+    }
+  }
+
+  @override
+  Uint8List? read([int? len]) {
+    _sendSynchronousError();
+    return null;
+  }
+
+  @override
+  int write(List<int> buffer, [int offset = 0, int? count]) {
+    _sendSynchronousError();
+    return 0;
+  }
+
+  @override
+  StreamSubscription<RawSocketEvent> listen(
+    void Function(RawSocketEvent)? onData, {
+    Function? onError,
+    void Function()? onDone,
+    bool? cancelOnError,
+  }) {
+    _onError = onError;
+    return super.listen(
+      onData,
+      onError: onError,
+      onDone: onDone,
+      cancelOnError: cancelOnError,
+    );
+  }
+}
+
+class BlockNextWriteRawSocket extends DelegatingRawSocket {
+  bool blockNextWrite = false;
+
+  BlockNextWriteRawSocket(super.socket);
+
+  @override
+  int write(List<int> buffer, [int offset = 0, int? count]) {
+    if (blockNextWrite) {
+      blockNextWrite = false;
+      return 0;
+    }
+    return super.write(buffer, offset, count);
+  }
+}
+
+class InvalidCountRawSocket extends DelegatingRawSocket {
+  final bool invalidRead;
+
+  InvalidCountRawSocket(super.socket, {required this.invalidRead});
+
+  @override
+  Uint8List? read([int? len]) {
+    if (invalidRead) return Uint8List((len ?? 1) + 1);
+    return super.read(len);
+  }
+
+  @override
+  int write(List<int> buffer, [int offset = 0, int? count]) {
+    if (!invalidRead) return (count ?? buffer.length - offset) + 1;
+    return super.write(buffer, offset, count);
+  }
+}
+
+class ReentrantWriteRawSocket extends DelegatingRawSocket {
+  RawSecureSocket? secureSocket;
+  Uint8List? reentrantData;
+  int? reentrantResult;
+
+  ReentrantWriteRawSocket(super.socket);
+
+  void arm(RawSecureSocket socket, Uint8List data) {
+    secureSocket = socket;
+    reentrantData = data;
+  }
+
+  @override
+  int write(List<int> buffer, [int offset = 0, int? count]) {
+    final socket = secureSocket;
+    final data = reentrantData;
+    if (socket != null && data != null) {
+      secureSocket = null;
+      reentrantData = null;
+      reentrantResult = socket.write(data);
+    }
+    return super.write(buffer, offset, count);
+  }
+}
+
+Future<(int, int)> consume(Stream<List<int>> stream) async {
+  var length = 0;
+  var sum = 0;
+  await for (final data in stream) {
+    length += data.length;
+    sum = (sum + checksum(data)) & 0x7fffffff;
+  }
+  return (length, sum);
+}
+
+Future<ServerSocket> bindServer() =>
+    ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+
+Future<void> testSlowReceiverBackpressure(Uint8List payload) async {
+  final received = Completer<(int, int)>();
+  final serverDone = Completer<void>();
+  final server = await bindServer();
+  final serverSubscription = server.listen((socket) async {
+    try {
+      final secureSocket = await SecureSocket.secureServer(
+        socket,
+        serverContext,
+        bufferedData: const [],
+      );
+      // Let the sender fill its bounded plaintext queue before consuming.
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      received.complete(await consume(secureSocket));
+      await secureSocket.close();
+      serverDone.complete();
+    } catch (error, stackTrace) {
+      if (!received.isCompleted) {
+        received.completeError(error, stackTrace);
+      }
+      if (!serverDone.isCompleted) {
+        serverDone.completeError(error, stackTrace);
+      }
+    }
+  });
+
+  final client = await SecureSocket.connect(
+    InternetAddress.loopbackIPv4,
+    server.port,
+    context: clientContext,
+  );
+  client.add(payload);
+  await client.flush();
+  await client.close();
+
+  final result = await received.future;
+  client.destroy();
+  Expect.equals(payload.length, result.$1);
+  Expect.equals(checksum(payload), result.$2);
+  await serverDone.future;
+  await server.close();
+  await serverSubscription.cancel();
+}
+
+Future<void> testFullPlaintextRingBackpressure(int payloadLength) async {
+  const chunkCount = 2048;
+  final payload = makePayload(payloadLength);
+  final received = Completer<(int, int)>();
+  final serverDone = Completer<void>();
+  final server = await bindServer();
+  final serverSubscription = server.listen((socket) async {
+    try {
+      final secureSocket = await SecureSocket.secureServer(
+        socket,
+        serverContext,
+        bufferedData: const [],
+      );
+      // Force the sender through non-blocking socket backpressure after each
+      // write has exactly filled the current plaintext ring.
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+      received.complete(await consume(secureSocket));
+      await secureSocket.close();
+      serverDone.complete();
+    } catch (error, stackTrace) {
+      if (!received.isCompleted) {
+        received.completeError(error, stackTrace);
+      }
+      if (!serverDone.isCompleted) {
+        serverDone.completeError(error, stackTrace);
+      }
+    }
+  });
+
+  final rawClient = await RawSocket.connect(
+    InternetAddress.loopbackIPv4,
+    server.port,
+  );
+  final client = await RawSecureSocket.secure(
+    rawClient,
+    context: clientContext,
+  );
+  final writesDone = Completer<void>();
+  var payloadOffset = 0;
+  var chunksWritten = 0;
+  var firstWrite = true;
+  late final StreamSubscription<RawSocketEvent> clientSubscription;
+  clientSubscription = client.listen(
+    (event) {
+      if (event == RawSocketEvent.read) {
+        while (client.read() != null) {}
+        client.readEventsEnabled = true;
+        return;
+      }
+      if (event != RawSocketEvent.write || writesDone.isCompleted) return;
+      try {
+        // One RawSecureSocket.write call per event is part of the regression:
+        // the call exactly fills the ring without bypassing backpressure.
+        final written = client.write(
+          payload,
+          payloadOffset,
+          payload.length - payloadOffset,
+        );
+        if (firstWrite) {
+          // A 16 KiB write first advances the 1 KiB ring to the intermediate
+          // 4 KiB class; a later writable event advances it to 16 KiB.
+          Expect.equals(
+            payload.length > 4 * 1024 ? 4 * 1024 : payload.length,
+            written,
+          );
+          firstWrite = false;
+        }
+        payloadOffset += written;
+        if (payloadOffset == payload.length) {
+          payloadOffset = 0;
+          chunksWritten++;
+        }
+        if (chunksWritten == chunkCount) {
+          client.writeEventsEnabled = false;
+          client.shutdown(SocketDirection.send);
+          writesDone.complete();
+        } else {
+          client.writeEventsEnabled = true;
+        }
+      } catch (error, stackTrace) {
+        writesDone.completeError(error, stackTrace);
+      }
+    },
+    onError: (Object error, StackTrace stackTrace) {
+      if (!writesDone.isCompleted) {
+        writesDone.completeError(error, stackTrace);
+      }
+    },
+  );
+  client.readEventsEnabled = true;
+  client.writeEventsEnabled = true;
+
+  await writesDone.future.timeout(const Duration(seconds: 30));
+  final result = await received.future.timeout(const Duration(seconds: 30));
+  Expect.equals(payload.length * chunkCount, result.$1);
+  Expect.equals((checksum(payload) * chunkCount) & 0x7fffffff, result.$2);
+
+  await serverDone.future;
+  await client.close();
+  await clientSubscription.cancel();
+  await server.close();
+  await serverSubscription.cancel();
+}
+
+Future<void> testServerFullPlaintextRingBackpressure(int payloadLength) async {
+  const chunkCount = 2048;
+  final payload = makePayload(payloadLength);
+  final server = await RawSecureServerSocket.bind(
+    InternetAddress.loopbackIPv4,
+    0,
+    serverContext,
+  );
+  final serverConnection = server.first;
+  final client = await SecureSocket.connect(
+    InternetAddress.loopbackIPv4,
+    server.port,
+    context: clientContext,
+  );
+  final secureServer = await serverConnection;
+  await server.close();
+
+  final writesDone = Completer<void>();
+  var payloadOffset = 0;
+  var chunksWritten = 0;
+  var firstWrite = true;
+  late final StreamSubscription<RawSocketEvent> serverSubscription;
+  serverSubscription = secureServer.listen(
+    (event) {
+      if (event == RawSocketEvent.read) {
+        while (secureServer.read() != null) {}
+        secureServer.readEventsEnabled = true;
+        return;
+      }
+      if (event != RawSocketEvent.write || writesDone.isCompleted) return;
+      try {
+        final written = secureServer.write(
+          payload,
+          payloadOffset,
+          payload.length - payloadOffset,
+        );
+        if (firstWrite) {
+          Expect.equals(
+            payload.length > 4 * 1024 ? 4 * 1024 : payload.length,
+            written,
+          );
+          firstWrite = false;
+        }
+        payloadOffset += written;
+        if (payloadOffset == payload.length) {
+          payloadOffset = 0;
+          chunksWritten++;
+        }
+        if (chunksWritten == chunkCount) {
+          secureServer.writeEventsEnabled = false;
+          secureServer.shutdown(SocketDirection.send);
+          writesDone.complete();
+        } else {
+          secureServer.writeEventsEnabled = true;
+        }
+      } catch (error, stackTrace) {
+        writesDone.completeError(error, stackTrace);
+      }
+    },
+    onError: (Object error, StackTrace stackTrace) {
+      if (!writesDone.isCompleted) {
+        writesDone.completeError(error, stackTrace);
+      }
+    },
+  );
+  secureServer.readEventsEnabled = true;
+  secureServer.writeEventsEnabled = true;
+
+  // Match the benchmark's server-side encode path while forcing transport
+  // backpressure independently of machine speed.
+  await Future<void>.delayed(const Duration(milliseconds: 100));
+  final received = consume(client);
+  await writesDone.future.timeout(const Duration(seconds: 30));
+  final result = await received.timeout(const Duration(seconds: 30));
+  Expect.equals(payload.length * chunkCount, result.$1);
+  Expect.equals((checksum(payload) * chunkCount) & 0x7fffffff, result.$2);
+
+  await client.close();
+  client.destroy();
+  await secureServer.close();
+  await serverSubscription.cancel();
+}
+
+Future<void> testPublicRawSocketImplementation(Uint8List payload) async {
+  final server = await bindServer();
+  final serverConnection = server.first;
+  final secureServerConnection = serverConnection.then(
+    (socket) => SecureSocket.secureServer(
+      socket,
+      serverContext,
+      bufferedData: const [],
+    ),
+  );
+  final rawClient = await RawSocket.connect(
+    InternetAddress.loopbackIPv4,
+    server.port,
+  );
+  final client = await RawSecureSocket.secure(
+    DelegatingRawSocket(rawClient),
+    context: clientContext,
+  );
+  final serverClient = await secureServerConnection;
+
+  final received = BytesBuilder(copy: false);
+  final readClosed = Completer<void>();
+  final clientSubscription = client.listen((event) {
+    if (event == RawSocketEvent.read) {
+      while (true) {
+        final data = client.read();
+        if (data == null) break;
+        received.add(data);
+      }
+    } else if (event == RawSocketEvent.readClosed) {
+      if (!readClosed.isCompleted) readClosed.complete();
+    }
+  });
+
+  serverClient.add(payload);
+  await serverClient.flush();
+  await serverClient.close();
+  serverClient.destroy();
+  await readClosed.future;
+
+  final result = received.takeBytes();
+  Expect.equals(payload.length, result.length);
+  Expect.equals(checksum(payload), checksum(result));
+
+  await client.close();
+  await clientSubscription.cancel();
+  await server.close();
+}
+
+Future<void> testNestedSecureSocketCleanReadClose() async {
+  const payload = [1, 2, 3, 4];
+  final server = await RawServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+  final secureServerConnection = Completer<RawSecureSocket>();
+  final serverSubscription = server.listen((rawSocket) async {
+    try {
+      final inner = await RawSecureSocket.secureServer(
+        rawSocket,
+        serverContext,
+        bufferedData: const [],
+      );
+      final outer = await RawSecureSocket.secureServer(
+        inner,
+        serverContext,
+        bufferedData: const [],
+      );
+      secureServerConnection.complete(outer);
+      Expect.equals(payload.length, outer.write(payload));
+      outer.shutdown(SocketDirection.send);
+    } catch (error, stackTrace) {
+      if (!secureServerConnection.isCompleted) {
+        secureServerConnection.completeError(error, stackTrace);
+      }
+    }
+  });
+
+  final rawClient = await RawSocket.connect(
+    InternetAddress.loopbackIPv4,
+    server.port,
+  );
+  final innerClient = await RawSecureSocket.secure(
+    rawClient,
+    context: clientContext,
+  );
+  final outerClient = await RawSecureSocket.secure(
+    innerClient,
+    context: clientContext,
+  );
+  final outerServer = await secureServerConnection.future;
+
+  final received = BytesBuilder(copy: false);
+  final readClosed = Completer<void>();
+  Object? streamError;
+  final clientSubscription = outerClient.listen(
+    (event) {
+      if (event == RawSocketEvent.read) {
+        while (true) {
+          final data = outerClient.read();
+          if (data == null) break;
+          received.add(data);
+        }
+      } else if (event == RawSocketEvent.readClosed) {
+        if (!readClosed.isCompleted) readClosed.complete();
+      }
+    },
+    onError: (Object error, StackTrace stackTrace) {
+      streamError = error;
+      if (!readClosed.isCompleted) readClosed.complete();
+    },
+  );
+  outerClient.readEventsEnabled = true;
+
+  await readClosed.future.timeout(const Duration(seconds: 10));
+  Expect.isNull(streamError);
+  Expect.listEquals(payload, received.takeBytes());
+
+  await outerClient.close();
+  await outerServer.close();
+  await clientSubscription.cancel();
+  await server.close();
+  await serverSubscription.cancel();
+}
+
+Future<void> testGrowDuringWriteRetry() async {
+  final received = Completer<(int, int)>();
+  final server = await bindServer();
+  final serverSubscription = server.listen((socket) async {
+    try {
+      final secureSocket = await SecureSocket.secureServer(
+        socket,
+        serverContext,
+        bufferedData: const [],
+      );
+      received.complete(await consume(secureSocket));
+      await secureSocket.close();
+    } catch (error, stackTrace) {
+      if (!received.isCompleted) {
+        received.completeError(error, stackTrace);
+      }
+    }
+  });
+
+  final rawClient = await RawSocket.connect(
+    InternetAddress.loopbackIPv4,
+    server.port,
+  );
+  final transport = BlockNextWriteRawSocket(rawClient);
+  final client = await RawSecureSocket.secure(
+    transport,
+    context: clientContext,
+  );
+  final clientSubscription = client.listen((event) {
+    if (event == RawSocketEvent.read) {
+      while (client.read() != null) {}
+    }
+  });
+
+  final first = makePayload(2 * 1024);
+  final second = makePayload(4 * 1024);
+  transport.blockNextWrite = true;
+  Expect.equals(first.length, client.write(first));
+  // The first SSL_write is now waiting on its transport. This write grows the
+  // plaintext backing allocation and retries with the original bytes as an
+  // unchanged prefix at a different address.
+  Expect.equals(second.length, client.write(second));
+  client.shutdown(SocketDirection.send);
+
+  final result = await received.future.timeout(const Duration(seconds: 30));
+  Expect.equals(first.length + second.length, result.$1);
+  Expect.equals((checksum(first) + checksum(second)) & 0x7fffffff, result.$2);
+
+  await client.close();
+  await clientSubscription.cancel();
+  await server.close();
+  await serverSubscription.cancel();
+}
+
+Future<void> testReentrantFallbackWriteIsBackpressured() async {
+  final received = Completer<(int, int)>();
+  final server = await bindServer();
+  final serverSubscription = server.listen((socket) async {
+    try {
+      final secureSocket = await SecureSocket.secureServer(
+        socket,
+        serverContext,
+        bufferedData: const [],
+      );
+      received.complete(await consume(secureSocket));
+      await secureSocket.close();
+    } catch (error, stackTrace) {
+      if (!received.isCompleted) {
+        received.completeError(error, stackTrace);
+      }
+    }
+  });
+
+  final rawClient = await RawSocket.connect(
+    InternetAddress.loopbackIPv4,
+    server.port,
+  );
+  final transport = ReentrantWriteRawSocket(rawClient);
+  final client = await RawSecureSocket.secure(
+    transport,
+    context: clientContext,
+  );
+  Completer<void>? writeReady;
+  final clientSubscription = client.listen((event) {
+    if (event == RawSocketEvent.read) {
+      while (client.read() != null) {}
+    } else if (event == RawSocketEvent.write) {
+      final ready = writeReady;
+      if (ready != null && !ready.isCompleted) ready.complete();
+    }
+  });
+
+  final first = makePayload(512);
+  final reentrant = makePayload(8 * 1024);
+  transport.arm(client, reentrant);
+  Expect.equals(first.length, client.write(first));
+  // The transport callback runs inside SSL_write. The nested write must not
+  // replace or mutate the plaintext backing passed to that native call.
+  Expect.equals(0, transport.reentrantResult);
+  var reentrantOffset = client.write(reentrant);
+  Expect.isTrue(reentrantOffset > 0);
+  while (reentrantOffset < reentrant.length) {
+    final written = client.write(
+      reentrant,
+      reentrantOffset,
+      reentrant.length - reentrantOffset,
+    );
+    if (written > 0) {
+      reentrantOffset += written;
+      continue;
+    }
+    writeReady = Completer<void>();
+    client.writeEventsEnabled = true;
+    await writeReady!.future.timeout(const Duration(seconds: 10));
+    writeReady = null;
+  }
+  client.shutdown(SocketDirection.send);
+
+  final result = await received.future.timeout(const Duration(seconds: 30));
+  Expect.equals(first.length + reentrant.length, result.$1);
+  Expect.equals(
+    (checksum(first) + checksum(reentrant)) & 0x7fffffff,
+    result.$2,
+  );
+
+  await client.close();
+  await clientSubscription.cancel();
+  await server.close();
+  await serverSubscription.cancel();
+}
+
+Future<void> testUpgradeAfterNativeReadClosed() async {
+  final server = await bindServer();
+  final serverClosed = server.first.then((socket) => socket.close());
+  final rawClient = await RawSocket.connect(
+    InternetAddress.loopbackIPv4,
+    server.port,
+  );
+  final readClosed = Completer<void>();
+  final subscription = rawClient.listen((event) {
+    if (event == RawSocketEvent.readClosed && !readClosed.isCompleted) {
+      readClosed.complete();
+    }
+  });
+  await readClosed.future;
+
+  Object? handshakeError;
+  try {
+    await RawSecureSocket.secure(
+      rawClient,
+      subscription: subscription,
+      context: clientContext,
+    );
+  } catch (error) {
+    handshakeError = error;
+  }
+  Expect.isTrue(handshakeError is HandshakeException);
+
+  await rawClient.close();
+  await subscription.cancel();
+  final closedServerClient = await serverClosed;
+  closedServerClient.destroy();
+  await server.close();
+}
+
+Future<void> testSynchronousFallbackTransportError() async {
+  final server = await bindServer();
+  final serverConnection = server.first;
+  final rawClient = await RawSocket.connect(
+    InternetAddress.loopbackIPv4,
+    server.port,
+  );
+  final serverClient = await serverConnection;
+
+  Object? handshakeError;
+  try {
+    await RawSecureSocket.secure(
+      SynchronousErrorRawSocket(rawClient),
+      context: clientContext,
+    );
+  } catch (error) {
+    handshakeError = error;
+  }
+  Expect.isTrue(handshakeError is SocketException);
+
+  await rawClient.close();
+  await serverClient.close();
+  serverClient.destroy();
+  await server.close();
+}
+
+Future<void> testConcurrentShortWriteHandshakeFailures() async {
+  const connectionCount = 32;
+
+  Future<void> runOne(int index) async {
+    final server = await SecureServerSocket.bind(
+      InternetAddress.loopbackIPv4,
+      0,
+      null,
+    );
+    final clientDone =
+        SecureSocket.connect(
+          InternetAddress.loopbackIPv4,
+          server.port,
+          context: clientContext,
+        ).then<void>(
+          (socket) {
+            socket.destroy();
+            Expect.fail('Client $index unexpectedly completed its handshake');
+          },
+          onError: (Object error, StackTrace stackTrace) {
+            Expect.isTrue(
+              error is HandshakeException || error is SocketException,
+            );
+          },
+        );
+    final serverDone = Completer<void>();
+    final subscription = server.listen(
+      (socket) {
+        socket.destroy();
+        if (!serverDone.isCompleted) {
+          serverDone.completeError(
+            StateError('Server $index unexpectedly completed its handshake'),
+          );
+        }
+      },
+      onError: (Object error, StackTrace stackTrace) async {
+        if (serverDone.isCompleted) return;
+        try {
+          Expect.isTrue(
+            error is HandshakeException || error is SocketException,
+          );
+          await clientDone;
+          await server.close();
+          serverDone.complete();
+        } catch (error, stackTrace) {
+          serverDone.completeError(error, stackTrace);
+        }
+      },
+      cancelOnError: false,
+    );
+
+    try {
+      await serverDone.future.timeout(const Duration(seconds: 10));
+    } finally {
+      await server.close();
+      await subscription.cancel();
+    }
+  }
+
+  // Forced short writes can complete without leaving an OS write pending. In
+  // that case the TLS state machine must retry from the reported byte progress
+  // instead of waiting for a transport event which is not guaranteed to fire.
+  await Future.wait([
+    for (var index = 0; index < connectionCount; index++) runOne(index),
+  ]).timeout(const Duration(seconds: 30));
+}
+
+Future<void> testFallbackTransportRejectsInvalidCounts() async {
+  Future<Object> connectWithInvalidTransport({
+    required bool invalidRead,
+  }) async {
+    final server = await RawServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+    final accepted = server.first;
+    final rawClient = await RawSocket.connect(
+      InternetAddress.loopbackIPv4,
+      server.port,
+    );
+    final serverClient = await accepted;
+    final transport = InvalidCountRawSocket(
+      rawClient,
+      invalidRead: invalidRead,
+    );
+    if (invalidRead) {
+      Expect.equals(1, serverClient.write(const [0]));
+    }
+
+    Object? handshakeError;
+    try {
+      await RawSecureSocket.secure(
+        transport,
+        context: clientContext,
+      ).timeout(const Duration(seconds: 5));
+    } catch (error) {
+      handshakeError = error;
+    }
+    await transport.close();
+    await serverClient.close();
+    await server.close();
+    return handshakeError ?? StateError('Invalid transport count was accepted');
+  }
+
+  final invalidWrite = await connectWithInvalidTransport(invalidRead: false);
+  Expect.isTrue(invalidWrite is ArgumentError);
+  Expect.isTrue(invalidWrite.toString().contains('invalid byte count'));
+  final invalidRead = await connectWithInvalidTransport(invalidRead: true);
+  Expect.isTrue(invalidRead is ArgumentError);
+  Expect.isTrue(invalidRead.toString().contains('invalid byte count'));
+}
+
+Future<void> testNativeDescriptorLifetimeAcrossGC() async {
+  // Regression test: On Windows and Fuchsia, fd is a pointer to a heap Handle*
+  // object. If RawSecureSocket secures a RawSocket and the original Dart
+  // RawSocket object is garbage-collected while TLS operations are active, the
+  // native Handle* must not be deleted prematurely.
+  final server = await bindServer();
+  final serverDone = Completer<void>();
+  final payload = makePayload(64 * 1024);
+
+  final serverSubscription = server.listen((socket) async {
+    try {
+      final secureServer = await SecureSocket.secureServer(
+        socket,
+        serverContext,
+        bufferedData: const [],
+      );
+      final received = await consume(secureServer);
+      Expect.equals(payload.length, received.$1);
+      Expect.equals(checksum(payload), received.$2);
+      await secureServer.close();
+      serverDone.complete();
+    } catch (error, stackTrace) {
+      if (!serverDone.isCompleted) {
+        serverDone.completeError(error, stackTrace);
+      }
+    }
+  });
+
+  // Secure client in a scope and drop all references to the underlying Socket.
+  SecureSocket? secureClient;
+  {
+    final plainClient = await Socket.connect(
+      InternetAddress.loopbackIPv4,
+      server.port,
+    );
+    secureClient = await SecureSocket.secure(
+      plainClient,
+      context: clientContext,
+    );
+  }
+
+  // Force memory allocation to trigger GC cycles while the secure socket is active.
+  for (var i = 0; i < 5; i++) {
+    Uint8List(8 * 1024 * 1024);
+  }
+
+  secureClient.add(payload);
+  await secureClient.flush();
+  await secureClient.close();
+
+  await serverDone.future.timeout(const Duration(seconds: 15));
+  secureClient.destroy();
+  await server.close();
+  await serverSubscription.cancel();
+}
+
+Future<void> testAbruptDisconnectDuringHandshakeAndTransfer() async {
+  // Regression test: When a peer abruptly disconnects or aborts during TLS
+  // handshake or I/O, OS error codes (WSAECONNRESET, ERROR_OPERATION_ABORTED,
+  // ECONNRESET, etc.) must not crash the BoringSSL custom socket BIO or abort
+  // the VM. Instead, stream events or Socket/Handshake exceptions must be
+  // delivered gracefully.
+  final server = await bindServer();
+  final serverSubscription = server.listen((socket) async {
+    // Abruptly destroy the socket immediately after accepting.
+    await Future<void>.delayed(const Duration(milliseconds: 5));
+    socket.destroy();
+  });
+
+  for (var i = 0; i < 8; i++) {
+    try {
+      final client = await SecureSocket.connect(
+        InternetAddress.loopbackIPv4,
+        server.port,
+        context: clientContext,
+        timeout: const Duration(seconds: 5),
+      );
+      client.destroy();
+    } catch (e) {
+      Expect.isTrue(
+        e is SocketException ||
+            e is HandshakeException ||
+            e is TimeoutException,
+      );
+    }
+  }
+
+  await server.close();
+  await serverSubscription.cancel();
+}
+
+Future<void> testUpgradeAfterCustomSocketReadClosed() async {
+  // Regression test: A non-native custom RawSocket (such as DelegatingRawSocket
+  // or a custom stream wrapper) upgraded to TLS with an existing subscription
+  // that already consumed the readClosed event must detect the closed state
+  // and fail the handshake gracefully with HandshakeException instead of
+  // hanging indefinitely.
+  final server = await bindServer();
+  final serverClosed = server.first.then((socket) => socket.close());
+  final rawClient = await RawSocket.connect(
+    InternetAddress.loopbackIPv4,
+    server.port,
+  );
+  final customClient = DelegatingRawSocket(rawClient);
+  final readClosed = Completer<void>();
+  final subscription = customClient.listen((event) {
+    if (event == RawSocketEvent.readClosed && !readClosed.isCompleted) {
+      readClosed.complete();
+    }
+  });
+  await readClosed.future;
+
+  Object? handshakeError;
+  try {
+    await RawSecureSocket.secure(
+      customClient,
+      subscription: subscription,
+      context: clientContext,
+    ).timeout(const Duration(seconds: 5));
+  } catch (error) {
+    handshakeError = error;
+  }
+  Expect.isTrue(handshakeError is HandshakeException);
+
+  await customClient.close();
+  await subscription.cancel();
+  final closedServerClient = await serverClosed;
+  closedServerClient.destroy();
+  await server.close();
+}
+
+Future<void> main() async {
+  await testConcurrentShortWriteHandshakeFailures();
+  await testFallbackTransportRejectsInvalidCounts();
+  await testNativeDescriptorLifetimeAcrossGC();
+  await testAbruptDisconnectDuringHandshakeAndTransfer();
+  // This is hundreds of times larger than the initial 1 KiB plaintext rings
+  // and exercises growth and repeated wraparound without encrypted staging.
+  final payload = makePayload(2 * 1024 * 1024 + 257);
+  await testSlowReceiverBackpressure(payload);
+  // A ring reserves one byte to distinguish full from empty, so these are the
+  // exact usable capacities of the 1, 4, and 16 KiB backings.
+  for (final payloadLength in const [1 * 1024, 4 * 1024, 16 * 1024]) {
+    await testFullPlaintextRingBackpressure(payloadLength);
+    await testServerFullPlaintextRingBackpressure(payloadLength);
+  }
+  await testPublicRawSocketImplementation(payload.sublist(0, 64 * 1024 + 17));
+  await testNestedSecureSocketCleanReadClose();
+  await testGrowDuringWriteRetry();
+  await testReentrantFallbackWriteIsBackpressured();
+  await testUpgradeAfterNativeReadClosed();
+  await testUpgradeAfterCustomSocketReadClosed();
+  await testSynchronousFallbackTransportError();
+}


### PR DESCRIPTION
Related to #64115

It replaces the previous [two plaintext and two ciphertext fixed-size rings](https://github.com/DubaiChewyCookie/sdk/blob/0073832ca7fc20d237c61c8fe2b599cae02f1979/sdk/lib/_internal/vm/bin/secure_socket_patch.dart?plain=1#L65-L80) and [buffered BIO pair](https://github.com/DubaiChewyCookie/sdk/blob/0073832ca7fc20d237c61c8fe2b599cae02f1979/runtime/bin/secure_socket_filter.cc?plain=1#L501-L513) with [two growable plaintext rings](https://github.com/DubaiChewyCookie/sdk/blob/600537dd1e14f4570fa03ab7d681841ba1ef350e/sdk/lib/io/secure_socket.dart?plain=1#L1473-L1578) and a [non-buffering custom socket BIO](https://github.com/DubaiChewyCookie/sdk/blob/600537dd1e14f4570fa03ab7d681841ba1ef350e/runtime/bin/secure_socket_filter.cc?plain=1#L450-L638). The rings have 1 KiB, 4 KiB, or 16 KiB of usable capacity, each backing includes one sentinel byte, and ciphertext no longer passes through Dart-visible staging rings.

### Dart I/O layer

- Previously, each filter turn [exposed a native pointer to Dart](https://github.com/DubaiChewyCookie/sdk/blob/0073832ca7fc20d237c61c8fe2b599cae02f1979/sdk/lib/_internal/vm/bin/secure_socket_patch.dart?plain=1#L193-L195). The native getter [retained the `SSLFilter` for the IO-service thread, which released it only when `ProcessFilterRequest` ran](https://github.com/DubaiChewyCookie/sdk/blob/0073832ca7fc20d237c61c8fe2b599cae02f1979/runtime/bin/secure_socket_filter.cc?plain=1#L208-L241), while Dart [awaited IO-service request 43](https://github.com/DubaiChewyCookie/sdk/blob/0073832ca7fc20d237c61c8fe2b599cae02f1979/sdk/lib/io/secure_socket.dart?plain=1#L1215-L1240). An isolate exiting with filter work pending could therefore leave the native filter retained. Filter processing now [runs synchronously through a native entry point](https://github.com/DubaiChewyCookie/sdk/blob/600537dd1e14f4570fa03ab7d681841ba1ef350e/runtime/bin/secure_socket_filter.cc?plain=1#L326-L373), removing that cross-thread ownership and leak path. Dart [serializes handshake attempts](https://github.com/DubaiChewyCookie/sdk/blob/600537dd1e14f4570fa03ab7d681841ba1ef350e/sdk/lib/io/secure_socket.dart?plain=1#L1146-L1208) and [filter turns](https://github.com/DubaiChewyCookie/sdk/blob/600537dd1e14f4570fa03ab7d681841ba1ef350e/sdk/lib/io/secure_socket.dart?plain=1#L1266-L1335), [treats callback reentry as backpressure](https://github.com/DubaiChewyCookie/sdk/blob/600537dd1e14f4570fa03ab7d681841ba1ef350e/sdk/lib/io/secure_socket.dart?plain=1#L958-L1027), schedules filter errors and readiness asynchronously, and [defers native destruction until both are idle](https://github.com/DubaiChewyCookie/sdk/blob/600537dd1e14f4570fa03ab7d681841ba1ef350e/sdk/lib/io/secure_socket.dart?plain=1#L885-L900).

- Previously, TLS upgrade [queried already-consumed read-close state through a hard `_RawSocketBase` cast](https://github.com/DubaiChewyCookie/sdk/blob/0073832ca7fc20d237c61c8fe2b599cae02f1979/sdk/lib/io/secure_socket.dart?plain=1#L761-L762) and [dispatched that state before replacing subscription callbacks or connecting the filter](https://github.com/DubaiChewyCookie/sdk/blob/0073832ca7fc20d237c61c8fe2b599cae02f1979/sdk/lib/io/secure_socket.dart?plain=1#L684-L720). With a supplied subscription, this rejected public delegating sockets at the cast. The custom BIO supports them through callbacks, but treating a missing `_RawSocketBase` as open would lose a consumed `readClosed` event and leave the handshake waiting indefinitely. The final implementation therefore [unwraps delegating sockets when inspecting read-close state](https://github.com/DubaiChewyCookie/sdk/blob/600537dd1e14f4570fa03ab7d681841ba1ef350e/sdk/lib/io/secure_socket.dart?plain=1#L812-L834), [captures that state before replacing callbacks, and applies it only after the filter is connected](https://github.com/DubaiChewyCookie/sdk/blob/600537dd1e14f4570fa03ab7d681841ba1ef350e/sdk/lib/io/secure_socket.dart?plain=1#L720-L770), so a consumed close produces `HandshakeException` instead of a cast failure or connection hang.

- The previous encrypted-ring transport could [compare each `RawSocket.write` result with the queued ciphertext and enable write events after a short write](https://github.com/DubaiChewyCookie/sdk/blob/0073832ca7fc20d237c61c8fe2b599cae02f1979/sdk/lib/io/secure_socket.dart?plain=1#L1406-L1415). Direct BIO writes remove that Dart-side comparison, and a positive short write is not guaranteed to produce another socket event. Handshake processing now [uses the byte progress and pending-write state returned by native code to retry until the BIO actually blocks](https://github.com/DubaiChewyCookie/sdk/blob/600537dd1e14f4570fa03ab7d681841ba1ef350e/sdk/lib/io/secure_socket.dart?plain=1#L1146-L1195), while connected filter turns [treat native transport bytes as progress](https://github.com/DubaiChewyCookie/sdk/blob/600537dd1e14f4570fa03ab7d681841ba1ef350e/sdk/lib/io/secure_socket.dart?plain=1#L1419-L1446), preventing connections from hanging while waiting for an event that may never arrive.

### Native TLS and socket layer

- Previously, BoringSSL [exchanged ciphertext through a BIO pair](https://github.com/DubaiChewyCookie/sdk/blob/0073832ca7fc20d237c61c8fe2b599cae02f1979/runtime/bin/secure_socket_filter.cc?plain=1#L769-L817), while Dart [copied that ciphertext between encrypted rings and `RawSocket`](https://github.com/DubaiChewyCookie/sdk/blob/0073832ca7fc20d237c61c8fe2b599cae02f1979/sdk/lib/io/secure_socket.dart?plain=1#L1136-L1175). The custom BIO now [reads and writes a retained native socket directly or invokes Dart transport callbacks](https://github.com/DubaiChewyCookie/sdk/blob/600537dd1e14f4570fa03ab7d681841ba1ef350e/runtime/bin/secure_socket_filter.cc?plain=1#L450-L615) for public `RawSocket` implementations, propagating callback byte counts outside the requested range as catchable `ArgumentError`s. A nested `RawSecureSocket` [deliberately remains a callback transport](https://github.com/DubaiChewyCookie/sdk/blob/600537dd1e14f4570fa03ab7d681841ba1ef350e/sdk/lib/io/secure_socket.dart?plain=1#L836-L849), so an outer TLS layer cannot bypass the inner one. Because native transport bypasses Dart `RawSocket.read` and `write`, the VM now [mirrors availability, write readiness, and profiling counters explicitly](https://github.com/DubaiChewyCookie/sdk/blob/600537dd1e14f4570fa03ab7d681841ba1ef350e/sdk/lib/_internal/vm/bin/socket_patch.dart?plain=1#L2506-L2537).

- Previously, TLS-upgrade `bufferedData` was [sliced in Dart and copied into the encrypted input ring](https://github.com/DubaiChewyCookie/sdk/blob/0073832ca7fc20d237c61c8fe2b599cae02f1979/sdk/lib/io/secure_socket.dart?plain=1#L1136-L1165). It is now copied into native memory in [chunks of at most 16 KiB](https://github.com/DubaiChewyCookie/sdk/blob/600537dd1e14f4570fa03ab7d681841ba1ef350e/runtime/bin/secure_socket_filter.h?plain=1#L71-L74); if a Dart-owned tail remains, [the BIO sets its read-retry flag before reading newer socket bytes](https://github.com/DubaiChewyCookie/sdk/blob/600537dd1e14f4570fa03ab7d681841ba1ef350e/runtime/bin/secure_socket_filter.cc?plain=1#L411-L480), preserving transport order without an unbounded native copy.

- The BIO pair previously kept nonblocking and close handling outside BoringSSL in Dart's [`RawSocket` staging reads and writes](https://github.com/DubaiChewyCookie/sdk/blob/0073832ca7fc20d237c61c8fe2b599cae02f1979/sdk/lib/io/secure_socket.dart?plain=1#L1158-L1174). Since the custom BIO calls `SocketBase` directly, it now [maps nonblocking, reset, and close-related socket results to BIO retry state](https://github.com/DubaiChewyCookie/sdk/blob/600537dd1e14f4570fa03ab7d681841ba1ef350e/runtime/bin/secure_socket_filter.cc?plain=1#L25-L71), allowing `RawSocket` close events to terminate the connection instead of immediately turning those results into `SSL_ERROR_SYSCALL`.

- The previous native filter [owned a BIO-pair endpoint but no native `Socket` or fd](https://github.com/DubaiChewyCookie/sdk/blob/0073832ca7fc20d237c61c8fe2b599cae02f1979/runtime/bin/secure_socket_filter.h?plain=1#L121-L137), so descriptor lifetime belonged to the Dart transport. The custom BIO caches the descriptor across TLS calls. The filter [retains the native `Socket`](https://github.com/DubaiChewyCookie/sdk/blob/600537dd1e14f4570fa03ab7d681841ba1ef350e/runtime/bin/secure_socket_filter.cc?plain=1#L896-L947), also [retains its heap-backed handle on Windows and Fuchsia](https://github.com/DubaiChewyCookie/sdk/blob/600537dd1e14f4570fa03ab7d681841ba1ef350e/runtime/bin/socket.h?plain=1#L61-L74), and [releases both after `SSL_free` frees the BIO](https://github.com/DubaiChewyCookie/sdk/blob/600537dd1e14f4570fa03ab7d681841ba1ef350e/runtime/bin/secure_socket_filter.cc?plain=1#L1086-L1098), preventing use-after-free when the original Dart socket is collected.

- The previous `SSLFilter` constructor [initialized several fields but not its backing arrays](https://github.com/DubaiChewyCookie/sdk/blob/0073832ca7fc20d237c61c8fe2b599cae02f1979/runtime/bin/secure_socket_filter.h?plain=1#L59-L68), leaving [`buffers_` and `dart_buffer_objects_` without initial values](https://github.com/DubaiChewyCookie/sdk/blob/0073832ca7fc20d237c61c8fe2b599cae02f1979/runtime/bin/secure_socket_filter.h?plain=1#L132-L137). `InitializeBuffers` could [return an error before initializing either array](https://github.com/DubaiChewyCookie/sdk/blob/0073832ca7fc20d237c61c8fe2b599cae02f1979/runtime/bin/secure_socket_filter.cc?plain=1#L360-L406), after which the failure path [called `Destroy`](https://github.com/DubaiChewyCookie/sdk/blob/0073832ca7fc20d237c61c8fe2b599cae02f1979/runtime/bin/secure_socket_filter.cc?plain=1#L80-L94), whose cleanup [traversed both ownership arrays](https://github.com/DubaiChewyCookie/sdk/blob/0073832ca7fc20d237c61c8fe2b599cae02f1979/runtime/bin/secure_socket_filter.cc?plain=1#L667-L715); this could access invalid ownership state or attempt invalid cleanup during partial initialization. The new constructor [null-initializes every backing slot](https://github.com/DubaiChewyCookie/sdk/blob/600537dd1e14f4570fa03ab7d681841ba1ef350e/runtime/bin/secure_socket_filter.h?plain=1#L79-L103), and each backing is [reference-counted and wrapped with an `ExternalUint8List` finalizer](https://github.com/DubaiChewyCookie/sdk/blob/600537dd1e14f4570fa03ab7d681841ba1ef350e/runtime/bin/secure_socket_filter.cc?plain=1#L100-L134). Initialization [publishes a backing only after its wrapper succeeds](https://github.com/DubaiChewyCookie/sdk/blob/600537dd1e14f4570fa03ab7d681841ba1ef350e/runtime/bin/secure_socket_filter.cc?plain=1#L762-L832), and growth [releases the filter's old generation only after the replacement wrapper exists](https://github.com/DubaiChewyCookie/sdk/blob/600537dd1e14f4570fa03ab7d681841ba1ef350e/runtime/bin/secure_socket_filter.cc?plain=1#L703-L749), closing the cleanup hole without invalidating an old Dart view.
