### PR TITLE
[vm] Steal a mutator slot eagerly when every holder is blocked in native code

### DIFF
--- a/runtime/vm/isolate.cc
+++ b/runtime/vm/isolate.cc
@@ -597,6 +597,11 @@ void IsolateGroup::IncreaseMutatorCount(Thread* thread,
     // max_active_mutators) and only use monitors in the uncommon case.
     MonitorLocker ml(active_mutators_monitor_.get());
     ASSERT(active_mutators_ <= max_active_mutators_);
+    if (active_mutators_ == max_active_mutators_ && !was_stolen) {
+      active_mutators_ -=
+          thread_registry()->StealActiveMutators(thread_pool(), /*limit=*/1);
+      ASSERT(active_mutators_ >= 0);
+    }
     while (active_mutators_ == max_active_mutators_) {
       waiting_mutators_++;
       bool timed_out = false;

--- a/runtime/vm/thread_registry.cc
+++ b/runtime/vm/thread_registry.cc
@@ -116,11 +116,11 @@ void ThreadRegistry::FlushMarkingStacks() {
   }
 }
 
-intptr_t ThreadRegistry::StealActiveMutators(ThreadPool* pool) {
+intptr_t ThreadRegistry::StealActiveMutators(ThreadPool* pool, intptr_t limit) {
   MonitorLocker ml(threads_lock());
   intptr_t count = 0;
   Thread* thread = active_list_;
-  while (thread != nullptr) {
+  while (thread != nullptr && (limit == 0 || count < limit)) {
     if (thread->TryStealActiveMutator()) {
       pool->MarkWorkerAsBlocked(thread->os_thread());
       count++;

--- a/runtime/vm/thread_registry.h
+++ b/runtime/vm/thread_registry.h
@@ -38,7 +38,7 @@ class ThreadRegistry {
   void AcquireMarkingStacks();
   void ReleaseMarkingStacks();
   void FlushMarkingStacks();
-  intptr_t StealActiveMutators(ThreadPool* pool);
+  intptr_t StealActiveMutators(ThreadPool* pool, intptr_t limit = 0);
 
   // Concurrent-approximate number of active isolates in the active_list
   intptr_t active_isolates_count() { return active_isolates_count_.load(); }

--- a/tests/ffi/threading_mutator_slot_latency_test.dart
+++ b/tests/ffi/threading_mutator_slot_latency_test.dart
@@ -1,0 +1,209 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+//
+// Regression test for https://github.com/dart-lang/sdk/issues/51261.
+//
+// An isolate group allows at most Scavenger::MaxMutatorThreadCount() threads
+// to hold a mutator at once. A thread that blocks in native code keeps its
+// slot but is "stealable"; a thread waiting for a slot may steal one, but only
+// after kActiveMutatorPreemptionTimeout (120 ms) of uninterrupted waiting.
+//
+// When the slot holders are native threads that periodically cycle through
+// runEventLoopSync (which exits and re-enters the group), each cycle notifies
+// the waiter and restarts its timeout, so the steal never happens and the
+// waiter only ever runs in the brief hand-off between two cycles. With a
+// cycle period shorter than the timeout, a plain message round trip between
+// two unrelated isolates degrades from microseconds to the holders' cycle
+// period.
+//
+// VMOptions=--new_gen_semi_max_size=8
+
+import 'dart:async';
+import 'dart:ffi';
+import 'dart:io';
+import 'dart:isolate';
+
+import "package:expect/async_helper.dart";
+import 'package:expect/expect.dart';
+import 'package:ffi/ffi.dart';
+
+import 'threading_utils.dart';
+
+// --new_gen_semi_max_size=8 gives MaxMutatorThreadCount() == 4. With this many
+// holders every slot is taken before the main isolate or the echo isolate
+// wants one.
+const int holderCount = 4;
+
+// Shorter than kActiveMutatorPreemptionTimeout, so the holders keep
+// interrupting the waiter's timeout.
+const int holderCyclePeriodMicros = 20 * 1000;
+
+typedef UsleepNFT = Int32 Function(Uint32);
+typedef UsleepFT = int Function(int);
+final usleep = DynamicLibrary.process().lookupFunction<UsleepNFT, UsleepFT>(
+  'usleep',
+);
+
+/// Per holder, in native memory: [0] is the holder's state (see
+/// [holderMain]), [1] is set by the main isolate to make it stop.
+class Holder {
+  final ThreadInfo threadInfo = ThreadInfo();
+  final Pointer<Int32> cells = calloc<Int32>(2);
+  int get state => cells[0];
+  bool get started => state != 0;
+  void stop() => cells[1] = 1;
+}
+
+// Keeps a holder isolate alive between drains; an isolate without open ports
+// exits on its first runEventLoopSync.
+late RawReceivePort holderPort;
+
+const int holderRunning = 1;
+const int holderDone = 2;
+const int holderFailed = 3;
+
+/// Runs on a native thread, outside any isolate: owns an isolate and drains
+/// it forever, blocking in native code between drains. The thread holds a
+/// mutator slot for as long as the loop lives, and is stealable while it is
+/// inside usleep.
+///
+/// An exception here would silently end the thread through
+/// [exceptionalReturn], and a holder that dies is a holder that no longer
+/// holds, so the state is reported back through [data] and checked by main.
+int holderMain(Pointer<Void> data) {
+  final cells = data.cast<Int32>();
+  try {
+    final isolate = Isolate.create(debugName: 'holder');
+    isolate.runSync(() {
+      holderPort = RawReceivePort((_) {});
+    });
+    cells[0] = holderRunning;
+    while (cells[1] == 0) {
+      usleep(holderCyclePeriodMicros);
+      isolate.runEventLoopSync();
+    }
+    isolate.runSync(() {
+      holderPort.close();
+    });
+    isolate.shutdownSync();
+    cells[0] = holderDone;
+    return 0;
+  } catch (e) {
+    cells[0] = holderFailed;
+    return -1;
+  }
+}
+
+Holder startHolder() {
+  final holder = Holder();
+  final threadInfo = holder.threadInfo;
+  Expect.equals(0, pthreadAttrInit(threadInfo.ptr_attr));
+  final callback =
+      NativeCallable<IntPtr Function(Pointer<Void>)>.isolateGroupBound(
+        holderMain,
+        exceptionalReturn: -1,
+      );
+  Expect.equals(
+    0,
+    pthreadCreate(
+      threadInfo.ptr_tid,
+      threadInfo.ptr_attr,
+      callback.nativeFunction,
+      holder.cells.cast<Void>(),
+    ),
+  );
+  return holder;
+}
+
+void echoMain(SendPort reply) {
+  final port = RawReceivePort();
+  port.handler = (message) {
+    if (message == null) {
+      port.close();
+      return;
+    }
+    reply.send(message);
+  };
+  reply.send(port.sendPort);
+}
+
+Future<double> measureRoundTripMicros(
+  SendPort echo,
+  StreamIterator<dynamic> replies,
+  int rounds,
+) async {
+  final stopwatch = Stopwatch()..start();
+  for (int i = 0; i < rounds; i++) {
+    echo.send(i);
+    Expect.isTrue(await replies.moveNext());
+    Expect.equals(i, replies.current);
+  }
+  return stopwatch.elapsedMicroseconds / rounds;
+}
+
+main(List<String> args) async {
+  if (Platform.isWindows) {
+    // pthread library loading doesn't work on Windows.
+    return;
+  }
+  asyncStart();
+
+  final replyPort = ReceivePort();
+  final replies = StreamIterator<dynamic>(replyPort);
+  await Isolate.spawn(echoMain, replyPort.sendPort);
+  Expect.isTrue(await replies.moveNext());
+  final echo = replies.current as SendPort;
+
+  // Warm up and measure with no contention.
+  await measureRoundTripMicros(echo, replies, 100);
+  final baseline = await measureRoundTripMicros(echo, replies, 200);
+
+  // Start the holders one at a time: each needs to run Dart to set itself up,
+  // and once every slot is taken that only works while no other holder is
+  // doing the same.
+  final holders = <Holder>[];
+  for (int i = 0; i < holderCount; i++) {
+    final holder = startHolder();
+    holders.add(holder);
+    while (!holder.started) {
+      await Future.delayed(const Duration(milliseconds: 10));
+    }
+  }
+
+  await measureRoundTripMicros(echo, replies, 20);
+  final contended = await measureRoundTripMicros(echo, replies, 200);
+  print(
+    'round trip: ${baseline.toStringAsFixed(1)} us uncontended, '
+    '${contended.toStringAsFixed(1)} us with $holderCount holders',
+  );
+  final holderStates = holders.map((h) => h.state).toList();
+
+  // Tear down before asserting: exiting with an error while the holder
+  // threads still cycle through the group ends in a crash rather than a
+  // readable failure.
+  for (final holder in holders) {
+    holder.stop();
+  }
+  for (final holder in holders) {
+    holder.threadInfo.joinAndDestroy();
+    Expect.equals(holderDone, holder.state, 'a holder failed to shut down');
+    calloc.free(holder.cells);
+  }
+  echo.send(null);
+  replyPort.close();
+
+  for (final state in holderStates) {
+    Expect.equals(holderRunning, state, 'a holder thread died');
+  }
+  // Before the fix this is about holderCyclePeriodMicros per round trip
+  // (roughly 1000x the baseline); after it, the two are indistinguishable.
+  // The bound leaves a wide margin for slow bots while still failing on the
+  // convoy, which is a fixed multiple of the cycle period.
+  Expect.isTrue(
+    contended < holderCyclePeriodMicros / 4,
+    'round trip under contention took ${contended.toStringAsFixed(1)} us, '
+    'expected well under ${holderCyclePeriodMicros / 4} us',
+  );
+  asyncEnd();
+}


### PR DESCRIPTION
While working on a library that is an alternative to isolates (many lightweight isolates multiplexed onto a few native threads that each own a real isolate through `Isolate.create` and `runEventLoopSync`), I was doing some benchmark work against plain isolates and it caught my attention that when running several of those threads the latency of a message round trip didn't degrade gradually. It was flat at about 0.01 ms up to 7 threads and then jumped to over 100 ms at 8, every run, and only under Flutter. The same program on the `dart` CLI was flat past 12. It turned out the difference is `new_gen_semi_max_size`: Flutter runs the VM default of 16, the CLI reports 32, and the number of threads that may hold a mutator at once is half of that, so the cliff was at 8 in one and 16 in the other. Moving the flag on the CLI moved the cliff exactly where the formula said it would. I filed flutter/flutter#192343 for the Flutter side (an app can't change that flag), then found dart-lang/sdk#51261, which already describes the limit itself, and went into the VM to see why crossing it costs three orders of magnitude instead of degrading. This PR is what came out of that.

The part that surprised me is that the existing steal path never runs. `IncreaseMutatorCount` waits 120 ms before stealing a slot from a holder that is blocked in native code, but every notify restarts that wait. If the holders are threads that cycle through `runEventLoopSync` (an embedder thread that owns an isolate, say), each cycle exits and re-enters the group and notifies the waiter, so with any cycle period under 120 ms the timeout can't elapse. The waiter only ever gets in during that hand-off. I put a temporary dump of the active mutator list in to check: during the collapse no timeout fires at all, and the only thing that ever releases the waiter is a holder's `ExitIsolateGroupAsMutator`.

Standalone version. `--new_gen_semi_max_size=8` makes the cap 4. Four native threads each own an isolate and loop on `usleep(20 ms)` then `runEventLoopSync()`. Main sends messages to an unrelated isolate and times the round trip as holders are added.

```dart
// dart --new_gen_semi_max_size=8 mutator_slot_repro.dart
//
// --new_gen_semi_max_size=8 makes Scavenger::MaxMutatorThreadCount() 4.
// Each "holder" is a native thread that owns an isolate and cycles
// usleep(20 ms) / runEventLoopSync(), so it holds a mutator slot and is
// blocked in native code most of the time. Main measures a message round
// trip to an unrelated isolate as holders are added.
import 'dart:async';
import 'dart:ffi';
import 'dart:io';
import 'dart:isolate';

typedef PthreadCreateN = IntPtr Function(
  Pointer<IntPtr>,
  Pointer<Void>,
  Pointer,
  Pointer<Void>,
);
typedef PthreadCreateD = int Function(
  Pointer<IntPtr>,
  Pointer<Void>,
  Pointer,
  Pointer<Void>,
);
typedef UsleepN = Int32 Function(Uint32);
typedef UsleepD = int Function(int);
typedef MallocN = Pointer<Void> Function(IntPtr);
typedef MallocD = Pointer<Void> Function(int);

late RawReceivePort keepAlive;

int holderMain(Pointer<Void> _, SendPort up) {
  final usleep = DynamicLibrary.process().lookupFunction<UsleepN, UsleepD>(
    'usleep',
  );
  final upPort = up; // runSync closures may only capture final locals
  final isolate = Isolate.create(debugName: 'holder');
  isolate.runSync(() {
    keepAlive = RawReceivePort((_) {}); // an isolate without ports exits
    upPort.send(null);
  });
  while (true) {
    usleep(20 * 1000);
    isolate.runEventLoopSync();
  }
}

void echoMain(SendPort reply) {
  final inbox = RawReceivePort();
  inbox.handler = reply.send;
  reply.send(inbox.sendPort);
}

Future<double> roundTripMicros(
  SendPort echo,
  StreamIterator<dynamic> replies,
  int rounds,
) async {
  final sw = Stopwatch()..start();
  for (var i = 0; i < rounds; i++) {
    echo.send(i);
    await replies.moveNext();
  }
  return sw.elapsedMicroseconds / rounds;
}

Future<void> main() async {
  final lib = DynamicLibrary.process();
  final pthreadCreate = lib.lookupFunction<PthreadCreateN, PthreadCreateD>(
    'pthread_create',
  );
  final malloc = lib.lookupFunction<MallocN, MallocD>('malloc');

  final replies = ReceivePort();
  final replyIt = StreamIterator<dynamic>(replies);
  await Isolate.spawn(echoMain, replies.sendPort);
  await replyIt.moveNext();
  final echo = replyIt.current as SendPort;

  final up = ReceivePort();
  final upIt = StreamIterator<dynamic>(up);
  final upPort = up.sendPort;
  final holder =
      NativeCallable<IntPtr Function(Pointer<Void>)>.isolateGroupBound(
        (p) => holderMain(p, upPort),
        exceptionalReturn: -1,
      );

  print('holders  round trip');
  print(
    '      0  ${(await roundTripMicros(echo, replyIt, 200)).toStringAsFixed(1)} us',
  );
  for (var n = 1; n <= 4; n++) {
    pthreadCreate(malloc(8).cast(), nullptr, holder.nativeFunction, nullptr);
    await upIt.moveNext(); // holders start one at a time
    print(
      '      $n  ${(await roundTripMicros(echo, replyIt, 50)).toStringAsFixed(1)} us',
    );
  }
  exit(0);
}
```

Stock 3.13.1, or this checkout without the patch:

```
$ dart --new_gen_semi_max_size=8 mutator_slot_repro.dart
holders  round trip
      0  7.5 us
      1  12.4 us
      2  5.5 us
      3  5.1 us
      4  83182.4 us
```

With the patch:

```
holders  round trip
      0  7.3 us
      1  9.4 us
      2  4.8 us
      3  5.1 us
      4  6.3 us
```

At the default cap of 16 you need 16 holders to see it. Under Flutter the engine runs with `new_gen_semi_max_size=16`, so 8.

The fix: when a thread finds every slot taken, steal one from a holder that is in native code right away, then fall into the existing timed wait if that didn't free anything. `StealActiveMutators` gets a `limit` argument so this path only takes one slot; the timeout path still takes all of them. A thread that just had its own slot stolen skips the eager steal when it comes back, otherwise stolen threads would trade slots with each other. Threads actually running Dart aren't stealable, so nothing changes for them.

Cost. I looked for the worst case for this: 12 isolates at a cap of 4 doing nothing but `File.statSync()` in a loop, so every holder is a steal target all the time. Throughput went from about 2.2M to 1.6M ops/s. That's real, but what the old behaviour buys there is four threads keeping the group to themselves in 120 ms slices while the other eight wait. Stealing every stealable holder instead of one was worse (about 1.35M), and lowering the timeout to 2 or 10 ms was worse still and very uneven between workers, so I didn't go with either of those.

Test: `tests/ffi/threading_mutator_slot_latency_test.dart`, same shape as the repro but using the pthread helpers already in `tests/ffi`. Unpatched it fails with a round trip around 70 ms against a 5 ms bound; patched it's around 5 us. Two things in it are there because the obvious version doesn't work. The holder isolates keep a port open, since an isolate with no ports exits on its first `runEventLoopSync`. And the holders start one at a time, because starting four at once at a cap of four left each of them holding one slot while waiting for a second, with none of them stealable. `limited_active_mutator_test` and `many_isolates_blocked_at_process_run_sync_test` still pass in the same time.

I did the work on a 3.13.1 checkout because that's what Flutter 3.47 ships. The code involved is identical on main and this is the same diff rebased onto it.

---

- [x] I've reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
