### PR TITLE
Range check kernel binary trailing-index reads

### DIFF
--- a/runtime/vm/kernel_loader.cc
+++ b/runtime/vm/kernel_loader.cc
@@ -390,6 +390,9 @@ void KernelLoader::InitializeFields(UriToSourceTable* uri_to_source_table) {
   Reader reader(binary);
   reader.set_offset(program_->string_table_offset());
   intptr_t count = reader.ReadUInt() + 1;
+  if (count < 0 || count > reader.size()) {
+    FATAL("Invalid kernel binary: string table count out of range");
+  }
   const auto& offsets = TypedData::Handle(
       Z, TypedData::New(kTypedDataUint32ArrayCid, count, Heap::kOld));
   offsets.SetUint32(0, 0);
@@ -400,6 +403,9 @@ void KernelLoader::InitializeFields(UriToSourceTable* uri_to_source_table) {
   }
 
   // Create view of the string data.
+  if (end_offset < 0 || reader.offset() + end_offset > reader.size()) {
+    FATAL("Invalid kernel binary: string table end offset out of range");
+  }
   const auto& string_data = TypedDataView::Handle(
       reader.ViewFromTo(reader.offset(), reader.offset() + end_offset));
 
@@ -680,6 +686,10 @@ void KernelLoader::walk_incremental_kernel(BitVector* modified_libs,
     }
     if (collect_library_stats) {
       intptr_t library_end = library_offset(i + 1);
+      if (library_end < kernel_offset ||
+          library_end > helper_.reader_.size()) {
+        FATAL("Invalid kernel binary: library offset out of range");
+      }
       library_kernel_data_ =
           helper_.reader_.ViewFromTo(kernel_offset, library_end);
       LibraryIndex library_index(library_kernel_data_);


### PR DESCRIPTION
The kernel loader reads the string-table count, the string-data end offset, and the library offsets from the trailing index of a `.dill` file and feeds them unchecked into `TypedData::New` and `Reader::ViewFromTo`. The bounds that exist inside those helpers are `ASSERT`s, which are stripped in release/product builds — so a malformed kernel binary produces out-of-bounds `TypedDataView`s that are then read past the buffer during string decoding, and unbounded allocations from a corrupted library count.

This adds range checks against `Reader::size()` at the three read sites, in the same style as the existing `library_count` range check (#63366) and the size check at `kernel_loader.cc:352` (`FATAL("Invalid kernel binary: …")`).

This fixes memory-safety issues reported via a private security advisory (out-of-bounds reads / SEGV in `dart run`, `dart compile`, and `gen_snapshot` on crafted kernel binaries). I have single-field-corruption mutants of a real `.dill` plus a generator script ready to contribute as regression tests, and am happy to rework these into unit tests or coordinate landing however the team prefers given the advisory.