### PR TITLE
[dds] Validate Origin headers for all DevTools API requests

### DIFF
--- a/pkg/dds/lib/src/devtools/handler.dart
+++ b/pkg/dds/lib/src/devtools/handler.dart
@@ -184,16 +184,19 @@ FutureOr<Handler> defaultHandler({
       }
     }
 
+    // Validate Origin for all API requests, including state-changing GETs.
+    // Preserve the existing policy: absent Origin headers and allowed
+    // loopback origins are accepted.
+    if (originCheckEnabled) {
+      final origin = request.headers['Origin'];
+      if (origin != null && !isAllowedOrigin(origin)) {
+        return Response.forbidden('forbidden origin');
+      }
+    }
+
     final method = request.url.pathSegments[1];
 
-    // Origin check specifically for api/sse to prevent CSRF.
     if (method == 'sse') {
-      if (originCheckEnabled) {
-        final origin = request.headers['Origin'];
-        if (origin != null && !isAllowedOrigin(origin)) {
-          return Response.forbidden('forbidden origin');
-        }
-      }
       return devToolsApiHandler.handler(request);
     }
 

--- a/pkg/dds/test/devtools_server/security_test.dart
+++ b/pkg/dds/test/devtools_server/security_test.dart
@@ -52,6 +52,37 @@ void main() {
         expect(response.statusCode, HttpStatus.forbidden);
         await response.drain();
       });
+
+      test('forbids GET request with bad Origin Header to /api/ping', () async {
+        final request = await client.getUrl(serverUri.resolve('api/ping'));
+        request.headers.set('Origin', 'http://evil.example.com');
+        final response = await request.close();
+        expect(response.statusCode, HttpStatus.forbidden);
+        await response.drain();
+      });
+
+      test(
+          'forbids GET request with bad Origin Header to '
+          '/api/setPreferenceValue', () async {
+        // The delegated ServerApi route, exercised before dispatch, so no
+        // query parameters are needed and no state is changed.
+        final request =
+            await client.getUrl(serverUri.resolve('api/setPreferenceValue'));
+        request.headers.set('Origin', 'http://evil.example.com');
+        final response = await request.close();
+        expect(response.statusCode, HttpStatus.forbidden);
+        await response.drain();
+      });
+
+      test('allows GET request with loopback Origin to /api/ping', () async {
+        // A debug frontend served from another loopback port is a documented
+        // workflow, and isAllowedOrigin always allows loopback origins.
+        final request = await client.getUrl(serverUri.resolve('api/ping'));
+        request.headers.set('Origin', 'http://127.0.0.1:42000');
+        final response = await request.close();
+        expect(response.statusCode, HttpStatus.ok);
+        await response.drain();
+      });
     });
 
     group('Disable Origin Check', () {
@@ -89,6 +120,14 @@ void main() {
         request.headers.set('Origin', 'http://evil.example.com');
         final response = await request.close();
         expect(response.statusCode, isNot(HttpStatus.forbidden));
+        await response.drain();
+      });
+
+      test('allows bad Origin Header to /api/ping', () async {
+        final request = await client.getUrl(serverUri.resolve('api/ping'));
+        request.headers.set('Origin', 'http://evil.example.com');
+        final response = await request.close();
+        expect(response.statusCode, HttpStatus.ok);
         await response.drain();
       });
     });


### PR DESCRIPTION
The standalone DevTools server validates Origin only for `api/sse`. Other API routes include state-changing GET handlers and currently accept requests carrying a disallowed Origin header. This extends the DevTools Origin check introduced by https://dart-review.googlesource.com/c/sdk/+/528242 to all `/api/*` requests, moving the existing check before API dispatch (including `api/ping`).

Host validation, loopback origins, requests without an Origin header, SSE dispatch, and the `--disable-service-origin-check` opt-out are all preserved. This extends Origin validation; Origin-less requests remain accepted. `--disable-cors` continues to control response headers and does not disable Host or Origin validation.

Tests cover foreign-Origin rejection on non-SSE APIs (including the delegated `api/setPreferenceValue` route), allowed loopback and absent Origins, and the explicit opt-out.

```
TEST=pkg/dds/test/devtools_server/security_test.dart
```

Local validation: the 9 tests in this file pass against a server built from this change using a temporary launcher (not included); `dart format` clean; no full SDK build was run. Note for reproduction: the stock test driver spawns `dart devtools` from the running SDK, which serves the bundled snapshot rather than this change, so upstream reproduction should run the test with an SDK rebuilt from this branch.

Bug: 559604495

- [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>

