### PR TITLE
analyzer_utilities: Handle HTML comments containing > and newlines

### DIFF
--- a/pkg/analyzer_utilities/lib/html_parser.dart
+++ b/pkg/analyzer_utilities/lib/html_parser.dart
@@ -12,7 +12,7 @@ import 'html_dom.dart';
 
 /// Given HTML text, return a parsed HTML tree.
 Document parse(String htmlContents, Uri uri) {
-  RegExp commentRegex = RegExp(r'<!--[^>]+-->');
+  var commentRegex = RegExp(r'<!--.*?-->', dotAll: true);
 
   Element createElement(XmlElement xmlElement) {
     // element

--- a/pkg/analyzer_utilities/test/html_parser_test.dart
+++ b/pkg/analyzer_utilities/test/html_parser_test.dart
@@ -1,0 +1,35 @@
+// Copyright (c) 2026, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer_utilities/html_parser.dart' as html_parser;
+import 'package:test/test.dart';
+
+void main() {
+  test('removes empty HTML comments', () {
+    var document = html_parser.parse(
+      '<div><!---->hello</div>',
+      Uri.parse('test.html'),
+    );
+
+    expect(document.outerHtml, '<!DOCTYPE html><div>hello</div>\n');
+  });
+
+  test('removes comments containing greater-than signs', () {
+    var document = html_parser.parse(
+      '<div><!-- a > b -->hello</div>',
+      Uri.parse('test.html'),
+    );
+
+    expect(document.outerHtml, '<!DOCTYPE html><div>hello</div>\n');
+  });
+
+  test('removes multiline comments', () {
+    var document = html_parser.parse(
+      '<div><!--\nmultiline\ncomment\n-->hello</div>',
+      Uri.parse('test.html'),
+    );
+
+    expect(document.outerHtml, '<!DOCTYPE html><div>hello</div>\n');
+  });
+}


### PR DESCRIPTION
Fix HTML comment removal in the lightweight HTML parser.

The parser currently removes comments from text nodes with:

    RegExp(r'<!--[^>]+-->')

This fails for valid comments such as:

    <div><!---->hello</div>
    <div><!-- a > b -->hello</div>

Multiline comments are also not removed. Since the lightweight DOM does not represent comments as separate nodes, these comments incorrectly remain as ordinary Text nodes.

Use a non-greedy dotAll regular expression so empty, multiline, and comments containing `>` are removed before text nodes are created.

Tests:
- empty HTML comments
- comments containing `>`
- multiline comments

Relevant issues: None. This is a small, self-contained bug fix.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
