### PR TITLE
[docs] Building: Instructions for running uninstalled

### DIFF
--- a/docs/Building.md
+++ b/docs/Building.md
@@ -132,11 +132,12 @@ A notification is a small transient non-modal window, for now, only supported on
 
 ### Running from the build directory
 
-On Linux and macOS, if you wish to use the `dart` tool uninstalled after building the Dart SDK, the subdirectory `sdk/bin/` contains a `dart` launcher script which will generate correct paths to the `dart` executable when invoking it. This directory should be added to your `PATH`, rather than the build output directory. If `dart` is run from the output directory, some tools (such as `dart run`) will generate incorrect paths when executing other tools. To set the correct `PATH` for running uninstalled, after building Dart SDK:
+On Linux and macOS, if you wish to use the `dart` tool uninstalled after building the Dart SDK, you should add the directory `dart-sdk/bin` inside the output directory to your `$PATH`. While there is a `dart` binary at the top level of the output directory, some tools (such as `dart run`) will generate incorrect paths when executing other tools if run from that location. For example, if building `--release` on Linux x64, building the SDK and setting the correct `PATH` for running uninstalled would look like:
 ```bash
 
 # From within the "dart-sdk/sdk" directory.
-export PATH="$PATH:$(pwd)/sdk/bin"
+./tools/build.py --release create_sdk
+export PATH="$PATH:$(pwd)/out/ReleaseX64/dart-sdk/bin"
 dart --version
 ```
 

--- a/docs/Building.md
+++ b/docs/Building.md
@@ -130,6 +130,16 @@ The environment variable `DART_BUILD_NOTIFICATION_DELAY` controls if `build.py` 
 
 A notification is a small transient non-modal window, for now, only supported on Mac and Linux.
 
+### Running from the build directory
+
+On Linux and macOS, if you wish to use the `dart` tool uninstalled after building the Dart SDK, the subdirectory `sdk/bin/` contains a `dart` launcher script which will generate correct paths to the `dart` executable when invoking it. This directory should be added to your `PATH`, rather than the build output directory. If `dart` is run from the output directory, some tools (such as `dart run`) will generate incorrect paths when executing other tools. To set the correct `PATH` for running uninstalled, after building Dart SDK:
+```bash
+
+# From within the "dart-sdk/sdk" directory.
+export PATH="$PATH:$(pwd)/sdk/bin"
+dart --version
+```
+
 ## Special note for Windows users using Visual Studio Community Edition:
 Your Visual Studio executable command may have a different name from the standard Visual Studio installations. You can specify the name for that executable by passing the additional flag "--executable=$VS\_EXECUTABLE\_NAME" to build.py. The executable name will probably be something like "VSExpress.exe".
 


### PR DESCRIPTION
Add a subsection to "Tips" about using the `sdk/bin/dart` launcher script on Linux & macOS, when running `dart` from the build directory. Running directly from the output directory causes incorrect paths to be used by some subcommands (`dart run`) when relaunching `dart`.

Though running from the build dir was not previously covered in the doc at all, the output directory is discussed several times, so it would be understandable for users to attempt to use it as the `$PATH` location of `dart` after building. This does not work for some tools. (See sanitized example console transcripts below.)

### Wrong

```console
$ cd sdk
$ ./tools/build.py --mode release create_sdk
$ export PATH="$PATH:$(pwd)/out/ReleaseX64"

$ # (Later, in the dart-sass project directory...)
$ dart run grinder protobuf
Building package executable... 
ProcessException: No such file or directory
  Command: ../dart-sdk/sdk/out/bin/dart ../dart-sdk/sdk/out/bin/snapshots/frontend_server.dart.snapshot --sdk-root ../dart-sdk/sdk/out --platform=lib/_internal/vm_platform_strong.dill --target=vm --filesystem-scheme org-dartlang-root --output-dill /path/to/dart-sass/.dart_tool/pub/bin/grinder/tmpSPGUQS/grinder.dart-3.14.0-edge.32e0b7eb7782beb850893e5b2c4e94cc776f9b10.snapshot.incremental.temp --packages=.dart_tool/package_config.json --incremental --no-print-incremental-dependencies
#0      _ProcessImpl._start (dart:io-patch/process_patch.dart:411)
#1      Process.start (dart:io-patch/process_patch.dart:42)
#2      FrontendServerClient.start (package:frontend_server_client/src/frontend_server_client.dart:144)
#3      precompile (package:pub/src/dart.dart:142)
#4      Entrypoint._precompileExecutable (package:pub/src/entrypoint.dart:777)
#5      Entrypoint.precompileExecutable.<anonymous closure> (package:pub/src/entrypoint.dart:762)
#6      progress (package:pub/src/log.dart:455)
#7      Entrypoint.precompileExecutable (package:pub/src/entrypoint.dart:760)
#8      getExecutableForCommand.<anonymous closure> (package:pub/src/executable.dart:428)
#9      errorsOnlyUnlessTerminal (package:pub/src/log.dart:438)
#10     getExecutableForCommand (package:pub/src/executable.dart:427)
<asynchronous suspension>
#11     RunCommand._runLocal (package:dartdev/src/commands/run.dart:551)
<asynchronous suspension>
#12     CommandRunner.runCommand (package:args/command_runner.dart:236)
<asynchronous suspension>
#13     DartdevRunner.runCommand (package:dartdev/dartdev.dart:328)
<asynchronous suspension>
#14     runDartdev (package:dartdev/dartdev.dart:55)
<asynchronous suspension>
#15     main (file:///path/to/dart-sdk/sdk/pkg/dartdev/bin/dartdev.dart:13)
<asynchronous suspension>
```

### Right
```console
$ cd sdk
$ ./tools/build.py --mode release create_sdk
$ export PATH="$PATH:$(pwd)/sdk/bin"

$ # (Later, in the dart-sass project directory...)
$ dart run grinder protobuf
Building package executable... 
Built grinder:grinder.
grinder running update-language-repo protobuf

update-language-repo
  git init build/language
  Initialized empty Git repository in /path/to/dart-sass/build/language/.git/
  git config advice.detachedHead false
  git remote add origin https://github.com/sass/sass.git
  git fetch origin --depth=1 main
  From https://github.com/sass/sass
   * branch            main       -> FETCH_HEAD
   * [new branch]      main       -> origin/main
  git checkout FETCH_HEAD
  HEAD is now at f7fbdb1 [Analogous Sets] Flush to spec (#4242)
  

protobuf
  Writing protoc-gen-dart
  chmod a+x build/protoc-gen-dart
  buf generate

finished in 16.5 seconds
```
---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
