### PR TITLE
[analysis_server] Do not offer CreateClass for method invocations on non-prefix targets

### DIFF
--- a/pkg/analysis_server/lib/src/services/correction/dart/create_class.dart
+++ b/pkg/analysis_server/lib/src/services/correction/dart/create_class.dart
@@ -50,11 +50,13 @@ class CreateClass extends MultiCorrectionProducer {
       requiresConstConstructor |= _requiresConstConstructor(targetNode);
     } else if (targetNode case SimpleIdentifier(:var parent)
         when parent is! PropertyAccess && parent is! PrefixedIdentifier) {
-      if (parent case MethodInvocation(:var target)) {
-        if (target case SimpleIdentifier(:PrefixElement element)) {
-          prefixElement = element;
-        } else if (target?.staticType != null) {
-          return const [];
+      if (parent case MethodInvocation(:var target, :var methodName)) {
+        if (targetNode == methodName) {
+          if (target case SimpleIdentifier(:PrefixElement element)) {
+            prefixElement = element;
+          } else if (target != null) {
+            return const [];
+          }
         }
       }
       className = targetNode.nameOfType ?? targetNode.name;

--- a/pkg/analysis_server/test/src/services/correction/fix/create_class_test.dart
+++ b/pkg/analysis_server/test/src/services/correction/fix/create_class_test.dart
@@ -55,6 +55,17 @@ String? f(C c) => c.foo();
     await assertNoFix();
   }
 
+  Future<void> test_staticMethod_noFix() async {
+    await resolveTestCode('''
+class C {}
+
+void f() {
+  C.m();
+}
+''');
+    await assertNoFix();
+  }
+
   Future<void> test_lowercaseAssignment() async {
     await resolveTestCode('''
 void f() {
@@ -326,6 +337,17 @@ class A {
 
 void f() {
   int _ = A.Test;
+}
+''');
+    await assertNoFix();
+  }
+
+  Future<void> test_class_staticMethod() async {
+    await resolveTestCode('''
+class A {}
+
+void f() {
+  A.Test();
 }
 ''');
     await assertNoFix();
@@ -636,6 +658,18 @@ var a = [Foo.bar];
 ''');
     await assertHasFix('''
 var a = [Foo.bar];
+
+class Foo {
+}
+''');
+  }
+
+  Future<void> test_withStaticMethod() async {
+    await resolveTestCode('''
+var a = [Foo.bar()];
+''');
+    await assertHasFix('''
+var a = [Foo.bar()];
 
 class Foo {
 }


### PR DESCRIPTION
### Summary
Do not offer the `Create class` quick fix on method invocations where the target is not an import prefix.

In Dart, an invocation of the form `target.name()` can only be a class instantiation if `target` is an import prefix (`PrefixElement`). Previously, when calling an undefined member on a class (e.g. `C.m()`), `target.staticType` evaluated to `null`, causing `CreateClass` to erroneously offer to create a top-level `class m`.

Fixes https://github.com/dart-lang/sdk/issues/64192
Work towards https://github.com/dart-lang/sdk/issues/63444

### Changes
- Updated `CreateClass.producers` in `pkg/analysis_server/lib/src/services/correction/dart/create_class.dart` to verify that when `targetNode == methodName`, `target` must either be `null` (unqualified invocation) or a `PrefixElement`. If `target != null` and not an import prefix, creating a class is rejected.
- Added unit tests in `pkg/analysis_server/test/src/services/correction/fix/create_class_test.dart` covering lowercase and uppercase static method invocations, as well as preserving support for undefined target invocations (e.g. `Foo.bar()`).
